### PR TITLE
[glean] Bump node version in Netlify

### DIFF
--- a/glean/website/netlify.toml
+++ b/glean/website/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+  NODE_VERSION = "16.13.0"


### PR DESCRIPTION
Doc building was failing with
```
5:01:59 PM: error @docusaurus/core@2.0.0-beta.9: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.18.0"
```
Like on [this](https://app.netlify.com/sites/fb-oss-glean/deploys/61f02ce660b712000891014b) run.

This PR ensures we use a more up to date LTS node version.