### PR TITLE
Drop any trailing separator when indexing

### DIFF
--- a/glean/shell/Glean/Shell/Index.hs
+++ b/glean/shell/Glean/Shell/Index.hs
@@ -53,7 +53,7 @@ indexCmd str
       withSystemTempDirectory' "glean-shell" $ \tmp -> do
         liftIO $ runIndexer lang dir tmp
         files <- liftIO $ listDirectory tmp
-        let name = Text.pack (takeBaseName dir)
+        let name = Text.pack (takeBaseName (dropTrailingPathSeparator dir))
         hash <- pickHash name
         let repo = Glean.Repo name hash
         load repo (map (tmp </>) files)


### PR DESCRIPTION
This ensures we always get a valid basename when using :index on the cli

> :index hack /a/b/c/

will be the same as

> :index hack /a/b/c

Both will generate "c/0" as the repo name.

Previously, if the index dir path ended in / , we would generate "/0" as the basename, an absolute
path, and attempt to write to the filesystem root dir, ignoring any
--db-root relative path.