### PR TITLE
Label docker image so it shows up in right project and fix docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN cat /react-code/scripts/flow/config/flowconfig \
 
 FROM ubuntu:20.04 AS demo
 
+LABEL org.opencontainers.image.source="https://github.com/facebookincubator/Glean"
+
 ENV PATH=/glean-demo/bin:$PATH
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
@@ -78,4 +80,4 @@ EXPOSE 8888
 
 ENTRYPOINT ["./docker_entrypoint.sh"]
 
-# docker run -ti -p8888:8888 ghcr.io/facebookincubator/glean/glean-demo
+# docker run -ti -p8888:8888 ghcr.io/facebookincubator/glean/demo

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ See [Building Glean](https://glean.software/docs/building).
 ## Docker demo
 
 For demo of the react codebase with hyperlinks powered by glean run
-`docker run -ti -p8888:8888 ghcr.io/facebookincubator/glean/glean-demo`
+`docker run -ti -p8888:8888 ghcr.io/facebookincubator/glean/demo`
 
 Try out on your own codebase with a .flowconfig by running
-`docker run -ti -p8888:8888 -v __YOUR_CODE_DIR__:/glean_demo/code ghcr.io/facebookincubator/glean/glean-demo`
+`docker run -ti -p8888:8888 -v __YOUR_CODE_DIR__:/glean_demo/code ghcr.io/facebookincubator/glean/demo`
 
 Play round using the glean binaries in a shell by running
-`docker run -ti -p8888:8888 ghcr.io/facebookincubator/glean/glean-demo shell`
+`docker run -ti -p8888:8888 ghcr.io/facebookincubator/glean/demo shell`


### PR DESCRIPTION
Currently the glean/demo docker image is showing up in the hsthrift project, I think setting this label will force it to show up under this project instead.

Then we need to work out how to kill glean/glean-demo somehow