### PR TITLE
Before we install deps, synchronize the cabal package index

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -7,6 +7,9 @@
 
 set -e
 
+# Make sure we have updated cabal index before we do anything
+cabal update
+
 git clone https://github.com/facebookincubator/hsthrift.git
 cd hsthrift
 ./install_deps.sh --nuke


### PR DESCRIPTION
On a fresh machine (e.g. blank Debian VM) with no Haskell packages, the
default cabal index is missing HUnit. This leads to a confusing build
error when building for the first time:

```
cabal: Could not resolve dependencies:
[__0] trying: fb-stubs-0.1.0.0 (user goal)
[__1] unknown package: HUnit (dependency of fb-stubs)
[__1] fail (backjumping, conflict set: HUnit, fb-stubs)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: fb-stubs, HUnit
```

The fix is to cabal update before commencing to build HS targets.

Verified by fresh build on blank Debian aarch64 VM.