### PR TITLE
Add index endpoint (#36)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ THRIFT_GLEAN= \
 	glean/github/if/fb303.thrift \
 	glean/github/if/fb303_core.thrift \
 	glean/if/glean.thrift \
+	glean/if/index.thrift \
 	glean/config/recipes/recipes.thrift \
 	glean/config/recipes/recipes.thrift \
 	glean/config/server/server_config.thrift \

--- a/glean.cabal
+++ b/glean.cabal
@@ -212,6 +212,18 @@ library if-glean-hs
         glean:config,
         glean:if-fb303-hs
 
+library if-index-hs
+    import: fb-haskell, deps
+    visibility: public
+    hs-source-dirs:
+        glean/if/gen-hs2
+    exposed-modules:
+        Glean.Index.Types
+        Glean.Index.GleanIndexingService.Client
+        Glean.Index.GleanIndexingService.Service
+    build-depends:
+        glean:if-glean-hs
+
 library if-internal-hs
     import: fb-haskell, fb-cpp, deps
     visibility: public
@@ -816,12 +828,14 @@ executable glean-server
     default-extensions: CPP
     other-modules:
         Glean.Handler
+        Glean.Index
         Glean.Server.Config
     extra-libraries: stdc++
     build-depends:
         glean:client-hs,
         glean:if-fb303-hs,
         glean:if-glean-hs,
+        glean:if-index-hs,
         glean:stubs,
         glean:config,
         glean:core,

--- a/glean/if/index.thrift
+++ b/glean/if/index.thrift
@@ -1,0 +1,54 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+
+include "glean/if/glean.thrift"
+
+namespace hs Glean
+
+struct Revision {
+  1: string hash;
+}
+
+// path relative to the repository root
+typedef string FilePath
+
+struct Diff {
+  1: i32 line;
+  // changes performed from this line
+  2: i32 removed;
+  // number of lines removed
+  3: list<string> added;
+// new lines to be added
+}
+
+struct FileModified {
+  1: list<Diff> diffs;
+}
+
+struct FileMoved {
+  1: FilePath new_path;
+  2: list<Diff> diffs;
+}
+
+struct FileDeleted {
+}
+
+union FileChange {
+  1: FileModified modified;
+  2: FileMoved moved;
+  3: FileDeleted deleted;
+}
+
+struct IndexRequest {
+  1: glean.Repo repo;
+  2: Revision base;
+  3: map<FilePath,FileChange> changes;
+}
+
+struct IndexResponse {
+  1: glean.Repo repo;
+}
+
+service GleanIndexingService extends glean.GleanService {
+  // Create an incremental database based on file changes
+  IndexResponse index(1: IndexRequest request);
+}

--- a/glean/server/Glean/Handler.hs
+++ b/glean/server/Glean/Handler.hs
@@ -5,11 +5,14 @@ module Glean.Handler
   ( Write(..)
   , State(..)
   , handler
+  , handlerIndexing
   ) where
 
+import Glean.Index.GleanIndexingService.Service
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map as Map
 import Data.Maybe
+import qualified Glean.Index as Index
 
 import Facebook.Fb303
 
@@ -23,6 +26,11 @@ data State = State
   { fb303State :: Fb303State
   , stEnv :: Env
   }
+
+handlerIndexing :: State -> GleanIndexingServiceCommand a -> IO a
+handlerIndexing state req = case req of
+  Index req -> Index.index (stEnv state) req
+  SuperGleanService r -> handler state r
 
 handler :: State -> GleanServiceCommand a -> IO a
 handler State{..} req =

--- a/glean/server/Glean/Index.hs
+++ b/glean/server/Glean/Index.hs
@@ -1,0 +1,45 @@
+module Glean.Index
+  (index)
+  where
+
+import qualified Glean.Types as Thrift
+import qualified Glean.Index.Types as Thrift
+import qualified Glean.Database.Types as Database
+import Control.Exception (throwIO)
+
+index
+  :: Database.Env
+  -> Thrift.IndexRequest
+  -> IO Thrift.IndexResponse
+index _ _ =
+{- do
+    if indexer for repo is not available
+      error
+
+    if base repo is not available
+      download it from Backup in the background
+      error with "downloading base repo, try again later"
+
+    if revision is not indexed
+      in the background:
+        get diffs between base and revision from version control
+        run indexer on (base repo, revision diffs)
+      error with "indexing revision, try again later"
+
+    if there is no repo indexed with the received diffs
+      run indexer on (revision, received diffs)
+
+    execute eviction policy on repos from incremental indexing
+
+    return indexed repo
+    where
+      runIndexer (repo, diffs) =
+        create new incremental repo
+        for each diff in diffs
+          fetch full file content from version control
+          apply diff
+          exclude file from repo
+          invoke indexer process on file
+        finish repo
+-}
+  throwIO $ Thrift.Exception "not implemented"

--- a/glean/server/Glean/Server.hs
+++ b/glean/server/Glean/Server.hs
@@ -128,8 +128,19 @@ main =
         when (isNothing l) retry
       setAlive server
 
-  withBackgroundFacebookServiceDeferredAlive
-    (GleanHandler.fb303State state)
-    (GleanHandler.handler state)
-    defaultOptions{ desiredPort = cfgPort cfg }
-    (\server -> waitForAlive server >> waitForTerminateSignals)
+    waitToStart server = waitForAlive server >> waitForTerminateSignals
+    opts = defaultOptions{ desiredPort = cfgPort cfg }
+
+  if cfgEnableIndexing cfg
+    then
+      withBackgroundFacebookServiceDeferredAlive
+        (GleanHandler.fb303State state)
+        (GleanHandler.handlerIndexing state)
+        opts
+        waitToStart
+    else
+      withBackgroundFacebookServiceDeferredAlive
+        (GleanHandler.fb303State state)
+        (GleanHandler.handler state)
+        opts
+        waitToStart

--- a/glean/server/Glean/Server/Config.hs
+++ b/glean/server/Glean/Server/Config.hs
@@ -12,6 +12,7 @@ data Config = Config
   { cfgPort :: Maybe Int
   , cfgDBConfig :: DBConfig.Config
   , cfgSetShards :: Bool
+  , cfgEnableIndexing :: Bool
   , cfgWritePort :: Maybe FilePath
   , cfgHandler :: String -- ^ deprecated, ignored.
   }
@@ -21,6 +22,7 @@ options = Config
   <$> O.optional (O.option O.auto (O.long "port" <> O.short 'p'))
   <*> DBConfig.options
   <*> O.switch (O.long "set-shards")
+  <*> O.switch (O.long "enable-indexing")
   <*> O.optional (O.strOption
       (O.long "write-port"
         <> O.metavar "FILE"


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/Glean/pull/36

Add endpoint for triggering the indexing of modified files and the creation of an incremental database.

Although in practice indexing will probably run locally in a user's machine, the API does not require that.

Reviewed By: evangrayk

Differential Revision: D30544175

