### PR TITLE
Allow Glean to build against getdeps.py dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,13 @@ CABAL_PROJECT := --project-file=$(PWD)/cabal.project
 ifeq ($(BUILD_DEPS),1)
     empty :=
     space := $(empty) $(empty)
-    BUILDER := hsthrift/build.sh
+
+    # set to install deps into e.g. $HOME/.glean
+    ifdef INSTALL_PREFIX
+        BUILDER := hsthrift/build.sh --install-prefix=$(INSTALL_PREFIX)
+    else
+        BUILDER := hsthrift/build.sh
+    endif
 
     DEPS_INSTALLDIR := $(patsubst %/hsthrift,%,\
             $(shell $(BUILDER) show-inst-dir hsthrift))
@@ -76,7 +82,7 @@ test::
 SCHEMAS= \
 	buck \
 	builtin \
-	code_cxx \
+	e_cxx \
 	code_erlang \
 	code_flow \
 	code_hack \
@@ -177,3 +183,9 @@ thrift-cpp: thrift-hsthrift-cpp
 .PHONY: thrift-hsthrift-cpp
 thrift-hsthrift-cpp::
 	(cd hsthrift && make CABAL="$(CABAL)" thrift-cpp)
+
+# show ld paths used in this configuration
+.PHONY: show-paths
+show-paths::
+	@echo export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)
+	@echo export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH)

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ test::
 SCHEMAS= \
 	buck \
 	builtin \
-	e_cxx \
+	code_cxx \
 	code_erlang \
 	code_flow \
 	code_hack \

--- a/glean/website/docs/building.md
+++ b/glean/website/docs/building.md
@@ -114,8 +114,8 @@ sudo dnf install \
 :::warning
 
 The build process currently installs dependencies in
-`/usr/local/lib`. This isn't ideal; we're working on a more
-self-contained build process but it's not ready yet.
+`/usr/local/lib`. The BUILD\_DEPS=1 way (below) avoids this, but is
+experimental.
 
 :::
 
@@ -155,3 +155,26 @@ make test
 
 At this point you can `cabal install` to install the executables into
 `~/.cabal/bin`.
+
+## Building without sudo
+
+Using getdeps,py support we can build C++ dependencies in user space, which
+avoids the requirement for sudo access or additional path variables.
+
+Once you have checked out the Glean repo, continue with:
+
+```
+env BUILD_DEPS=1 ./install_deps.sh
+```
+
+Build everything:
+
+```
+make BUILD_DEPS=1
+```
+
+If everything worked, the tests should pass:
+
+```
+make test BUILD_DEPS=1
+```

--- a/glean/website/docs/building.md
+++ b/glean/website/docs/building.md
@@ -160,21 +160,33 @@ At this point you can `cabal install` to install the executables into
 
 Using getdeps,py support we can build C++ dependencies in user space, which
 avoids the requirement for sudo access or additional path variables.
+Dependencies can be installed into $HOME/.glean (for example) or another
+user-supplied path.
 
-Once you have checked out the Glean repo, continue with:
+Check out the Glean repo:
+```
+git clone https://github.com/facebookincubator/Glean.git
+cd Glean
+```
+
+Then build and install dependencies:
+```
+env BUILD_DEPS=1 INSTALL_PREFIX=$HOME/.glean ./install_deps.sh
+```
+
+Build Glean:
 
 ```
-env BUILD_DEPS=1 ./install_deps.sh
-```
-
-Build everything:
-
-```
-make BUILD_DEPS=1
+make BUILD_DEPS=1 INSTALL_PREFIX=$HOME/.glean
 ```
 
 If everything worked, the tests should pass:
 
 ```
-make test BUILD_DEPS=1
+make test BUILD_DEPS=1 INSTALL_PREFIX=$HOME/.glean
+```
+
+To see which ld and pkgconfig paths your user installation will use.
+```
+$ make show-paths BUILD_DEPS=1 INSTALL_PREFIX=$HOME/.glean
 ```

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -14,7 +14,7 @@ if test ! -d hsthrift; then
 fi
 
 cd hsthrift
-if test "${BUILD_DEPS}" -eq 1; then
+if test -n "${BUILD_DEPS}" && test "${BUILD_DEPS}" -eq 1; then
     ./build.sh build --allow-system-packages --only-deps hsthrift
 else
     ./install_deps.sh --nuke

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -17,5 +17,5 @@ cd hsthrift
 if test -n "${BUILD_DEPS}" && test "${BUILD_DEPS}" -eq 1; then
     ./build.sh build --allow-system-packages --only-deps hsthrift
 else
-    ./install_deps.sh --nuke
+    ./install_deps.sh --nuke --sudo
 fi

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -7,6 +7,15 @@
 
 set -e
 
-git clone https://github.com/facebookincubator/hsthrift.git
+HSTHRIFT_REPO=https://github.com/donsbot/hsthrift.git
+
+if test ! -d hsthrift; then
+    git clone "${HSTHRIFT_REPO}"
+fi
+
 cd hsthrift
-./install_deps.sh --nuke
+if test "${BUILD_DEPS}" -eq 1; then
+    ./build.sh build --allow-system-packages --only-deps hsthrift
+else
+    ./install_deps.sh --nuke
+fi

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -14,10 +14,16 @@
 #
 # You will need --sudo passed to ./install_deps.sh
 #
+# If you set BUIlD_DEPS=1, then deps are installed into GLEAN_INST_PREFIX,
+# default is ~/.glean
+#
+# And set LD_LIBRARY_PATH and PKG_CONFIG_PATH to pick those up.
+#
 
 set -e
 
 HSTHRIFT_REPO=https://github.com/facebookincubator/hsthrift.git
+INSTALL_PREFIX=${HOME}/.glean
 
 if test ! -d hsthrift; then
     git clone "${HSTHRIFT_REPO}"
@@ -25,7 +31,11 @@ fi
 
 cd hsthrift
 if test -n "${BUILD_DEPS}" && test "${BUILD_DEPS}" -eq 1; then
-    ./build.sh build --allow-system-packages --only-deps hsthrift
+    ./build.sh build \
+        --allow-system-packages \
+        --only-deps \
+        --install-prefix="${INSTALL_PREFIX}" \
+        hsthrift
 else
     ./install_deps.sh --nuke
 fi

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-HSTHRIFT_REPO=https://github.com/donsbot/hsthrift.git
+HSTHRIFT_REPO=https://github.com/facebookincubator/hsthrift.git
 
 if test ! -d hsthrift; then
     git clone "${HSTHRIFT_REPO}"

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -12,6 +12,8 @@
 # > export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 # > export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig#
 #
+# You will need --sudo passed to ./install_deps.sh
+#
 
 set -e
 
@@ -25,5 +27,5 @@ cd hsthrift
 if test -n "${BUILD_DEPS}" && test "${BUILD_DEPS}" -eq 1; then
     ./build.sh build --allow-system-packages --only-deps hsthrift
 else
-    ./install_deps.sh --nuke --sudo
+    ./install_deps.sh --nuke
 fi

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -5,6 +5,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+#
+# Note, if you don't use BUILD_DEPS=1 hsthrift deps will be installed into
+# /usr/local, which requires sudo privs, and you'll need to set:
+#
+# > export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+# > export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig#
+#
+
 set -e
 
 HSTHRIFT_REPO=https://github.com/donsbot/hsthrift.git


### PR DESCRIPTION
This teaches Glean how to build and link against getdep.py-installed C++ dependencies. 
There is a PR for hsthrift which adds similar support (and requires that PR landed in hsthrift to work).

    This teaches Glean how to build against hsthrift dependencies installed
    by getdeps.py in non-global locations. These additional paths are found
    via hsthrift/build.sh show-inst-path and friends, canned up in the
    Makefile.

    We provide BUILD_DEPS=1 ways to:
    - install hsthrift deps
    - build and link (and run) glean against those deps

    getdeps.py knows how to install Meta/Facebook open source libraries into
    user land, typically /tmp/fbcode_builder_getdeps-Z$HOME-project.

    From there's its a small matter of lib, ld and include paths to get
    glean itself to link and execute.

    A typical profile would be glean against system packages, except for:

        libfolly.so.0.58.0-dev
        libthriftcpp2.so.1.0.0
        libthriftmetadata.so.1.0.0
        libthriftprotocol.so.1.0.0
        libtransport.so.1.0.0
        librpcmetadata.so.1.0.0
        libconcurrency.so.1.0.0
        libthrift-core.so.1.0.0
        libasync.so.1.0.0
        libwangle.so.1
        libfizz.so.1

    Build instructions change slightly:

        $ env BUILD_DEPS=1 ./install_deps
        $ make BUILD_DEPS=1
        $ make test BUILD_DEPS=1

    etc.

    The old build way is still supported for now.

    N.B. we aren't adding rocksdb or xxhash deps, they are still treated as
    implicit glean system packages (to solve with your package manager).

Open questions:
- ldd will show library deps on .so files in /tmp/fbcode_builder* , we should decide on a user install policy to get those libraries somewhere more permanent. One idea would be to install in .cabal/* or $HOME/{bin,lib,include} . YMMV?
- doesn't update the ci.yml , yet, so that continues to build the old way
- the cabal binary has to be invoked with quite a lot of flags set to find all the deps. We might want to stage that by writing those to a config or script first, then invoking that.