### PR TITLE
Various improvements

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -1,0 +1,33 @@
+name: CI-ARM64
+on: [push]
+
+jobs:
+  ci-arm64:
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [8.10.7]
+    runs-on: [self-hosted, linux, ARM64]
+    container:
+      # built from hsthrift/.github/workflows/Dockerfile.arm64v8
+      image: ghcr.io/donsbot/hsthrift/ci-base:arm64
+      options: --cpus 4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install GHC ${{ matrix.ghc }}
+        run: ghcup install ghc ${{ matrix.ghc }} --set
+      - name: Install cabal-install 3.6
+        run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-aarch64-linux-deb10.tar.xz 3.6.0.0 --set
+      - name: Add GHC and cabal to PATH
+        run: echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
+      - name: Install libxxhash
+        run: apt-get install -y libxxhash-dev
+      - name: Fetch hsthrift and build folly, fizz, wangle, fbthrift, rocksdb
+        run: ./install_deps.sh
+      - name: Populate hackage index with new packages
+        run: cabal update
+      - name: Build hsthrift/Glean
+        run: make
+      - name: Run Glean tests
+        run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/facebookincubator/hsthrift/ci-base:latest as tools
-RUN apt-get install -y ghc-8.10.2 librocksdb-dev libxxhash-dev wget unzip
+RUN apt-get install -y ghc-8.10.2 ninja-build libfmt-dev libxxhash-dev wget unzip
 RUN cabal update
 RUN mkdir /glean-code
 WORKDIR /glean-code
@@ -12,6 +12,11 @@ ADD ./Makefile  /glean-code/
 ADD ./glean.cabal /glean-code/
 ADD ./LICENSE /glean-code/
 ADD ./Setup.hs /glean-code/
+
+ENV LD_LIBRARY_PATH=/root/.hsthrift/lib:/usr/local/lib
+ENV PKG_CONFIG_PATH=/root/.hsthrift/lib/pkgconfig
+ENV PATH=$PATH:/root/.hsthrift/bin
+
 RUN make
 RUN cp $(cabal exec --project-file=cabal.project -- which glean) ~/.cabal/bin/
 RUN cp $(cabal exec --project-file=cabal.project -- which glean-server) ~/.cabal/bin/
@@ -40,7 +45,6 @@ RUN apt-get update && apt-get install -y \
     libboost-filesystem1.71.0 \
     libboost-program-options1.71.0 \
     libboost-regex1.71.0 \
-    librocksdb5.17 \
     libunwind8 \
     libgoogle-glog0v5 \
     libssl1.1 \
@@ -56,7 +60,7 @@ WORKDIR /glean-demo
 
 RUN mkdir /glean-demo/bin
 
-COPY --from=tools /usr/local/lib /usr/local/lib
+COPY --from=tools /root/.hsthrift/lib /usr/local/lib
 COPY --from=tools /usr/local/bin/flow /usr/local/bin
 COPY --from=tools /root/.cabal/bin/glean /glean-demo/bin
 COPY --from=tools /root/.cabal/bin/glean-server /glean-demo/bin

--- a/glean/rts/ownership/fallbackavx.h
+++ b/glean/rts/ownership/fallbackavx.h
@@ -20,60 +20,6 @@
 #include <folly/experimental/Instructions.h>
 
 /*
- * Stub of immintrin.h needed by glean/rts/ownership
- */
-typedef uint32_t __m256i;
-
-inline int _mm256_testc_si256(__m256i __M, __m256i __V) {
-    return 0;
-}
-
-inline int _mm256_testz_si256(__m256i __M, __m256i __V) {
-    return 0;
-}
-
-inline __m256i _mm256_setzero_si256() {
-    return 0;
-}
-
-inline __m256i _mm256_set1_epi32(int __A) {
-    return 0;
-}
-
-inline __m256i _mm256_sllv_epi32(__m256i __X, __m256i __Y) {
-    return 0;
-}
-
-inline __m256i _mm256_sub_epi32(__m256i __A, __m256i __B) {
-    return 0;
-}
-
-inline __m256i _mm256_set_epi32(int __A, int __B, int __C, int __D, int __E, int __F, int __G, int __H) {
-    return 0;
-}
-
-// AV512
-inline long long _mm_popcnt_u64(unsigned long long __X) {
-    return 0;
-}
-
-inline unsigned long long _lzcnt_u64(unsigned long long __X) {
-    return 0;
-}
-
-inline __m256i _mm256_or_si256(__m256i __A, __m256i __B) {
-    return 0;
-}
-
-inline __m256i _mm256_and_si256(__m256i __A, __m256i __B) {
-    return 0;
-}
-
-inline __m256i _mm256_xor_si256(__m256i __A, __m256i __B) {
-    return 0;
-}
-
-/*
  * Stub of EliasFanoCoding.h API used by Glean
  */
 namespace folly {

--- a/glean/rts/ownership/setu32.h
+++ b/glean/rts/ownership/setu32.h
@@ -28,6 +28,10 @@ namespace facebook {
 namespace glean {
 namespace rts {
 
+#if !__x86_64__
+typedef uint32_t __m256i __attribute__((vector_size(32)));
+#endif
+
 /**
  * An implementation of 256-bit bitsets. This uses AVX2, most probably
  * unnecessarily.
@@ -96,15 +100,14 @@ inline __m256i xor_(__m256i value, __m256i other) {
 
 #else // not x86_64
 
-typedef uint32_t __m256i __attribute__((vector_size(32)));
-
 inline bool empty(__m256i value) {
   return !(value[0] || value[1] || value[2] || value[3] ||
            value[4] || value[5] || value[6] || value[7]);
 }
 
 inline __m256i none() {
-  return {0, 0, 0, 0, 0, 0, 0, 0};
+  __m256i v = {0, 0, 0, 0, 0, 0, 0, 0};
+  return v;
 }
 
 inline __m256i all() {

--- a/glean/website/docs/building.md
+++ b/glean/website/docs/building.md
@@ -36,8 +36,9 @@ that we use for building the base image for CI).
 sudo apt-get install \
     g++ \
     cmake \
+    ninja-build \
     bison flex \
-    git cmake \
+    git \
     libzstd-dev \
     libboost-all-dev \
     libevent-dev \
@@ -65,18 +66,8 @@ sudo apt-get install \
 
 ### Debian
 
-The package dependencies for Debian current are the same as above for Ubuntu, except you may see:
-```
- Package 'libmysqlclient-dev' has no installation candidate
-```
-Use
-```
-        default-libmysqlclient-dev
-```
-instead. You may also need to install:
-```
-        libfmt-dev
-```
+The package dependencies for Debian current are the same as above for Ubuntu,
+except you need `default-libmysqlclient-dev` instead of `libmysqlclient-dev`.
 
 ### Fedora
 
@@ -87,6 +78,7 @@ sudo dnf install \
     g++ \
     make \
     cmake \
+    ninja-build \
     binutils \
     bison flex \
     curl \
@@ -132,6 +124,8 @@ build and install its dependencies:
 ```
 ./install_deps.sh
 ```
+
+You can speed up builds by passing e.g. `--threads 8` if you have available hardware.
 
 ### Build Glean
 


### PR DESCRIPTION
- fixes docker recipes in light of new build paths
- fixes borkage on non-x86
- adds CI action to build on arm64 on our self-hosted ec2

The base image for the CI-ARM64 action is at ghcr.io/donsbot , please docker build and push to ghcr.io/facebookincubator and update the path when you get a chance. 