### PR TITLE
Use hsthrift non-sudo build style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,43 @@ jobs:
       - name: Install RocksDB/libxxhash
         run: apt-get install -y librocksdb-dev libxxhash-dev
       - name: Get hsthrift and build/install its dependencies
-        run: ./install_deps.sh
+        run: env GLEAN_DEPS_WITH_SUDO=1 ./install_deps.sh
       - name: Populate hackage index
         run: cabal update
       - name: Build hsthrift/Glean
         run: make
       - name: Run Glean tests
         run: make test
+  ci-nosudo:
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [8.10.7]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/facebookincubator/hsthrift/ci-base:ghcup
+      options: --cpus 2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install GHC ${{ matrix.ghc }}
+        run: ghcup install ghc ${{ matrix.ghc }} --set
+      - name: Install cabal-install 3.6
+        run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-x86_64-linux.tar.xz 3.6.0.0 --set
+      - name: Add GHC and cabal to PATH
+        run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+      - name: Populate hackage index
+        run: cabal update
+      - name: Install RocksDB/libxxhash
+        run: apt-get install -y librocksdb-dev libxxhash-dev
+      - name: Get hsthrift and build/install its dependencies
+        run: ./install_deps.sh
+      - name: Add thrift compiler to path
+        run: echo "$HOME/.hsthrift/bin" >> $GITHUB_PATH
+      - name: Build hsthrift/Glean
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make
+      - name: Run Glean tests
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make test
   vscode:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,14 @@ jobs:
         run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-x86_64-linux.tar.xz 3.6.0.0 --set
       - name: Add GHC and cabal to PATH
         run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-      - name: Populate hackage index
-        run: cabal update
       - name: Install RocksDB/libxxhash
         run: apt-get install -y librocksdb-dev libxxhash-dev
       - name: Get hsthrift and build/install its dependencies
         run: ./install_deps.sh
       - name: Add thrift compiler to path
         run: echo "$HOME/.hsthrift/bin" >> $GITHUB_PATH
+      - name: Populate hackage index
+        run: cabal update
       - name: Build hsthrift/Glean
         run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make
       - name: Run Glean tests

--- a/glean/website/docs/building.md
+++ b/glean/website/docs/building.md
@@ -17,7 +17,7 @@ that are needed for building Glean.
 ## You will need
 
 * Linux. The build is only tested on Linux so far; we hope to add
-  support for other OSs in the future.
+  support for other OSs in the future. We have tested on x86\_64 and arm64v8.
 
 * [GHC](https://www.haskell.org/ghc/). To see which versions Glean is tested with, check the current [ci.yml](https://github.com/facebookincubator/Glean/blob/master/.github/workflows/ci.yml) script.
 
@@ -111,14 +111,6 @@ sudo dnf install \
 
 ## Building
 
-:::warning
-
-The build process currently installs dependencies in
-`/usr/local/lib`. This isn't ideal; we're working on a more
-self-contained build process but it's not ready yet.
-
-:::
-
 Clone the repository:
 
 ```
@@ -126,22 +118,40 @@ git clone https://github.com/facebookincubator/Glean.git
 cd Glean
 ```
 
-These are necessary so that the Glean build can find the dependencies
-that get installed in `/usr/local/lib`:
+### Build hsthrift and dependencies
+
+Glean depends on hsthrift, fbthrift, folly and some other core libraries.
+We need to set paths to these that the Glean build can find the thrift compiler
+and associated libraries:
+
+```
+export LD_LIBRARY_PATH=$HOME/.hsthrift/lib:$LD_LIBRARY_PATH
+export PKG_CONFIG_PATH=$HOME/lib/pkgconfig
+export PATH=$PATH:$HOME/.hsthrift/bin
+```
+
+Now clone [hsthrift](https://github.com/facebookincubator/hsthrift) and
+install its dependencies:
+```
+./install_deps.sh
+```
+
+If you prefer to install into /usr/local/ and have root privs, set instead:
 
 ```
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 ```
 
-Clone [hsthrift](https://github.com/facebookincubator/hsthrift) and
-install its dependencies:
+and build hsthrift with:
 
 ```
-./install_deps.sh
+env GLEAN_DEPS_WITH_SUDO=1 ./install_deps.sh
 ```
 
-Build everything:
+### Build Glean
+
+Now you can build all the Glean parts:
 
 ```
 make
@@ -155,3 +165,4 @@ make test
 
 At this point you can `cabal install` to install the executables into
 `~/.cabal/bin`.
+

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -5,8 +5,33 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+#
+# Note, if you set GLEAN_DEPS_WITH_SUDO=1 hsthrift deps will be installed into
+# /usr/local, which requires sudo privs, and you'll need to set:
+#
+# > export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+# > export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+#
+# You will need --sudo passed to ./install_deps.sh
+#
+# To build without root privs (the default), you will need to set:
+#
+# > export LD_LIBRARY_PATH=$HOME/.hsthrift/lib
+# > export PKG_CONFIG_PATH=$HOME/.hsthrift/lib/pkgconfig
+# > export PATH=$PATH:$HOME/.hsthrift/bin
+#
+
 set -e
 
-git clone https://github.com/facebookincubator/hsthrift.git
+HSTHRIFT_REPO=https://github.com/facebookincubator/hsthrift.git
+
+if test ! -d hsthrift; then
+    git clone "${HSTHRIFT_REPO}"
+fi
+
 cd hsthrift
-./install_deps.sh --nuke
+if test -z "${GLEAN_DEPS_WITH_SUDO}"; then
+    ./new_install_deps.sh
+else
+    ./install_deps.sh --nuke
+fi


### PR DESCRIPTION
This teaches the ci and install step how to build hsthrift dependencies without sudo using getdeps.py.

- libraries and binaries will be placed into $HOME/.hsthrift/{bin,lib,lib/pkgconfig} , determined by hsthrift/new_install_deps.sh

This makes no-sudo the default. For the old way use: env GLEAN_WITH_SUDO_DEPS=1 ./install_deps.sh 

Tested on aarch64 and x86_64. Docs updated and scary warning about /usr/local removed. Instructions for both dep install styles are mentioned. `make test` passes 

Depends on : https://github.com/facebookincubator/hsthrift/pull/58   (or override ./install_deps.sh repo path to https://github.com/donsbot/hsthrift to test)

Notes:
- we are blocked on an fbthrift issue that prevents hsthrift building. See https://github.com/facebook/fbthrift/issues/476 (you can work around the fbthrift issue by building fbthrift at rev b80cfa6)
- its arguable that where we should put the hsthrift deps. $HOME/.hsthrift/{bin,lib} doesn't seem terrible

Further work:
- Once these are all landed we should delete the old manual way entirely, I think, as it is strictly subsumed and try dropping root on a few more things.
- Update the ci.yml to build the new way on more arch/compilers
- double check the 'ninja' dep is required and check -j flags etc.