### PR TITLE
Move "Meta" and related types to internal.thrift

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -216,6 +216,7 @@ library if-internal-hs
     exposed-modules:
         Glean.Internal.Types
     build-depends:
+        glean:config,
         glean:if-glean-hs
 
 library if-search-hs

--- a/glean/db/Glean/Database/Backup.hs
+++ b/glean/db/Glean/Database/Backup.hs
@@ -46,6 +46,7 @@ import Glean.Database.Schema.Types
 import Glean.Database.Storage
 import Glean.ServerConfig.Types (DatabaseBackupPolicy(..))
 import qualified Glean.ServerConfig.Types as ServerConfig
+import Glean.Internal.Types as Thrift
 import Glean.Types as Thrift
 import Glean.Util.Some
 import Glean.Util.Observed as Observed

--- a/glean/db/Glean/Database/Catalog.hs
+++ b/glean/db/Glean/Database/Catalog.hs
@@ -46,6 +46,7 @@ import Glean.Database.Exception
 import Glean.Database.Meta
 import Glean.Database.Repo
 import Glean.Types (Repo(..))
+import qualified Glean.Internal.Types as Thrift
 import qualified Glean.Types as Thrift
 
 -- | Catalog entry

--- a/glean/db/Glean/Database/Catalog/Filter.hs
+++ b/glean/db/Glean/Database/Catalog/Filter.hs
@@ -45,6 +45,7 @@ import GHC.Generics hiding (Meta)
 
 import Glean.Database.Meta
 import Glean.Types (Repo(..))
+import qualified Glean.Internal.Types as Thrift
 import qualified Glean.Types as Thrift
 
 -- | How a DB is available

--- a/glean/db/Glean/Database/Index.hs
+++ b/glean/db/Glean/Database/Index.hs
@@ -57,6 +57,7 @@ import Glean.Database.Writes
 import qualified Glean.Recipes.Types as Recipes
 import Glean.RTS.Foreign.Lookup (firstFreeId)
 import Glean.Database.Schema (toSchemaInfo)
+import Glean.Internal.Types
 import Glean.RTS.Types (lowestFid)
 import qualified Glean.ServerConfig.Types as ServerConfig
 import Glean.Types hiding (Database)

--- a/glean/db/Glean/Database/Meta.hs
+++ b/glean/db/Glean/Database/Meta.hs
@@ -28,6 +28,7 @@ import Thrift.Protocol.JSON
 import Util.TimeSec
 
 import Glean.ServerConfig.Types (DBVersion(..))
+import Glean.Internal.Types
 import Glean.Types
 
 -- | Produce DB metadata

--- a/glean/db/Glean/Database/Stuff.hs
+++ b/glean/db/Glean/Database/Stuff.hs
@@ -53,6 +53,7 @@ import Glean.RTS.Foreign.Subst (Subst)
 import qualified Glean.RTS.Foreign.Subst as Subst
 import qualified Glean.ServerConfig.Types as ServerConfig
 import Glean.Types (Repo)
+import qualified Glean.Internal.Types as Thrift
 import qualified Glean.Types as Thrift
 import Glean.Util.Metric
 import Glean.Util.Mutex

--- a/glean/db/Glean/Database/Tailer.hs
+++ b/glean/db/Glean/Database/Tailer.hs
@@ -43,6 +43,7 @@ import Glean.Database.Repo
 import Glean.Database.Stuff (lookupActiveDatabase, withActiveDatabase)
 import Glean.Database.Types
 import Glean.Database.Writes
+import Glean.Internal.Types
 import Glean.Tailer
 import Glean.Tailer.Types
 import Glean.Types hiding (Database, Exception)

--- a/glean/db/Glean/Database/Work.hs
+++ b/glean/db/Glean/Database/Work.hs
@@ -46,6 +46,7 @@ import Glean.Database.Types
 import Glean.Database.Work.Controller
 import Glean.Database.Work.Heartbeat
 import Glean.Database.Work.Queue
+import Glean.Internal.Types as Thrift
 import Glean.Recipes.Types (Executor(..), Recipe(..))
 import Glean.Types as Thrift
 import Glean.Util.Time

--- a/glean/db/Glean/Query/Derive.hs
+++ b/glean/db/Glean/Query/Derive.hs
@@ -36,6 +36,7 @@ import Glean.Database.Schema.Types
 import Glean.Database.Stuff
 import Glean.Database.Types as Database
 import Glean.Database.Writes
+import Glean.Internal.Types hiding (Predicate)
 import qualified Glean.Query.UserQuery as UserQuery
 import Glean.Query.Typecheck.Types
 import Glean.Query.Codegen

--- a/glean/if/glean.thrift
+++ b/glean/if/glean.thrift
@@ -122,24 +122,7 @@ struct Task {
   2: TaskState state;
 }
 
-struct DatabaseBroken {
-  1: string task;
-  2: string reason;
-}
-
 typedef map<recipes.TaskName, Task> (hs.type = "HashMap") Tasks
-
-// This is a legacy data structure which will be replaced soon
-union DatabaseIncomplete {
-  1: Tasks tasks;
-}
-
-struct DatabaseComplete {
-  1: PosixEpochTime time;
-}
-
-struct DatabaseFinalizing {
-}
 
 union ScribeStart {
   1: string start_time;
@@ -178,14 +161,6 @@ struct WriteFromScribe {
 // how to choose a bucket; omit for no bucket
 }
 
-// The status of data being written into a DB
-union Completeness {
-  1: DatabaseIncomplete incomplete;
-  3: DatabaseComplete complete;
-  4: DatabaseBroken broken;
-  5: DatabaseFinalizing finalizing;
-} (hs.prefix = "", hs.nonempty)
-
 typedef map<string, string> (hs.type = "HashMap") DatabaseProperties
 
 // A Stacked DB that views only a portion of the underlying DB
@@ -200,31 +175,6 @@ union Dependencies {
   1: Repo stacked; // TODO remove?
   2: Pruned pruned;
 } (hs.nonempty)
-
-// Information about a database stored by Glean.
-struct Meta {
-  1: server_config.DBVersion metaVersion;
-  // Database version
-
-  2: PosixEpochTime metaCreated;
-  // When was the database created
-
-  3: Completeness metaCompleteness;
-  // Completeness status
-
-  4: optional string metaBackup;
-  // Backup status
-
-  5: DatabaseProperties metaProperties;
-  // Arbitrary metadata about this DB. Properties prefixed by
-  // "glean."  are reserved for use by Glean itself.
-
-  6: optional Dependencies metaDependencies;
-  // What this DB depends on.
-
-  7: list<PredicateRef> metaCompletePredicates;
-// Whether all facts for a predicate have already been inserted.
-} (hs.prefix = "")
 
 // -----------------------------------------------------------------------------
 // Thrift API

--- a/glean/test/lib/Glean/Database/Test.hs
+++ b/glean/test/lib/Glean/Database/Test.hs
@@ -38,6 +38,7 @@ import qualified Glean.Database.Storage.Memory as Memory
 import Glean.Database.Stuff
 import Glean.Database.Types
 import Glean.Impl.ConfigProvider ()
+import qualified Glean.Internal.Types as Thrift
 import Glean.Recipes.Types (Recipes)
 import qualified Glean.Recipes.Types as Recipes
 import Glean.Schema.Resolve

--- a/glean/test/tests/CatalogTest.hs
+++ b/glean/test/tests/CatalogTest.hs
@@ -29,6 +29,7 @@ import Glean.Init
 import Glean.Test.HUnit
 import Glean.Repo.Text
 import Glean.Test.Mock
+import Glean.Internal.Types
 import Glean.Types hiding (Exception)
 
 repos :: [Repo]

--- a/glean/test/tests/DatabaseJanitorTest.hs
+++ b/glean/test/tests/DatabaseJanitorTest.hs
@@ -41,6 +41,7 @@ import Glean.Impl.ConfigProvider
 import Glean.Init
 import Glean.RTS.Types (lowestFid)
 import Glean.ServerConfig.Types as ServerTypes
+import Glean.Internal.Types
 import Glean.Types as Thrift
 import Glean.Util.ConfigProvider
 import Glean.Util.ThriftSource as ThriftSource

--- a/glean/test/tests/DbDeriveTest.hs
+++ b/glean/test/tests/DbDeriveTest.hs
@@ -22,6 +22,7 @@ import Glean hiding (derivePredicate, deriveStored)
 import Glean.Init
 import Glean.Database.Types
 import qualified Glean.Database.Catalog as Catalog
+import Glean.Internal.Types hiding (Predicate)
 import Glean.Types as Thrift
 import Glean.Test.HUnit
 import qualified Glean.Schema.GleanTest.Types as Glean.Test

--- a/glean/test/tests/LifecycleTest.hs
+++ b/glean/test/tests/LifecycleTest.hs
@@ -30,6 +30,7 @@ import Glean.Database.Stuff
 import Glean.Database.Test
 import Glean.Database.Types
 import Glean.Init
+import Glean.Internal.Types
 import Glean.Test.HUnit
 import Glean.Test.Mock
 import Glean.Types hiding (Exception)


### PR DESCRIPTION
Summary: Trying to keep internal-only things out of `glean.thrift`.

Reviewed By: donsbot

Differential Revision: D29613502

