### PR TITLE
Make C++ indexer buildable with cabal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Update apt database
+        run: apt-get update
       - name: Install ninja
         run: apt install ninja-build
-      - name: Install libxxhash wget unzip
-        run: apt-get install -y libxxhash-dev wget unzip
+      - name: Install libxxhash wget unzip clang llvm
+        run: apt-get install -y libxxhash-dev wget unzip clang-11 libclang-11-dev llvm-11-dev
       - name: Remove libfmt
         run: apt-get remove -y libfmt-dev
       - name: Install GHC ${{ matrix.ghc }}

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,11 @@ gen-schema ::
 	$(CABAL) run glean:gen-schema -- \
 		--dir glean/schema/source \
 		--thrift glean/schema \
-		--hs glean/schema \
+		--hs glean/schema
+	$(CABAL) run glean:gen-schema -- \
+		--dir glean/schema/source \
+		--thrift glean/schema \
+		--cpp glean/lang/clang/schema.h
 
 THRIFT_GLEAN= \
 	glean/github/if/fb303.thrift \
@@ -172,3 +176,7 @@ glass-lib:: thrift $(BYTECODE_GEN) gen-schema thrift-schema-hs thrift-glean-hs
 .PHONY: glass
 glass::
 	$(CABAL) build glass-server glass-democlient
+
+.PHONY: glean-clang
+glean-clang:: gen-schema glean
+	$(CABAL) build glean-clang

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ THRIFT_GLEAN= \
 	glean/config/client/client_config.thrift
 
 .PHONY: thrift-glean-hs
-thrift-glean-hs: thrift-compiler
+thrift-glean-hs:
 	for f in $(THRIFT_GLEAN); do \
 		$(THRIFT_COMPILE) --hs $$f -o $$(dirname $$f); \
 	done
@@ -136,7 +136,7 @@ thrift-glean-hs: thrift-compiler
 
 
 .PHONY: thrift-schema-hs
-thrift-schema-hs: thrift-compiler
+thrift-schema-hs:
 	for s in $(SCHEMAS); do \
 		$(THRIFT_COMPILE) --hs \
 			glean/schema/thrift/$$s.thrift \

--- a/cabal.project
+++ b/cabal.project
@@ -11,6 +11,7 @@ packages:
     hsthrift/haxl/thrift-haxl.cabal
     hsthrift/tests/thrift-tests.cabal
     glean.cabal
+    glean/lang/clang/glean-clang.cabal
 
 tests: True
 

--- a/glean.cabal
+++ b/glean.cabal
@@ -297,7 +297,7 @@ library ffi
 
 library rts
     import: fb-haskell, fb-cpp, deps
-    visibility: private
+    visibility: public
     include-dirs: .
     cxx-sources:
         glean/rts/binary.cpp

--- a/glean/cpp/sender.cpp
+++ b/glean/cpp/sender.cpp
@@ -184,6 +184,7 @@ private:
 
 }
 
+#if FACEBOOK
 std::unique_ptr<Sender> thriftSender(
     const std::string& service,
     const std::string& repo_name,
@@ -197,6 +198,7 @@ std::unique_ptr<Sender> thriftSender(
     }
   );
 }
+#endif
 
 namespace {
 

--- a/glean/interprocess/cpp/worklist.cpp
+++ b/glean/interprocess/cpp/worklist.cpp
@@ -16,7 +16,11 @@
 #include <boost/interprocess/file_mapping.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 
+#ifdef OSS
+#include <glog/logging.h>
+#else
 #include "common/logging/logging.h"
+#endif
 
 // A stealing counter file has the following structure:
 //

--- a/glean/lang/clang/LICENSE
+++ b/glean/lang/clang/LICENSE
@@ -1,0 +1,30 @@
+BSD License
+
+For Glean software
+
+Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/glean/lang/clang/Setup.hs
+++ b/glean/lang/clang/Setup.hs
@@ -1,0 +1,193 @@
+-- This a slight adaptation of the llvm-hs Setup.hs:
+-- https://github.com/llvm-hs/llvm-hs/blob/llvm-12/llvm-hs/Setup.hs
+{-# LANGUAGE CPP, FlexibleInstances, TupleSections #-}
+import Control.Exception (SomeException, try)
+import Control.Monad
+import Data.Char
+import Data.List
+import Data.Maybe
+import Data.Monoid
+import Distribution.PackageDescription hiding (buildInfo, includeDirs)
+import Distribution.Simple
+import Distribution.Simple.LocalBuildInfo
+import Distribution.Simple.PreProcess
+import Distribution.Simple.Program
+import Distribution.Simple.Setup hiding (Flag)
+import Distribution.System
+import qualified Distribution.Types.Executable as Exe
+import System.Environment
+
+-- define these selectively in C files (we are _not_ using HsFFI.h),
+-- rather than universally in the ccOptions, because HsFFI.h currently defines them
+-- without checking they're already defined and so causes warnings.
+uncheckedHsFFIDefines :: [String]
+uncheckedHsFFIDefines = ["__STDC_LIMIT_MACROS"]
+
+llvmVersions :: [Version]
+llvmVersions = map mkVersion $ concat
+  [ concat
+    [ [ [a, b, c]
+      | c <- versions_c
+      ] ++ [[a, b]]
+    | b <- versions_b
+    ] ++ [[a]]
+  | a <- versions_a
+  ]
+
+  where versions_a = [11, 12]
+        versions_b = [0, 1]
+        versions_c = [0, 1]
+
+-- Ordered by decreasing specificty so we will prefer llvm-config-9.0
+-- over llvm-config-9 over llvm-config.
+llvmConfigNames :: [String]
+llvmConfigNames = reverse versionedConfigs ++ ["llvm-config"]
+  where
+    versionedConfigs =
+      map
+        (\vs -> "llvm-config-" ++ intercalate "." (map show $ versionNumbers vs))
+        llvmVersions
+
+findJustBy :: Monad m => (a -> m (Maybe b)) -> [a] -> m (Maybe b)
+findJustBy f (x:xs) = do
+  x' <- f x
+  case x' of
+    Nothing -> findJustBy f xs
+    j -> return j
+findJustBy _ [] = return Nothing
+
+llvmProgram :: Program
+llvmProgram = (simpleProgram "llvm-config") {
+  programFindLocation = \v p -> findJustBy (\n -> programFindLocation (simpleProgram n) v p) llvmConfigNames,
+  programFindVersion = \verbosity path ->
+    let
+      stripVcsSuffix = takeWhile (\c -> isDigit c || c == '.')
+      trim = dropWhile isSpace . reverse . dropWhile isSpace . reverse
+    in findProgramVersion "--version" (stripVcsSuffix . trim) verbosity path
+ }
+
+getLLVMConfig :: ConfigFlags -> IO ([String] -> IO String)
+getLLVMConfig confFlags = do
+  let verbosity = fromFlag $ configVerbosity confFlags
+  (program, _, _) <- requireProgramVersion verbosity llvmProgram
+                     llvmVersionsRange
+                     (configPrograms confFlags)
+  return $ getProgramOutput verbosity program
+
+  where llvmVersionsRange = foldr1 unionVersionRanges [ thisVersion v | v <- llvmVersions ]
+
+addToLdLibraryPath :: String -> IO ()
+addToLdLibraryPath path = do
+  let (ldLibraryPathVar, ldLibraryPathSep) =
+        case buildOS of
+          OSX -> ("DYLD_LIBRARY_PATH",":")
+          _ -> ("LD_LIBRARY_PATH",":")
+  v <- try $ getEnv ldLibraryPathVar :: IO (Either SomeException String)
+  setEnv ldLibraryPathVar (path ++ either (const "") (ldLibraryPathSep ++) v)
+
+addLLVMToLdLibraryPath :: ConfigFlags -> IO ()
+addLLVMToLdLibraryPath confFlags = do
+  llvmConfig <- getLLVMConfig confFlags
+  [libDir] <- liftM lines $ llvmConfig ["--libdir"]
+  addToLdLibraryPath libDir
+
+-- | These flags are not relevant for us and dropping them allows
+-- linking against LLVM build with Clang using GCC
+ignoredCxxFlags :: [String]
+ignoredCxxFlags = ["-fcolor-diagnostics"] ++ map ("-D" ++) uncheckedHsFFIDefines
+
+ignoredCFlags :: [String]
+ignoredCFlags = ["-fcolor-diagnostics"]
+
+-- | Header directories are added separately to configExtraIncludeDirs
+isIncludeFlag :: String -> Bool
+isIncludeFlag flag = "-I" `isPrefixOf` flag
+
+isWarningFlag :: String -> Bool
+isWarningFlag flag = "-W" `isPrefixOf` flag
+
+isIgnoredCFlag :: String -> Bool
+isIgnoredCFlag flag = flag `elem` ignoredCFlags || isIncludeFlag flag || isWarningFlag flag
+
+isIgnoredCxxFlag :: String -> Bool
+isIgnoredCxxFlag flag = flag `elem` ignoredCxxFlags || isIncludeFlag flag || isWarningFlag flag
+
+main :: IO ()
+main = do
+  let origUserHooks = simpleUserHooks
+
+  defaultMainWithHooks (origUserHooks {
+    hookedPrograms = [ llvmProgram ],
+
+    confHook = \(genericPackageDescription, hookedBuildInfo) confFlags -> do
+      llvmConfig <- getLLVMConfig confFlags
+      llvmCxxFlags <- do
+        rawLlvmCxxFlags <- llvmConfig ["--cxxflags"]
+        return . filter (not . isIgnoredCxxFlag) $ words rawLlvmCxxFlags
+      let stdLib = maybe "stdc++"
+                         (drop (length stdlibPrefix))
+                         (find (isPrefixOf stdlibPrefix) llvmCxxFlags)
+            where stdlibPrefix = "-stdlib=lib"
+      includeDirs <- liftM lines $ llvmConfig ["--includedir"]
+      libDirs <- liftM lines $ llvmConfig ["--libdir"]
+      [llvmVersion] <- liftM lines $ llvmConfig ["--version"]
+      let getLibs = liftM (map (fromJust . stripPrefix "-l") . words) . llvmConfig
+          flags    = configConfigurationsFlags confFlags
+          linkFlag = "--link-shared"
+      libs       <- getLibs ["--libs", linkFlag]
+      systemLibs <- getLibs ["--system-libs", linkFlag]
+
+      let llvmBuildInfo = mempty {
+            extraLibs = libs ++ stdLib : systemLibs
+            }
+          genericPackageDescription' = genericPackageDescription
+            { condLibrary = do -- maybe monad
+                libraryCondTree <- condLibrary genericPackageDescription
+                return libraryCondTree {
+                  condTreeData = condTreeData libraryCondTree <>
+                                 mempty { libBuildInfo = llvmBuildInfo }
+                  }
+            , condExecutables = do -- list monad
+                (name, exeCondTree) <- condExecutables genericPackageDescription
+                return . (name,) $ exeCondTree {
+                  condTreeData = condTreeData exeCondTree <>
+                                 mempty { Exe.buildInfo = llvmBuildInfo }
+                  }
+            }
+          configFlags' = confFlags {
+            configExtraLibDirs = libDirs ++ configExtraLibDirs confFlags,
+            configExtraIncludeDirs = includeDirs ++ configExtraIncludeDirs confFlags
+           }
+      addLLVMToLdLibraryPath configFlags'
+      confHook simpleUserHooks (genericPackageDescription', hookedBuildInfo) configFlags',
+
+    hookedPreProcessors =
+      let origHookedPreprocessors = hookedPreProcessors origUserHooks
+          newHsc buildInfo localBuildInfo componentLocalBuildInfo =
+              PreProcessor {
+                  platformIndependent = platformIndependent (origHsc buildInfo),
+                  runPreProcessor = \inFiles outFiles verbosity -> do
+                      llvmConfig <- getLLVMConfig (configFlags localBuildInfo)
+                      llvmCFlags <- do
+                          rawLlvmCFlags <- llvmConfig ["--cflags"]
+                          return . filter (not . isIgnoredCFlag) $ words rawLlvmCFlags
+                      let buildInfo' = buildInfo { ccOptions = "-Wno-variadic-macros" : llvmCFlags }
+                      runPreProcessor (origHsc buildInfo') inFiles outFiles verbosity
+              }
+              where origHsc buildInfo' =
+                      fromMaybe
+                        ppHsc2hs
+                        (lookup "hsc" origHookedPreprocessors)
+                        buildInfo'
+                        localBuildInfo
+                        componentLocalBuildInfo
+      in [("hsc", newHsc)] ++ origHookedPreprocessors,
+
+    buildHook = \packageDesc localBuildInfo userHooks buildFlags ->
+      do addLLVMToLdLibraryPath (configFlags localBuildInfo)
+         buildHook origUserHooks packageDesc localBuildInfo userHooks buildFlags,
+
+    testHook = \args packageDesc localBuildInfo userHooks testFlags ->
+      do addLLVMToLdLibraryPath (configFlags localBuildInfo)
+         testHook origUserHooks args packageDesc localBuildInfo userHooks testFlags
+   })

--- a/glean/lang/clang/action.cpp
+++ b/glean/lang/clang/action.cpp
@@ -11,6 +11,8 @@
 #if FACEBOOK
 #include "glean/facebook/lang/clang/logger.h"
 #include "common/fbwhoami/FbWhoAmI.h"
+#else
+#include <folly/ExceptionWrapper.h>
 #endif
 
 namespace facebook {
@@ -48,6 +50,8 @@ ActionLogger::ActionLogger(const std::string& name,
     start = Clock::now();
   }
 }
+
+#define LOG_VIA_LOGGER_ASYNC(l)
 
 ActionLogger::~ActionLogger() {
   if (enabled) {

--- a/glean/lang/clang/action.h
+++ b/glean/lang/clang/action.h
@@ -29,6 +29,29 @@ namespace clangx {
 
 #if FACEBOOK
 using Logger = facebook::logger::GleanClangIndexerLogger;
+#else
+class Logger {
+public:
+  Logger() { }
+  Logger& setTask(const std::string& task) { return (*this); }
+  Logger& setRequest(const std::string& task) { return (*this); }
+  Logger& setRepo(const std::string& repo) { return (*this); }
+  Logger& setRevision(const std::string& repo_hash) { return (*this); }
+  Logger& setProcess(const uint32_t& worker_index) { return (*this); }
+  Logger& setCommand(const std::string& name) { return (*this); }
+  Logger& setOrigin(const std::string& origin) { return (*this); }
+  Logger& setSubdir(const std::string& cwd_subdir) { return (*this); }
+  Logger& setTimeElapsedMS(const long& x) { return (*this); }
+  Logger& setTimeElapsed(const std::string& x) { return (*this); }
+  Logger& setSuccess(bool suc) { return (*this); }
+  Logger& setError(const std::string& what) { return (*this); }
+  Logger& setTarget(const std::string& target) { return (*this); }
+  Logger& setPlatform(const folly::Optional<std::string>& platform) { return (*this); }
+  Logger& setFile(const std::string& file) { return (*this); }
+  Logger& setCompileError(bool err) { return (*this); }
+  Logger& setFactBufferSize(bool sz) { return (*this); }
+  Logger& setFactCacheSize(bool sz) { return (*this); }
+};
 #endif
 
 struct SourceFile {

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -1,0 +1,207 @@
+cabal-version:       3.6
+
+-- Copyright (c) Facebook, Inc. and its affiliates.
+
+name:                glean-clang
+version:             0.1.0.0
+synopsis:            C++ code indexing infrastructure for Glean
+homepage:            https://github.com/facebookincubator/Glean
+bug-reports:         https://github.com/facebookincubator/Glean/issues
+license:             BSD-3-Clause
+license-file:        LICENSE
+author:              Facebook, Inc.
+maintainer:          Glean-team@fb.com
+copyright:           (c) Facebook, All Rights Reserved
+build-type:          Custom
+extra-source-files:  CHANGELOG.md
+
+-- These bits of code live in their own package because we want the custom setup
+-- to detect LLVM/clang, but this is not compatible with glean.cabal's use of
+-- multiple (public) libraries:
+--
+--   Error:
+--       Internal libraries only supported with per-component builds.
+--       Per-component builds were disabled because build-type is Custom
+--       In the inplace package 'glean-0.1.0.0'
+
+
+-- Custom setup used to detect LLVM (and clang) and configure the appropriate
+-- include/library directories, necessary for 'glean-clang-index' C++ program
+-- which uses the clang/llvm libraries.
+custom-setup
+  setup-depends: base
+               , Cabal >= 3.6
+               , containers
+
+flag opt
+     default: False
+
+-- copied from the main cabal file, probably a lot of superfluous deps here
+common deps
+    build-depends:
+        fb-util,
+        thrift-cpp-channel,
+        thrift-lib,
+        HUnit,
+        safe,
+        scientific,
+        text-show,
+        uuid,
+        extra,
+        aeson,
+        data-default,
+        temporary,
+        clock,
+        STMonadTrans,
+        utf8-string,
+        optparse-applicative,
+        ansi-terminal,
+        json,
+        regex-base,
+        regex-pcre,
+        base >=4.11.1 && <4.15,
+        array ^>=0.5.2.0,
+        async ^>=2.2.1,
+        attoparsec ^>=0.13.2.3,
+        unordered-containers ^>=0.2.9.0,
+        containers,
+        contravariant ^>=1.5,
+        text ^>=1.2.3.0,
+        bytestring ^>=0.10.8.2,
+        vector ^>=0.12.0.1,
+        transformers ^>=0.5.5.0,
+        network-uri ^>=2.6.1.0,
+        stm ^>=2.5.0.0,
+        directory ^>=1.3.1.5,
+        filepath ^>=1.4.2,
+        exceptions ^>=0.10.0,
+        mtl ^>=2.2.2,
+        unix ^>=2.7.2.2,
+        process ^>=1.6.3.0,
+        prettyprinter >=1.2.1 && <1.7,
+        time >=1.8.0.2 && <1.12,
+        binary ^>=0.8.5.1,
+        deepseq ^>=1.4.3.0,
+        hashable >=1.2.7.0 && <1.4,
+        tar ^>=0.5.1.0,
+        ghc-prim >=0.5.2.0 && <0.7,
+        parsec ^>=3.1.13.0,
+        haxl >= 2.1.2.0 && < 2.4,
+        hinotify ^>= 0.4.1
+
+common exe
+  ghc-options: -threaded
+
+common fb-haskell
+    default-language: Haskell2010
+    default-extensions:
+        BangPatterns
+        BinaryLiterals
+        DataKinds
+        DeriveDataTypeable
+        DeriveGeneric
+        EmptyCase
+        ExistentialQuantification
+        FlexibleContexts
+        FlexibleInstances
+        GADTs
+        GeneralizedNewtypeDeriving
+        LambdaCase
+        MultiParamTypeClasses
+        MultiWayIf
+        NoMonomorphismRestriction
+        OverloadedStrings
+        PatternSynonyms
+        RankNTypes
+        RecordWildCards
+        ScopedTypeVariables
+        StandaloneDeriving
+        TupleSections
+        TypeFamilies
+        TypeSynonymInstances
+        NondecreasingIndentation
+  if flag(opt)
+     ghc-options: -O2
+
+common fb-cpp
+  cxx-options: -DOSS=1 -std=c++17
+  if arch(x86_64)
+      cxx-options: -DGLEAN_X86_64 -march=haswell
+  if flag(opt)
+     cxx-options: -O3
+
+library
+    import: fb-haskell, fb-cpp, deps, exe
+    exposed-modules:
+        Derive
+        Derive.Common
+        Derive.CxxDeclarationSources
+        Derive.CxxDeclarationTargets
+        Derive.CxxSame
+        Derive.CxxTargetUses
+        Derive.Env
+        Derive.Generic
+        Derive.Lib
+        Derive.Types
+    build-depends:
+        ghc-compact,
+        glean:client-hs,
+        glean:client-hs-local,
+        glean:core,
+        glean:db,
+        glean:lib,
+        glean:schema,
+        glean:util,
+        vector-algorithms
+
+-- TODO: the relative paths below are annoying, but the files in
+--       question are not part of any glean sub-library.
+executable glean-clang-index
+    import: fb-cpp
+    ghc-options: -no-hs-main
+    include-dirs: ../../../
+    main-is: index.cpp
+    cxx-sources:
+        action.cpp,
+        ast.cpp,
+        db.cpp,
+        path.cpp,
+        preprocessor.cpp,
+        ../../cpp/sender.cpp,
+        ../../cpp/glean.cpp,
+        ../../interprocess/cpp/worklist.cpp,
+        ../../interprocess/cpp/counters.cpp
+    build-depends:
+        glean:rts,
+        glean:config,
+        glean:if-glean-cpp,
+        glean:if-internal-cpp
+    extra-libraries: clangFrontend,
+                     clangSerialization,
+                     clangDriver,
+                     clangParse,
+                     clangSema,
+                     clangAnalysis,
+                     clangAST,
+                     clangASTMatchers,
+                     clangEdit,
+                     clangFrontendTool,
+                     clangIndex,
+                     clangToolingCore,
+                     clangTooling,
+                     clangFormat,
+                     clangLex,
+                     clangBasic,
+                     LLVM,
+                     folly,
+                     glog,
+                     pthread,
+                     fmt,
+                     gflags,
+                     boost_filesystem,
+                     atomic
+    cxx-options: -fexceptions -DOSS=1 -std=c++17
+    if arch(x86_64)
+      cxx-options: -DGLEAN_X86_64 -march=haswell
+    if flag(opt)
+      cxx-options: -O3

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -131,7 +131,7 @@ common fb-cpp
      cxx-options: -O3
 
 library
-    import: fb-haskell, fb-cpp, deps, exe
+    import: fb-haskell, fb-cpp, deps
     exposed-modules:
         Derive
         Derive.Common


### PR DESCRIPTION
This is part of #95, this first patch lets us build the indexer (and the companion Haskell library), stubbing out the logger that I will quite likely need to actually implement (in addition to enabling logging in the "dumping to file" scenario, as opposed to the "talking to service" one) to figure out why the indexer doesn't seem to be producing any code fact on a trivial one-file CMake C++ project.

Quite happy to have ended up with something so small after all the adventures this took us through.