### PR TITLE
Add docker image for playing around with glean/hyperlink/flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+dist-newstyle
+Dockerfile
+*~

--- a/.github/workflows/glean-docker.yml
+++ b/.github/workflows/glean-docker.yml
@@ -1,0 +1,38 @@
+name: Glean demo Docker image
+on:
+  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
+  schedule:
+    - cron: '0 1 * * mon' # every monday at 1am
+
+# inspired by:
+# https://github.community/t/associate-build-ghcr-push-action-to-release/164733
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set env
+        run: echo "IMAGE_TAG=$(date +'v%Y.%m.%d')" >> $GITHUB_ENV
+
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id:   buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+              registry: ghcr.io
+              username: ${{ github.repository_owner }}
+              password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v2
+        with:
+              context: ./
+              file: ./Dockerfile
+              push: true # Will only build (not push) if this is not set
+              tags: |
+                  ghcr.io/facebookincubator/glean/demo:latest
+                  ghcr.io/facebookincubator/glean/demo:${{ env.IMAGE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ghcr.io/facebookincubator/hsthrift/ci-base:latest
+RUN apt-get install -y ghc-8.10.2 librocksdb-dev wget unzip
+RUN cabal update
+RUN mkdir /glean-code
+ADD ./install_deps.sh /glean-code/
+WORKDIR /glean-code
+RUN ./install_deps.sh
+ADD ./glean /glean-code/glean
+ADD ./cabal.project /glean-code/
+ADD ./Makefile  /glean-code/
+ADD ./glean.cabal /glean-code/
+ADD ./LICENSE /glean-code/
+ADD ./Setup.hs /glean-code/
+RUN make thrift && make gen-bytecode && make gen-schema && make thrift-schema-hs
+RUN cabal new-build --project-file=cabal.project exe:glean exe:shell exe:hyperlink
+RUN cp $(cabal exec --project-file=cabal.project -- which glean) ~/.cabal/bin/
+RUN cp $(cabal exec --project-file=cabal.project -- which shell) ~/.cabal/bin/
+RUN cp $(cabal exec --project-file=cabal.project -- which hyperlink) ~/.cabal/bin/
+RUN glean --help
+RUN apt-get install -y wget unzip
+RUN wget https://github.com/facebook/flow/releases/download/v0.148.0/flow-linux64-v0.148.0.zip
+RUN unzip flow-linux64-v0.148.0.zip
+RUN mv flow/flow /usr/local/bin/ && rm -rf flow-linux64-v0.148.0.zip flow/
+WORKDIR /
+RUN git clone https://github.com/facebook/react.git --depth 1 react-code
+
+RUN mkdir -p /gleandb /tmp/react
+RUN cat /react-code/scripts/flow/config/flowconfig \
+      | grep -v REACT_RENDERER_FLOW_OPTIONS \
+      | grep -v suppress_comment > /react-code/.flowconfig
+RUN flow glean /react-code --output-dir /tmp/react --write-root ""
+RUN glean --db-root /gleandb --db-schema dir:/glean-code/glean/schema/source create --repo react/0
+RUN glean --db-root /gleandb --db-schema dir:/glean-code/glean/schema/source write --repo react/0 /tmp/react/*
+RUN glean --db-root /gleandb --db-schema dir:/glean-code/glean/schema/source derive --repo react/0 flow.FileXRef flow.FileDeclaration
+RUN glean --db-root /gleandb --db-schema dir:/glean-code/glean/schema/source finish --repo react/0
+
+# can then run:
+#   hyperlink --db-root /gleandb --db-schema dir:/glean-code/glean/schema/source --repo react --root /react-code --http 8888
+# from within the image

--- a/cabal.project
+++ b/cabal.project
@@ -11,3 +11,6 @@ packages:
     glean.cabal
 
 tests: True
+
+-- necessary to use a haskeline <0.8 with GHCs that ship with base >= 4.14
+allow-newer: haskeline:base

--- a/glean.cabal
+++ b/glean.cabal
@@ -760,7 +760,7 @@ executable server
         glean:core,
         glean:db,
         glean:util,
-        haskeline >=0.7.3 && <0.9,
+        haskeline >=0.7.3 && <0.8,
         json,
         thrift-server
 
@@ -784,7 +784,7 @@ executable shell
         glean:client-hs,
         glean:util,
         glean:lib,
-        haskeline >=0.7.3 && <0.9,
+        haskeline >=0.7.3 && <0.8,
         json,
         monad-control,
         split
@@ -821,6 +821,21 @@ executable search
         glean:util,
         glean:if-search-hs,
         aeson-pretty,
+
+executable hyperlink
+    import: fb-haskell, deps
+    hs-source-dirs: glean/demo
+    main-is: Hyperlink.hs
+    ghc-options: -main-is Hyperlink
+    extra-libraries: stdc++
+    build-depends:
+        glean:lib,
+        glean:schema,
+        glean:util,
+        glean:client-hs,
+        http-types,
+        wai,
+        warp
 
 -- -----------------------------------------------------------------------------
 -- Tests


### PR DESCRIPTION
Along with a CI job specification for building and pushing the image.

The job is set to run once a week, on monday at 1am. Before creating this PR, I had it set up to run on every push to my branch, and one can see it succeeding here: https://github.com/facebookincubator/Glean/runs/2528045388?check_suite_focus=true

I do not have access to the ghcr.io page for the image though, so I can't be sure that it _did_ indeed push a freshly built image from the CI environment. @simonmar Can you confirm this indeed succeeded?