### PR TITLE
Fix conditional include syntax in cabal file

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -1501,19 +1501,22 @@ test-suite lookup
         glean:core,
         glean:db
 
-if arch(x86_64)
-    test-suite incremental
-        import: test
-        type: exitcode-stdio-1.0
-        main-is: IncrementalTest.hs
-        ghc-options: -main-is IncrementalTest
-        build-depends:
-            glean:stubs,
-            glean:client-hs,
-            glean:core,
-            glean:db,
-            glean:lib,
-            glean:schema
+test-suite incremental
+    import: test
+    type: exitcode-stdio-1.0
+    main-is: IncrementalTest.hs
+    ghc-options: -main-is IncrementalTest
+    build-depends:
+        glean:stubs,
+        glean:client-hs,
+        glean:core,
+        glean:db,
+        glean:lib,
+        glean:schema
+    if arch(x86_64)
+        buildable: True
+    else
+        buildable: False
 
 test-suite glass-range
     import: fb-haskell, fb-cpp, deps, exe


### PR DESCRIPTION
This test was accidentally disabled.  We can't have a top level arch
test, has to be buildable/not buildable

Test plan:
- runs on x86
- fails to be runnable on arm

```
$ cabal test glean:incremental
Resolving dependencies...
cabal: Cannot test the test suite 'incremental' because it is marked as
'buildable: False' within the 'glean.cabal' file (at least for the current
```