### PR TITLE
fix open source build

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -226,8 +226,6 @@ library if-search-hs
         glean/if/search/gen-hs2
     exposed-modules:
         Glean.Search.Types
-        Glean.Search.SearchService.Client
-        Glean.Search.SearchService.Service
     build-depends:
         glean:config,
         glean:if-glean-hs,
@@ -556,7 +554,8 @@ library client-hs
         glean:util,
         glean:core,
         glean:config,
-        glean:haxl-datasource
+        glean:haxl-datasource,
+        prettyprinter-ansi-terminal
 
 library client-hs-local
     import: fb-haskell, deps


### PR DESCRIPTION
Summary:
In D29733510 (https://github.com/facebookincubator/Glean/commit/ca5c9e454468c6dfc1311845f8b3d808b0636c64) we deleted the service. So the cabal side won't have the hsthrift
generated Client and Service modules

https://github.com/facebookincubator/Glean/runs/3105765338

Differential Revision: D29794516

