### PR TITLE
Fix CI

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -998,6 +998,7 @@ library glass-lib
         Glean.Glass.Attributes.Class
         Glean.Glass.Attributes.SymbolKind
         Glean.Glass.Base
+        Glean.Glass.Comments
         Glean.Glass.Config
         Glean.Glass.Env
         Glean.Glass.Handler


### PR DESCRIPTION
```
Building library 'glass-lib' for glean-0.1.0.0..

<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules:
        Glean.Glass.Comments
```