### PR TITLE
Improve Docker image and demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM ghcr.io/facebookincubator/hsthrift/ci-base:latest
+FROM ghcr.io/facebookincubator/hsthrift/ci-base:latest as tools
 RUN apt-get install -y ghc-8.10.2 librocksdb-dev libxxhash-dev wget unzip
 RUN cabal update
 RUN mkdir /glean-code
-ADD ./install_deps.sh /glean-code/
 WORKDIR /glean-code
+ADD https://api.github.com/repos/facebookincubator/hsthrift/compare/main...HEAD /dev/null
+ADD ./install_deps.sh /glean-code/
 RUN ./install_deps.sh
 ADD ./glean /glean-code/glean
 ADD ./cabal.project /glean-code/
@@ -22,20 +23,59 @@ RUN unzip flow-linux64-v0.148.0.zip
 RUN mv flow/flow /usr/local/bin/ && rm -rf flow-linux64-v0.148.0.zip flow/
 WORKDIR /
 RUN git clone https://github.com/facebook/react.git --depth 1 react-code
-
-RUN mkdir -p /gleandb /tmp/react
 RUN cat /react-code/scripts/flow/config/flowconfig \
       | grep -v REACT_RENDERER_FLOW_OPTIONS \
       | grep -v suppress_comment > /react-code/.flowconfig
-RUN flow glean /react-code --output-dir /tmp/react --write-root ""
-RUN glean --db-root /gleandb --db-schema dir:/glean-code/glean/schema/source create --repo react/0
-RUN glean --db-root /gleandb --db-schema dir:/glean-code/glean/schema/source write --repo react/0 /tmp/react/*
-RUN glean --db-root /gleandb --db-schema dir:/glean-code/glean/schema/source derive --repo react/0 flow.FileXRef flow.FileDeclaration
-RUN glean --db-root /gleandb --db-schema dir:/glean-code/glean/schema/source finish --repo react/0
 
-# can then run:
-#
-#   glean-server --db-root /gleandb --schema /glean-code/glean/schema/source --port 12345 &
-#   glean-hyperlink --service localhost:12345 --repo react --root /react-code --http 8888
-#
-# from within the image
+FROM ubuntu:20.04 AS demo
+
+ENV PATH=/glean-demo/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+RUN apt-get update && apt-get install -y \
+    libicu66 \
+    libboost-context1.71.0 \
+    libboost-filesystem1.71.0 \
+    libboost-program-options1.71.0 \
+    libboost-regex1.71.0 \
+    librocksdb5.17 \
+    libunwind8 \
+    libgoogle-glog0v5 \
+    libssl1.1 \
+    libsodium23 \
+    libdouble-conversion3 \
+    libmysqlclient21 \
+    libevent-2.1-7 \
+    libxxhash0 \
+    libatomic1 \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /glean-demo
+
+RUN mkdir /glean-demo/bin
+
+COPY --from=tools /usr/local/lib /usr/local/lib
+COPY --from=tools /usr/local/bin/flow /usr/local/bin
+COPY --from=tools /root/.cabal/bin/glean /glean-demo/bin
+COPY --from=tools /root/.cabal/bin/glean-server /glean-demo/bin
+COPY --from=tools /root/.cabal/bin/glean-hyperlink /glean-demo/bin
+COPY --from=tools /glean-code/glean/schema /glean-demo/schema
+COPY --from=tools /react-code /glean-demo/code
+ADD docker_entrypoint.sh docker_entrypoint.sh
+
+RUN mkdir -p db /tmp/flow-index-out
+
+RUN flow glean code --output-dir /tmp/flow-index-out --write-root "" && \
+    glean --db-root db --db-schema dir:schema/source create --repo react/0 && \
+    glean --db-root db --db-schema dir:schema/source write --repo react/0 /tmp/flow-index-out/* && \
+    glean --db-root db --db-schema dir:schema/source derive --repo react/0 flow.FileXRef flow.FileDeclaration && \
+    glean --db-root db --db-schema dir:schema/source finish --repo react/0 && \
+    rm -Rf /tmp/flow-index-out
+
+ENV REPO_NAME=react
+
+EXPOSE 8888
+
+ENTRYPOINT ["./docker_entrypoint.sh"]
+
+# docker run -ti -p8888:8888 ghcr.io/facebookincubator/glean/glean-demo

--- a/README.md
+++ b/README.md
@@ -57,3 +57,14 @@ pull request.
 ## Building
 
 See [Building Glean](https://glean.software/docs/building).
+
+## Docker demo
+
+For demo of the react codebase with hyperlinks powered by glean run
+`docker run -ti -p8888:8888 ghcr.io/facebookincubator/glean/glean-demo`
+
+Try out on your own codebase with a .flowconfig by running
+`docker run -ti -p8888:8888 -v __YOUR_CODE_DIR__:/glean_demo/code ghcr.io/facebookincubator/glean/glean-demo`
+
+Play round using the glean binaries in a shell by running
+`docker run -ti -p8888:8888 ghcr.io/facebookincubator/glean/glean-demo shell`

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = 'shell' ]; then
+# short cutting demo and going straight to shell
+    shift
+    exec bash "$@"
+    exit 0
+elif mount | grep '/glean-demo/code' >/dev/null ; then
+# test for mounted code and try to index it
+    if [ ! -f code/.flowconfig ]; then
+        echo "Your project must have a .flowconfig"
+        exit 2
+    fi
+    REPO_NAME="${REPO_NAME#react}"
+    REPO_NAME="${REPO_NAME:-code}"
+    rm -Rf db/${REPO_NAME}
+    mkdir -p /tmp/flow-index-out
+    flow glean code --output-dir /tmp/flow-index-out --write-root ""
+    glean --db-root db --db-schema dir:schema/source create --repo ${REPO_NAME}/0
+    glean --db-root db --db-schema dir:schema/source write --repo ${REPO_NAME}/0 /tmp/flow-index-out/*
+    glean --db-root db --db-schema dir:schema/source derive --repo ${REPO_NAME}/0 flow.FileXRef flow.FileDeclaration
+    glean --db-root db --db-schema dir:schema/source finish --repo ${REPO_NAME}/0
+    rm -Rf /tmp/flow-index-out
+fi
+
+echo "Starting Glean Server"
+exec bin/glean-server --db-root db --schema schema/source --port 12345 &
+sleep 2
+echo "Starting Hyperlink Server"
+exec bin/glean-hyperlink --service localhost:12345 --repo ${REPO_NAME} --root code --http 8888
+echo "Exiting.."


### PR DESCRIPTION
* Creates multistage docker images, to slim down the final result of build apparatus and source code
* Add cache check for facebookincubator/hsthrift dependency
* Create entrypoint script that
   * Defaults to react demo instead of bash shell
   * Adds escape hatch for still getting to bash shell with `shell` command
   * Allows you to mount your own flowtype source code directory at runtime with automatic glean indexing for hyperlink demo