### PR TITLE
Start on hack indexer test support

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -1239,9 +1239,11 @@ library regression-test-lib
     hs-source-dirs:
         glean/test/regression
         glean/lang/flow
+        glean/lang/hack
     exposed-modules:
         Glean.Regression.Config
         Glean.Regression.Driver.Args.Flow
+        Glean.Regression.Driver.Args.Hack
         Glean.Regression.Driver.External
         Glean.Regression.Indexer
         Glean.Regression.Indexer.External
@@ -1637,6 +1639,15 @@ test-suite glean-snapshot-flow
     main-is: Glean/Regression/Flow/Main.hs
     ghc-options: -main-is Glean.Regression.Flow.Main
     build-depends: glean:regression-test-lib
+
+test-suite glean-snapshot-hack
+    import: fb-haskell, deps
+    hs-source-dirs: glean/lang/codemarkup/tests/hack
+    type: exitcode-stdio-1.0
+    main-is: Glean/Regression/Hack/Main.hs
+    ghc-options: -main-is Glean.Regression.Hack.Main
+    build-depends: glean:regression-test-lib
+    buildable: False
 
 ------------------------------------------------------------------------
 -- glass regression tests

--- a/glean/lang/codemarkup/tests/hack/Glean/Regression/Hack/Main.hs
+++ b/glean/lang/codemarkup/tests/hack/Glean/Regression/Hack/Main.hs
@@ -1,0 +1,19 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Glean.Regression.Hack.Main ( main ) where
+
+import System.Environment ( withArgs )
+
+import qualified Glean.Regression.Driver.External as Driver ( main )
+import qualified Glean.Regression.Driver.Args.Hack as Hack
+
+main :: IO ()
+main = withArgs (Hack.args path) Driver.main
+  where
+      path = "glean/lang/codemarkup/tests/hack/cases"

--- a/glean/lang/codemarkup/tests/hack/cases/xrefs/RefClass.php
+++ b/glean/lang/codemarkup/tests/hack/cases/xrefs/RefClass.php
@@ -26,7 +26,7 @@ class RefClass implements SourceInterface {
     $source = new SourceClass();
     $result1 = corge() + SourceClass::BAZ + $source->daz + $this::JAZZ + WALDO;
     $result2 = $this->quux($result1) + Position::Right + $this::foo();
-    $result3 = $this->raz + $this->bazza() + SourceClass::superAdd(1, $param);
+    $result3 = $this->raz + $this->bazza() + $source->superAdd(1, $param);
     return ($result1 + $result2 + $result3 + Position::Center) * corge();
   }
 }

--- a/glean/lang/codemarkup/tests/hack/cases/xrefs/SuperClass.php
+++ b/glean/lang/codemarkup/tests/hack/cases/xrefs/SuperClass.php
@@ -11,7 +11,7 @@ class SuperClass {
 
   const int BAZ = 999;
 
-  public function superAdd(int $i, int $i): int {
-    return $i + $i + 55;
+  public function superAdd(int $i, int $j): int {
+    return $i + $j + 55;
   }
 }

--- a/glean/lang/hack/Glean/Regression/Driver/Args/Hack.hs
+++ b/glean/lang/hack/Glean/Regression/Driver/Args/Hack.hs
@@ -1,0 +1,34 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Glean.Regression.Driver.Args.Hack ( args ) where
+
+import Data.List ( intercalate )
+
+-- | How to run the hack (hhvm) external indexer from regression tests
+args :: FilePath -> [String]
+args path =
+    ["--binary", "hh_server"
+    ,"--json"
+    ,"--args"
+    ,"${TEST_ROOT} --write-symbol-info ${JSON_BATCH_DIR}"
+    ,"--root", path
+    ,"--derive", derives
+    ]
+  where
+    derives = intercalate ","
+      [ "hack.DeclarationSource"
+      , "hack.NameLowerCase"
+      , "hack.AttributeToDefinition"
+      , "hack.AttributeHasParameter"
+      , "hack.NamespaceMember"
+      , "hack.ContainerParent"
+      , "hack.ContainerChild"
+      , "hack.MethodOverridden"
+      , "hack.TargetUses"
+      ]


### PR DESCRIPTION
Set up the external driver with the right flags.
Put things in the right place.

Will set to buildable: True once the ci ymls are updated.

Note: the regression tests have PHP which doesn't pass hh_server , at least in the open source world. (using latest march 2 build from https://hhvm.com/blog/2022/03/02/hhvm-4.151.html , fix those hhstrict errors to let indexer succeed). Pls advise if flags are needed.