### PR TITLE
Fix OSS build

### DIFF
--- a/glean/schema/source/schema.angle
+++ b/glean/schema/source/schema.angle
@@ -7,7 +7,7 @@ schema all.3 :
   code.flow.2,
   code.hack.3,
   code.hs.2,
-  code.java.4,
+  code.java.3,
   code.python.1,
   code.thrift.1,
   codemarkup.16,


### PR DESCRIPTION
Summary: I think D29735243 (https://github.com/facebookincubator/Glean/commit/d745e360dd4b143ff8b516a42df720be02014210) broke the OSS build because it accidentally bumped `code.java.3` -> `4`. reverting that change

Differential Revision: D30931906

