### PR TITLE
Move Glean.Index to stubs

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -127,12 +127,15 @@ library stubs
         Glean.Datasource.Scribe.Write
         Glean.Init
         Glean.Server.Shard
+        Glean.Index
         Glean.Username
         ServiceData.Types
         ServiceData.GlobalStats
         TestRunner
     build-depends:
         glean:if-fb303-hs,
+        glean:if-glean-hs,
+        glean:if-index-hs,
         mangle,
         thrift-server,
         template-haskell
@@ -828,7 +831,6 @@ executable glean-server
     default-extensions: CPP
     other-modules:
         Glean.Handler
-        Glean.Index
         Glean.Server.Config
     extra-libraries: stdc++
     build-depends:

--- a/glean/github/Glean/Index.hs
+++ b/glean/github/Glean/Index.hs
@@ -4,11 +4,10 @@ module Glean.Index
 
 import qualified Glean.Types as Thrift
 import qualified Glean.Index.Types as Thrift
-import qualified Glean.Database.Types as Database
 import Control.Exception (throwIO)
 
 index
-  :: Database.Env
+  :: a
   -> Thrift.IndexRequest
   -> IO Thrift.IndexResponse
 index _ _ =


### PR DESCRIPTION
Summary:
Glean.Index was moved to have an internal and open-source version.
For now the open source version is only a stub.

Differential Revision: D30956938

