### PR TITLE
Simplify ARM CI script

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -22,14 +22,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Install libxxhash
         run: apt-get install -y libxxhash-dev
-      - name: Remove libfmt
-        run: apt-get remove -y libfmt-dev
       - name: Install GHC ${{ matrix.ghc }}
         run: ghcup install ghc ${{ matrix.ghc }} --set --force
       - name: Install cabal-install 3.6
         run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-aarch64-linux-deb10.tar.xz 3.6.0.0 --set
-      - name: Add GHC and cabal to PATH
-        run: echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
       - name: Fetch hsthrift and build folly, fizz, wangle, fbthrift, rocksdb
         run: ./install_deps.sh
       - name: Nuke build artifacts


### PR DESCRIPTION
We can simplify the arm build script a bit now, as the Docker image is more up to date (see latest state in https://github.com/facebookincubator/hsthrift/pull/66 ).

Note: need fbthrift fix for CI to see green: https://github.com/facebook/fbthrift/pull/482