### PR TITLE
Fix CI: drop system libfmt from CI image

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install libxxhash
         run: apt-get install -y libxxhash-dev
+      - name: Remove libfmt
+        run: apt-get remove -y libfmt-dev
       - name: Install GHC ${{ matrix.ghc }}
         run: ghcup install ghc ${{ matrix.ghc }} --set --force
       - name: Install cabal-install 3.6
@@ -30,6 +32,8 @@ jobs:
         run: echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
       - name: Fetch hsthrift and build folly, fizz, wangle, fbthrift, rocksdb
         run: ./install_deps.sh
+      - name: Nuke build artifacts
+        run: rm -rf /tmp/fbcode_builder_getdeps-Z__wZGleanZGleanZhsthriftZbuildZfbcode_builder-root/
       - name: Populate hackage index with new packages
         run: cabal update
       - name: Build hsthrift/Glean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,22 @@ jobs:
         uses: actions/checkout@v2
       - name: Install ninja
         run: apt install ninja-build
+      - name: Install libxxhash
+        run: apt-get install -y libxxhash-dev
+      - name: Remove libfmt
+        run: apt-get remove -y libfmt-dev
       - name: Install GHC ${{ matrix.ghc }}
         run: ghcup install ghc ${{ matrix.ghc }} --set
       - name: Install cabal-install 3.6
         run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-x86_64-linux.tar.xz 3.6.0.0 --set
       - name: Add GHC and cabal to PATH
-        run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-      - name: Install libxxhash
-        run: apt-get install -y libxxhash-dev
+        run: echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
       - name: Fetch hsthrift and build folly, fizz, wangle, fbthrift, rocksdb
         run: ./install_deps.sh
+      - name: Nuke build artifacts
+        run: rm -rf /tmp/fbcode_builder_getdeps-Z__wZGleanZGleanZhsthriftZbuildZfbcode_builder-root/
       - name: Add thrift compiler to path
-        run: echo "$HOME/.hsthrift/bin" >> $GITHUB_PATH
+        run: echo "$HOME/.hsthrift/bin" >> "$GITHUB_PATH"
       - name: Populate hackage index
         run: cabal update
       - name: Build hsthrift/Glean


### PR DESCRIPTION
We need to use libfmt 8, built from source. Make sure there's no libfmt
system package (v7) floating around. Fixes the CI.

While we're here, nuke getdeps ephemeral build artifacts directory to free up 5G or so of
space on the container.

Tested on:
- x86. github container: https://github.com/donsbot/Glean/runs/5134280882?check_suite_focus=true
- arm64 self hosted: https://github.com/donsbot/Glean/runs/5134280882?check_suite_focus=true