### PR TITLE
Get glass and friends building with cabal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make
       - name: Run Glean tests
         run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make test
+      - name: Build Glass
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make glass
   # check the vscode extension builds
   vscode:
     runs-on: ubuntu-latest

--- a/glean.cabal
+++ b/glean.cabal
@@ -159,6 +159,8 @@ library logger
         Logger.IO
         Logger.GleanDatabaseStats
         Logger.GleanServer
+        Logger.GleanGlass
+        Logger.GleanGlassErrors
     build-depends:
         glean:util
 
@@ -562,7 +564,6 @@ library db
         glean:tailer,
         glean:rocksdb,
 
-
 library client-hs
     import: fb-haskell, fb-cpp, deps
     visibility: public
@@ -573,6 +574,7 @@ library client-hs
           Glean.Write
           Glean.Haxl
           Glean.Repo
+          Glean.Haxl.Repos
           Glean.Util.ShellPrint
     build-depends:
         pretty,
@@ -595,7 +597,6 @@ library client-hs-local
         glean:core,
         glean:client-hs,
         glean:db,
-
 
 library schema
     import: fb-haskell, fb-cpp, deps
@@ -629,8 +630,11 @@ library schema
         Glean.Schema.Pp1
         Glean.Schema.Python
         Glean.Schema.Rust
+        Glean.Schema.SearchCode
         Glean.Schema.SearchCxx
+        Glean.Schema.SearchErlang
         Glean.Schema.SearchHack
+        Glean.Schema.SearchHs
         Glean.Schema.SearchPp
         Glean.Schema.Src
         Glean.Schema.Sys
@@ -661,8 +665,11 @@ library schema
         Glean.Schema.Pp1.Types
         Glean.Schema.Python.Types
         Glean.Schema.Rust.Types
+        Glean.Schema.SearchCode.Types
         Glean.Schema.SearchCxx.Types
+        Glean.Schema.SearchErlang.Types
         Glean.Schema.SearchHack.Types
+        Glean.Schema.SearchHs.Types
         Glean.Schema.SearchPp.Types
         Glean.Schema.Src.Types
         Glean.Schema.Sys.Types
@@ -960,6 +967,106 @@ executable glean-hyperlink
         http-types,
         wai,
         warp
+
+-- -----------------------------------------------------------------------------
+-- Glass services
+
+-- Glass thrift service definition
+library if-glass-hs
+    import: fb-haskell, fb-cpp, deps
+    visibility: public
+    hs-source-dirs:
+        glean/glass/if/glass/gen-hs2
+    exposed-modules:
+        Glean.Glass.Types
+        Glean.Glass.GlassService.Client
+        Glean.Glass.GlassService.Service
+    build-depends:
+        glean:config,
+        glean:if-fb303-hs,
+        glean:if-index-hs
+
+-- Glass core library
+library glass-lib
+    import: fb-haskell, fb-cpp, deps
+    visibility: public
+    default-extensions: CPP
+    hs-source-dirs: glean/glass
+    exposed-modules:
+        Glean.Glass.Attributes
+        Glean.Glass.Attributes.Class
+        Glean.Glass.Attributes.SymbolKind
+        Glean.Glass.Base
+        Glean.Glass.Config
+        Glean.Glass.Env
+        Glean.Glass.Handler
+        Glean.Glass.Logging
+        Glean.Glass.Main
+        Glean.Glass.Options
+        Glean.Glass.Pretty.Cxx
+        Glean.Glass.Pretty.Hack
+        Glean.Glass.Query
+        Glean.Glass.Query.Cxx
+        Glean.Glass.Range
+        Glean.Glass.Repos
+        Glean.Glass.Search
+        Glean.Glass.Search.Class
+        Glean.Glass.Search.Cxx
+        Glean.Glass.Search.Erlang
+        Glean.Glass.Search.Flow
+        Glean.Glass.Search.Hack
+        Glean.Glass.Search.Haskell
+        Glean.Glass.Search.Python
+        Glean.Glass.Path
+        Glean.Glass.RepoMapping
+        Glean.Glass.SymbolId
+        Glean.Glass.SymbolId.Buck
+        Glean.Glass.SymbolId.Class
+        Glean.Glass.SymbolId.Cxx
+        Glean.Glass.SymbolId.Erlang
+        Glean.Glass.SymbolId.Flow
+        Glean.Glass.SymbolId.Hack
+        Glean.Glass.SymbolId.Hs
+        Glean.Glass.SymbolId.Pp
+        Glean.Glass.SymbolId.Python
+        Glean.Glass.SymbolId.Rust
+        Glean.Glass.SymbolId.Thrift
+        Glean.Glass.SymbolMap
+        Glean.Glass.Utils
+    build-depends:
+        glean:client-hs,
+        glean:client-hs-local,
+        glean:core,
+        glean:if-glass-hs,
+        glean:if-index-hs,
+        glean:lib,
+        glean:logger,
+        glean:schema,
+        glean:stubs,
+        glean:util,
+        thrift-server,
+        uri-encode,
+
+executable glass-server
+    import: fb-haskell, fb-cpp, deps, exe
+    hs-source-dirs: glean/glass/server
+    main-is: Server.hs
+    ghc-options: -main-is Server
+    extra-libraries: stdc++
+    build-depends:
+        glean:glass-lib,
+
+executable glass-symbol
+    import: fb-haskell, fb-cpp, deps, exe
+    hs-source-dirs: glean/glass/tools/
+    main-is: Glean/Glass/Test/Symbol.hs
+    ghc-options: -main-is Glean.Glass.Test.Symbol
+    extra-libraries: stdc++
+    default-extensions: CPP
+    build-depends:
+        glean:glass-lib,
+        glean:if-glass-hs,
+        glean:stubs,
 
 -- -----------------------------------------------------------------------------
 -- Benchmarks
@@ -1388,3 +1495,21 @@ if arch(x86_64)
             glean:db,
             glean:lib,
             glean:schema
+
+test-suite glass-range
+    import: fb-haskell, fb-cpp, deps, exe
+    hs-source-dirs: glean/glass/test
+    default-extensions: CPP
+    type: exitcode-stdio-1.0
+    main-is: Glean/Glass/Test/Range.hs
+    ghc-options: -main-is Glean.Glass.Test.Range
+    build-depends:
+        HUnit,
+        glean:client-hs,
+        glean:glass-lib,
+        glean:if-glass-hs,
+        glean:lib,
+        glean:schema,
+        glean:stubs,
+        glean:test-lib,
+        glean:test-unit,

--- a/glean/github/Logger/GleanGlass.hs
+++ b/glean/github/Logger/GleanGlass.hs
@@ -1,0 +1,59 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Logger.GleanGlass (module Logger.GleanGlass) where
+
+import Data.Monoid
+import Data.Semigroup
+import Data.Text
+
+import Logger.IO
+
+data GleanGlassLogger = GleanGlassLogger
+
+instance Semigroup GleanGlassLogger where
+  _ <> _ = GleanGlassLogger
+
+instance Monoid GleanGlassLogger where
+  mempty = GleanGlassLogger
+
+runLog :: Logger -> GleanGlassLogger -> IO ()
+runLog _ _ = return ()
+
+setSuccess :: Bool -> GleanGlassLogger
+setSuccess _ = GleanGlassLogger
+
+setError :: Text -> GleanGlassLogger
+setError _ = GleanGlassLogger
+
+setTimeElapsedUs :: Int -> GleanGlassLogger
+setTimeElapsedUs _ = GleanGlassLogger
+
+setAllocatedBytes :: Int -> GleanGlassLogger
+setAllocatedBytes _ = GleanGlassLogger
+
+setFilepath :: Text -> GleanGlassLogger
+setFilepath _ = GleanGlassLogger
+
+setRepo :: Text -> GleanGlassLogger
+setRepo _ = GleanGlassLogger
+
+setSymbol :: Text -> GleanGlassLogger
+setSymbol _ = GleanGlassLogger
+
+setItemCount :: Int -> GleanGlassLogger
+setItemCount _ = GleanGlassLogger
+
+setRepoName :: Text -> GleanGlassLogger
+setRepoName _ = GleanGlassLogger
+
+setRepoHash :: Text -> GleanGlassLogger
+setRepoHash _ = GleanGlassLogger
+
+setMethod :: Text -> GleanGlassLogger
+setMethod _ = GleanGlassLogger

--- a/glean/github/Logger/GleanGlassErrors.hs
+++ b/glean/github/Logger/GleanGlassErrors.hs
@@ -1,0 +1,50 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Logger.GleanGlassErrors (module Logger.GleanGlassErrors) where
+
+import Data.Monoid
+import Data.Semigroup
+import Data.Text
+
+import Logger.IO
+
+data GleanGlassErrorsLogger = GleanGlassErrorsLogger
+
+instance Semigroup GleanGlassErrorsLogger where
+  _ <> _ = GleanGlassErrorsLogger
+
+instance Monoid GleanGlassErrorsLogger where
+  mempty = GleanGlassErrorsLogger
+
+runLog :: Logger -> GleanGlassErrorsLogger -> IO ()
+runLog _ _ = return ()
+
+setError :: Text -> GleanGlassErrorsLogger
+setError _ = GleanGlassErrorsLogger
+
+setErrorType :: Text -> GleanGlassErrorsLogger
+setErrorType _ = GleanGlassErrorsLogger
+
+setRepoName :: Text -> GleanGlassErrorsLogger
+setRepoName _ = GleanGlassErrorsLogger
+
+setRepoHash :: Text -> GleanGlassErrorsLogger
+setRepoHash _ = GleanGlassErrorsLogger
+
+setFilepath :: Text -> GleanGlassErrorsLogger
+setFilepath _ = GleanGlassErrorsLogger
+
+setRepo :: Text -> GleanGlassErrorsLogger
+setRepo _ = GleanGlassErrorsLogger
+
+setSymbol :: Text -> GleanGlassErrorsLogger
+setSymbol _ = GleanGlassErrorsLogger
+
+setMethod :: Text -> GleanGlassErrorsLogger
+setMethod _ = GleanGlassErrorsLogger

--- a/glean/glass/Glean/Glass/Config.hs
+++ b/glean/glass/Glean/Glass/Config.hs
@@ -12,14 +12,11 @@ module Glean.Glass.Config
     defaultConfigKey,
     defaultPort,
     defaultServiceName,
-    defaultServerConfig,
     defaultRefreshFreq,
   ) where
 
 import Data.Text (Text)
 import Glean.Util.Time ( DiffTimePoints, minutes )
-
-import Glean.Glass.ServerConfig.Types (ServerConfig(..))
 
 defaultPort :: Int
 defaultPort = 26073
@@ -32,9 +29,3 @@ defaultServiceName = "glean_glass"
 
 defaultRefreshFreq :: DiffTimePoints
 defaultRefreshFreq = minutes 5
-
-defaultServerConfig :: ServerConfig
-defaultServerConfig =
-  ServerConfig {
-    serverConfig_port = fromIntegral defaultPort
-  }

--- a/glean/glass/Glean/Glass/Env.hs
+++ b/glean/glass/Glean/Glass/Env.hs
@@ -12,9 +12,6 @@ module Glean.Glass.Env
     -- * Read-only configuration
     Config(..),
 
-    -- * Values from server_config key
-    ServerConfig(..),
-
     -- * Session resources
     Env(..),
     IndexBackend(..),
@@ -23,7 +20,12 @@ module Glean.Glass.Env
 import Util.EventBase (EventBaseDataplane)
 import Facebook.Fb303 (Fb303State)
 import Logger.IO (Logger)
+
+#ifdef FACEBOOK
 import Configerator (ConfigAPI)
+#else
+import Glean.Impl.ConfigProvider (ConfigAPI)
+#endif
 
 import Data.Text (Text)
 import Control.Concurrent.STM
@@ -35,8 +37,6 @@ import Glean.Backend.Remote (ThriftBackend)
 import Glean.Util.Some ( Some )
 import Glean.Util.Observed (Observed)
 import Glean.Util.Time ( DiffTimePoints )
-
-import Glean.Glass.ServerConfig.Types (ServerConfig(..))
 
 -- | Init-time configuration
 data Config = Config
@@ -55,7 +55,6 @@ data Env = Env
   , logger :: Logger
   , gleanBackend :: Some Glean.Backend
   , fb303 :: Fb303State
-  , serverConfig :: Observed ServerConfig
   , latestGleanRepos :: TVar Glean.LatestRepos
   , gleanIndexBackend :: IndexBackend
   }

--- a/glean/glass/Glean/Glass/Path.hs
+++ b/glean/glass/Glean/Glass/Path.hs
@@ -1,0 +1,15 @@
+module Glean.Glass.Path where
+
+import Data.Text
+
+import Glean.Glass.Base
+import qualified Glean.Glass.Types as Glass
+
+-- Convert repo-relative Glass normalized paths to Glean-index specific paths
+toGleanPath :: Glass.RepoName -> Glass.Path -> GleanPath
+toGleanPath _ = GleanPath . Glass.unPath
+
+-- | Site-level rules for processing index paths to the filesystem
+-- Glass paths are always repo-root relative
+fromGleanPath :: Glass.RepoName -> GleanPath -> Glass.Path
+fromGleanPath _ = Glass.Path . gleanPath

--- a/glean/glass/Glean/Glass/RepoMapping.hs
+++ b/glean/glass/Glean/Glass/RepoMapping.hs
@@ -1,0 +1,17 @@
+module Glean.Glass.RepoMapping where
+
+import qualified Data.Map.Strict as Map
+
+import Glean.Glass.Base ( GleanDBAttrName, GleanDBName(..) )
+import Glean.Glass.Types ( Language(..), RepoName(..) )
+
+-- E.g. example: the open source react repo.
+gleanIndices :: Map.Map RepoName [(GleanDBName, Language)]
+gleanIndices = Map.fromList
+    [ (RepoName "react",
+        [ ("react", Language_JavaScript) ])
+    ]
+
+-- repos that contain symbol attributes
+gleanAttrIndices :: Map.Map GleanDBName [GleanDBAttrName]
+gleanAttrIndices = Map.empty

--- a/glean/glass/Glean/Glass/Repos.hs
+++ b/glean/glass/Glean/Glass/Repos.hs
@@ -70,9 +70,8 @@ import Glean.Glass.Types
       ServerException(ServerException),
     )
 
-import Glean.Glass.RepoMapping  -- site-specific
-import Glean.Glass.Path  -- site-specific
-
+import Glean.Glass.RepoMapping
+import Glean.Glass.Path
 
 --  all pairs (repoName, Language) which maps to glean db,
 --  except for "test" repoName

--- a/glean/glass/server/Server.hs
+++ b/glean/glass/server/Server.hs
@@ -1,0 +1,14 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Server ( main ) where
+
+import qualified Glean.Glass.Main ( main )
+
+main :: IO ()
+main = Glean.Glass.Main.main

--- a/glean/glass/test/Glean/Glass/Test/Range.hs
+++ b/glean/glass/test/Glean/Glass/Test/Range.hs
@@ -18,7 +18,9 @@ import Data.Int ( Int64 )
 import Data.ByteString ( ByteString )
 
 import TestRunner ( testRunner )
+#ifdef FACEBOOK
 import Facebook.Init ( withFacebookUnitTest )
+#endif
 
 import Glean.Glass.Range
     ( exclusiveRangeToFileByteSpan,
@@ -31,7 +33,11 @@ import qualified Glean.Schema.Src.Types as Src
 import qualified Glean.Util.Range as Range
 
 main :: IO ()
+#ifdef FACEBOOK
 main = withFacebookUnitTest $ testRunner $ TestList
+#else
+main = testRunner $ TestList
+#endif
   [ TestList
       [ TestLabel name $
          testByteSpanToRange bs glass_range offs

--- a/glean/glass/tools/Glean/Glass/Test/Symbol.hs
+++ b/glean/glass/tools/Glean/Glass/Test/Symbol.hs
@@ -24,7 +24,11 @@ import Options.Applicative
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 
+#ifdef FACEBOOK
 import Facebook.Init ( withFacebookOptions )
+#else
+import Glean.Init ( withOptions )
+#endif
 import Util.OptParse ( maybeTextOption, maybeIntOption )
 import Util.Timing ( showTime, timeIt )
 import Util.Text ( textShow )
@@ -70,7 +74,11 @@ options = info (helper <*> parser) fullDesc
 
 main :: IO ()
 main =
+#ifdef FACEBOOK
   withFacebookOptions options $ \Config{..} ->
+#else
+  withOptions options $ \Config{..} ->
+#endif
   Glass.withEnv "glass-symbol" (Glass.gleanService cfgGlass)
     (Glass.configKey cfgGlass) (Glass.refreshFreq cfgGlass) $ \env -> do
 


### PR DESCRIPTION
This lets us build:
- glass thrift if
- glass-lib
- glass standalone server
- glass-symbol
- glass-tests

Enough to start experimenting with working open source glass.

- we drop the (unused) configerator import for glass
- adds a few missing schemas that glass knows about: search/code,
  search/erlang and search/hs
- generate thrift for glass
- move "Server.hs" exe entrypoint into separate dir to make linking
  faster
- stub of loggers for glass
- glass entrypoints in Makefile
- glass build in CI on x86 for now

bonus:
- parallelize query/search thrift generation in makefile (slightly faster)
- add --jobs to cabal to encourage package-level parallel builds (slightly faster)

Things I had to work around:
- the dummy glass configerator spec isn't exported, nor are the loggers (easy to reproduce though)
- for the configerator spec, I've just dropped it. We should remove it upstream

It's alive:
```
glass-server --service localhost:39583
I0216 02:36:24.547757 2538833 Main.hs:109] glass: port 26073, config glean/glass/glass_server
```

Index react as described here:
https://donsbot.com/2022/01/11/glean-on-aarch64-on-apple-silicon-part-3/

And then we can use it:
```
glass-symbol/build/glass-symbol/glass-symbol --service localhost:39583 -c describe -s react/js/Hook
...
TBD
```