### PR TITLE
Add --use-system-libs flag, to optionally avoid building rocksdb

### DIFF
--- a/.github/workflows/ci-clang-rocksdb.yml
+++ b/.github/workflows/ci-clang-rocksdb.yml
@@ -1,0 +1,45 @@
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+name: CI-Clang
+on: [push, pull_request]
+
+jobs:
+  ci-clang:
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [8.10.7]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/donsbot/hsthrift/ci-base:clang11rocksdb
+      options: --cpus 2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install libxxhash wget unzip
+        run: apt-get install -y libxxhash-dev wget unzip
+      - name: Install GHC ${{ matrix.ghc }}
+        run: ghcup install ghc ${{ matrix.ghc }} --set
+      - name: Install cabal-install
+        run: ghcup install cabal -u https://downloads.haskell.org/cabal/cabal-install-3.6.2.0/cabal-install-3.6.2.0-x86_64-linux-deb10.tar.xz 3.6.2.0 --set
+      - name: Add GHC and cabal to PATH
+        run: echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
+      - name: Install indexers (flow)
+        run: |
+          export FLOW=0.173.0
+          wget "https://github.com/facebook/flow/releases/download/v${FLOW}/flow-linux64-v${FLOW}.zip"
+          unzip "flow-linux64-v${FLOW}.zip"
+          mkdir -p "$HOME"/.hsthrift/bin && mv flow/flow "$HOME"/.hsthrift/bin
+      - name: Fetch hsthrift and build folly, fizz, wangle, fbthrift
+        run: ./install_deps.sh --use-system-libs
+      - name: Nuke build artifacts
+        run: rm -rf /tmp/fbcode_builder_getdeps-Z__wZGleanZGleanZhsthriftZbuildZfbcode_builder-root/
+      - name: Add thrift compiler to path
+        run: echo "$HOME/.hsthrift/bin" >> "$GITHUB_PATH"
+      - name: Populate hackage index
+        run: cabal update
+      - name: Build hsthrift and Glean
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make
+      - name: Build glass
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make glass
+      - name: Run tests
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make test

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -17,14 +17,22 @@ set -e
 
 HSTHRIFT_REPO=https://github.com/facebookincubator/hsthrift.git
 THREADS=4
+EXTRA_DEPS="rocksdb"
 
-case "$1" in
-    --threads) THREADS="$2"; shift; shift;;
-esac
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --threads) THREADS="$2"; shift;;
+        --use-system-libs) EXTRA_DEPS="";;
+        *)
+            echo "syntax: install_deps.sh [--use-system-libs] [--threads N]"
+            exit 1;;
+    esac
+    shift
+done
 
 if test ! -d hsthrift; then
     git clone "${HSTHRIFT_REPO}"
 fi
 
 cd hsthrift
-./new_install_deps.sh rocksdb --threads "${THREADS}"
+./new_install_deps.sh "${EXTRA_DEPS}" --threads "${THREADS}"


### PR DESCRIPTION
Idea is some containers or systems might have rocksdb already (7.0.x).

Test plan: passes, https://github.com/donsbot/Glean/actions/runs/1978473391

Once this lands we can delete ci-clang.yml, and potentially update the say, the  arm ci run to use a prebuilt rocksdb.

(I think its useful to have at least one run continuously integrate against rocksdb 7.0.1 from source, however, to catch new borkages).