### PR TITLE
Github Actions CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+name: CI
+on: [push, pull_request]
+
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [ghc-8.4.4, ghc-8.6.5, ghc-8.8.4, ghc-8.10.2]
+    runs-on: ubuntu-latest
+    container:
+      image: alpmestan/thrift:0.2
+      options: --cpus 2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install ${{ matrix.ghc }}
+        run: apt-get install -y ${{ matrix.ghc }} librocksdb-dev
+      - name: Get hsthrift and build/install its dependencies
+        run: ./install_deps.sh
+      - name: Populate hackage index
+        run: cabal update
+      - name: Build hsthrift/Glean
+        run: |
+          make thrift
+          make gen-bytecode
+          make glean
+      - name: Run Glean tests
+        run: make test

--- a/.github/workflows/get_deps_tag.sh
+++ b/.github/workflows/get_deps_tag.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+git clone https://github.com/facebook/wangle.git tmp >& /dev/null
+cd tmp && git tag | sort -r | head -1 && cd ..
+rm -rf tmp

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ gen-bytecode::
 	$(CABAL) new-run gen-bytecode-hs -- --install_dir=glean/hs
 
 test::
-	$(CABAL) new-test glean
+	$(CABAL) new-test glean:tests
 
 SCHEMAS= \
 	buck \

--- a/glean.cabal
+++ b/glean.cabal
@@ -90,7 +90,7 @@ common deps
         deepseq ^>=1.4.3.0,
         hashable >=1.2.7.0 && <1.4,
         tar ^>=0.5.1.0,
-        ghc-prim ^>=0.5.2.0,
+        ghc-prim >=0.5.2.0 && <0.7,
         parsec ^>=3.1.13.0,
         haxl >= 2.1.2.0 && < 2.4,
         hinotify ^>= 0.4.1
@@ -421,6 +421,7 @@ library core
         Glean.Util.PredMap
         Glean.Util.PredSet
 
+    build-tool-depends: alex:alex, happy:happy
     build-depends:
         glean:bytecode,
         glean:config,
@@ -757,7 +758,7 @@ executable server
         glean:core,
         glean:db,
         glean:util,
-        haskeline ^>=0.7.3,
+        haskeline >=0.7.3 && <0.9,
         json,
         thrift-server
 
@@ -780,7 +781,8 @@ executable shell
         glean:db,
         glean:client-hs,
         glean:util,
-        haskeline ^>=0.7.3,
+        glean:lib,
+        haskeline >=0.7.3 && <0.9,
         json,
         monad-control,
         split
@@ -800,6 +802,7 @@ executable glean
         glean:config,
         glean:core,
         glean:lib,
+        glean:util,
         json,
 
 executable search

--- a/glean/hs/Glean/RTS/Types.hs
+++ b/glean/hs/Glean/RTS/Types.hs
@@ -4,6 +4,10 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE UnboxedTuples #-}
 
+-- required for deriving 'Prim' below (at least with GHC 8.4),
+-- see https://gitlab.haskell.org/ghc/ghc/-/issues/15073
+{-# LANGUAGE TypeInType #-}
+
 module Glean.RTS.Types
   ( -- * fact types
     -- ** type

--- a/glean/hs/Glean/Typed/BuildFact.hs
+++ b/glean/hs/Glean/Typed/BuildFact.hs
@@ -7,6 +7,7 @@ module Glean.Typed.BuildFact
 
 import Data.Maybe
 import Control.Monad (void)
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Reader
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+git clone https://github.com/facebookincubator/hsthrift.git
+cd hsthrift
+./install_deps.sh --nuke
+cd ..


### PR DESCRIPTION
In addition to implementing a CI setup similar to hsthrift's, this patch
introduces a few changes to make the Glean codebase buildable by all the GHC
versions CI checks it against (8.4, 8.6, 8.8, 8.10).