### PR TITLE
Patch Glean dep installer to also build rocksdb from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,43 @@ jobs:
       - name: Install RocksDB/libxxhash
         run: apt-get install -y librocksdb-dev libxxhash-dev
       - name: Get hsthrift and build/install its dependencies
-        run: ./install_deps.sh
+        run: env GLEAN_DEPS_WITH_SUDO=1 ./install_deps.sh
       - name: Populate hackage index
         run: cabal update
       - name: Build hsthrift/Glean
         run: make
       - name: Run Glean tests
         run: make test
+  ci-nosudo:
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [8.10.7]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/facebookincubator/hsthrift/ci-base:ghcup
+      options: --cpus 2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install GHC ${{ matrix.ghc }}
+        run: ghcup install ghc ${{ matrix.ghc }} --set
+      - name: Install cabal-install 3.6
+        run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-x86_64-linux.tar.xz 3.6.0.0 --set
+      - name: Add GHC and cabal to PATH
+        run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+      - name: Install RocksDB/libxxhash
+        run: apt-get install -y librocksdb-dev libxxhash-dev
+      - name: Get hsthrift and build/install its dependencies
+        run: ./install_deps.sh
+      - name: Add thrift compiler to path
+        run: echo "$HOME/.hsthrift/bin" >> $GITHUB_PATH
+      - name: Populate hackage index
+        run: cabal update
+      - name: Build hsthrift/Glean
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make
+      - name: Run Glean tests
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make test
   vscode:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [8.4.4, 8.6.5, 8.8.4, 8.10.2]
+        ghc: [8.4.4, 8.6.5, 8.8.4, 8.10.7]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/facebookincubator/hsthrift/ci-base:ghcup
@@ -15,43 +15,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install ninja
+        run: apt install ninja-build
       - name: Install GHC ${{ matrix.ghc }}
         run: ghcup install ghc ${{ matrix.ghc }} --set
       - name: Install cabal-install 3.6
         run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-x86_64-linux.tar.xz 3.6.0.0 --set
       - name: Add GHC and cabal to PATH
         run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-      - name: Install RocksDB/libxxhash
-        run: apt-get install -y librocksdb-dev libxxhash-dev
-      - name: Get hsthrift and build/install its dependencies
-        run: env GLEAN_DEPS_WITH_SUDO=1 ./install_deps.sh
-      - name: Populate hackage index
-        run: cabal update
-      - name: Build hsthrift/Glean
-        run: make
-      - name: Run Glean tests
-        run: make test
-  ci-nosudo:
-    strategy:
-      fail-fast: false
-      matrix:
-        ghc: [8.10.7]
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/facebookincubator/hsthrift/ci-base:ghcup
-      options: --cpus 2
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Install GHC ${{ matrix.ghc }}
-        run: ghcup install ghc ${{ matrix.ghc }} --set
-      - name: Install cabal-install 3.6
-        run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-x86_64-linux.tar.xz 3.6.0.0 --set
-      - name: Add GHC and cabal to PATH
-        run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-      - name: Install RocksDB/libxxhash
-        run: apt-get install -y librocksdb-dev libxxhash-dev
-      - name: Get hsthrift and build/install its dependencies
+      - name: Install libxxhash
+        run: apt-get install -y libxxhash-dev
+      - name: Fetch hsthrift and build folly, fizz, wangle, fbthrift, rocksdb
         run: ./install_deps.sh
       - name: Add thrift compiler to path
         run: echo "$HOME/.hsthrift/bin" >> $GITHUB_PATH
@@ -61,6 +35,7 @@ jobs:
         run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make
       - name: Run Glean tests
         run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make test
+  # check the vscode extension builds
   vscode:
     runs-on: ubuntu-latest
     steps:

--- a/glean/website/docs/building.md
+++ b/glean/website/docs/building.md
@@ -17,7 +17,7 @@ that are needed for building Glean.
 ## You will need
 
 * Linux. The build is only tested on Linux so far; we hope to add
-  support for other OSs in the future.
+  support for other OSs in the future. We have tested on x86\_64 and arm64v8.
 
 * [GHC](https://www.haskell.org/ghc/). To see which versions Glean is tested with, check the current [ci.yml](https://github.com/facebookincubator/Glean/blob/master/.github/workflows/ci.yml) script.
 
@@ -111,14 +111,6 @@ sudo dnf install \
 
 ## Building
 
-:::warning
-
-The build process currently installs dependencies in
-`/usr/local/lib`. This isn't ideal; we're working on a more
-self-contained build process but it's not ready yet.
-
-:::
-
 Clone the repository:
 
 ```
@@ -126,22 +118,40 @@ git clone https://github.com/facebookincubator/Glean.git
 cd Glean
 ```
 
-These are necessary so that the Glean build can find the dependencies
-that get installed in `/usr/local/lib`:
+### Build hsthrift and dependencies
+
+Glean depends on hsthrift, fbthrift, folly and some other core libraries.
+We need to set paths to these that the Glean build can find the thrift compiler
+and associated libraries:
+
+```
+export LD_LIBRARY_PATH=$HOME/.hsthrift/lib:$LD_LIBRARY_PATH
+export PKG_CONFIG_PATH=$HOME/lib/pkgconfig
+export PATH=$PATH:$HOME/.hsthrift/bin
+```
+
+Now clone [hsthrift](https://github.com/facebookincubator/hsthrift) and
+install its dependencies:
+```
+./install_deps.sh
+```
+
+If you prefer to install into /usr/local/ and have root privs, set instead:
 
 ```
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 ```
 
-Clone [hsthrift](https://github.com/facebookincubator/hsthrift) and
-install its dependencies:
+and build hsthrift with:
 
 ```
-./install_deps.sh
+env GLEAN_DEPS_WITH_SUDO=1 ./install_deps.sh
 ```
 
-Build everything:
+### Build Glean
+
+Now you can build all the Glean parts:
 
 ```
 make
@@ -155,3 +165,4 @@ make test
 
 At this point you can `cabal install` to install the executables into
 `~/.cabal/bin`.
+

--- a/glean/website/docs/building.md
+++ b/glean/website/docs/building.md
@@ -60,7 +60,6 @@ sudo apt-get install \
     libpcre3-dev \
     libmysqlclient-dev \
     libfftw3-dev \
-    librocksdb-dev \
     libxxhash-dev
 ```
 
@@ -74,11 +73,10 @@ Use
 ```
         default-libmysqlclient-dev
 ```
-instead. You also need to install:
+instead. You may also need to install:
 ```
         libfmt-dev
 ```
-instead.
 
 ### Fedora
 
@@ -105,7 +103,6 @@ sudo dnf install \
     pcre-devel \
     community-mysql-devel \
     fftw-devel \
-    rocksdb-devel \
     xxhash-devel
 ```
 
@@ -120,7 +117,7 @@ cd Glean
 
 ### Build hsthrift and dependencies
 
-Glean depends on hsthrift, fbthrift, folly and some other core libraries.
+Glean depends on hsthrift, fbthrift, folly, rocksdb and some other core libraries.
 We need to set paths to these that the Glean build can find the thrift compiler
 and associated libraries:
 
@@ -131,22 +128,9 @@ export PATH=$PATH:$HOME/.hsthrift/bin
 ```
 
 Now clone [hsthrift](https://github.com/facebookincubator/hsthrift) and
-install its dependencies:
+build and install its dependencies:
 ```
 ./install_deps.sh
-```
-
-If you prefer to install into /usr/local/ and have root privs, set instead:
-
-```
-export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-```
-
-and build hsthrift with:
-
-```
-env GLEAN_DEPS_WITH_SUDO=1 ./install_deps.sh
 ```
 
 ### Build Glean

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -5,8 +5,33 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+#
+# Note, if you set GLEAN_DEPS_WITH_SUDO=1 hsthrift deps will be installed into
+# /usr/local, which requires sudo privs, and you'll need to set:
+#
+# > export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+# > export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+#
+# You will need --sudo passed to ./install_deps.sh
+#
+# To build without root privs (the default), you will need to set:
+#
+# > export LD_LIBRARY_PATH=$HOME/.hsthrift/lib
+# > export PKG_CONFIG_PATH=$HOME/.hsthrift/lib/pkgconfig
+# > export PATH=$PATH:$HOME/.hsthrift/bin
+#
+
 set -e
 
-git clone https://github.com/facebookincubator/hsthrift.git
+HSTHRIFT_REPO=https://github.com/facebookincubator/hsthrift.git
+
+if test ! -d hsthrift; then
+    git clone "${HSTHRIFT_REPO}"
+fi
+
 cd hsthrift
-./install_deps.sh --nuke
+if test -z "${GLEAN_DEPS_WITH_SUDO}"; then
+    ./new_install_deps.sh
+else
+    ./install_deps.sh --nuke
+fi

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -24,6 +24,11 @@
 set -e
 
 HSTHRIFT_REPO=https://github.com/facebookincubator/hsthrift.git
+THREADS=4
+
+case "$1" in
+    --threads) THREADS="$2"; shift; shift;;
+esac
 
 if test ! -d hsthrift; then
     git clone "${HSTHRIFT_REPO}"
@@ -31,7 +36,7 @@ fi
 
 cd hsthrift
 if test -z "${GLEAN_DEPS_WITH_SUDO}"; then
-    ./new_install_deps.sh
+    ./new_install_deps.sh rocksdb --threads "${THREADS}"
 else
     ./install_deps.sh --nuke
 fi

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -6,14 +6,6 @@
 # LICENSE file in the root directory of this source tree.
 
 #
-# Note, if you set GLEAN_DEPS_WITH_SUDO=1 hsthrift deps will be installed into
-# /usr/local, which requires sudo privs, and you'll need to set:
-#
-# > export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-# > export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-#
-# You will need --sudo passed to ./install_deps.sh
-#
 # To build without root privs (the default), you will need to set:
 #
 # > export LD_LIBRARY_PATH=$HOME/.hsthrift/lib
@@ -35,8 +27,4 @@ if test ! -d hsthrift; then
 fi
 
 cd hsthrift
-if test -z "${GLEAN_DEPS_WITH_SUDO}"; then
-    ./new_install_deps.sh rocksdb --threads "${THREADS}"
-else
-    ./install_deps.sh --nuke
-fi
+./new_install_deps.sh rocksdb --threads "${THREADS}"


### PR DESCRIPTION
So, recent trunk changes to rocksdb break compatibility with the standard packages we use. We have to switch to building rocksdb from source. We do that via hsthrift/build/fbcode_builder/getdeps.py 

We can't use the old dep installer now, as we have no other way to get rocksdb built, so this patch removes that stuff from the CI and documentation. We also don't need to install system packages for librocksdb now. They won't help us.

This depends on https://github.com/facebookincubator/hsthrift/pull/61 , which adds the needful cmd line arg support for non-core hsthrift packages. CI will be red until the hsthrift change lands, and glean ci gets re-run.