### PR TITLE
Fix :index hack cmd to use full set of necessary hhvm flags

### DIFF
--- a/glean/shell/Glean/Shell/Index.hs
+++ b/glean/shell/Glean/Shell/Index.hs
@@ -39,8 +39,19 @@ runIndexer :: Language -> String -> String -> IO ()
 runIndexer lang dir outputDir = case lang of
   Flow -> callProcess "flow"
     [ "glean", dir , "--output-dir", outputDir , "--write-root", "." ]
-  Hack -> callProcess "hh_server"
-    [ dir , "--write-symbol-info", outputDir ]
+  Hack -> callProcess "hh_server" $
+    [ dir , "--write-symbol-info", outputDir ] <> hackConfig
+  where
+    hackConfig = concatMap (\flag -> ["--config", flag])
+        [ "symbol_write_include_hhi=false"
+        , "symbolindex_search_provider=NoIndex"
+        , "use_mini_state=true"
+        , "lazy_decl=true"
+        , "lazy_parse=true"
+        , "lazy_init2=true"
+        , "enable_enum_classes=true"
+        , "enable_enum_supertyping=true"
+        ]
 
 indexCmd :: String -> Eval ()
 indexCmd str


### PR DESCRIPTION
We need quite a few little config flags to make the hh_server indexer happy.
These should be shared with regression tests.

Test plan:
```
> :index hack
/home/dons/Glean/glean/lang/codemarkup/tests/hack/cases/xrefs
[2022-03-16 00:44:02.474] Server version is not set
[2022-03-16 00:44:02.474] Loading config exception: (Sys_error
"/etc/hh.conf: No such file or directory")
[2022-03-16 00:44:02.474] Could not load config at /etc/hh.conf
Config overrides:
enable_enum_classes = true
enable_enum_supertyping = true
lazy_decl = true
lazy_init2 = true
lazy_parse = true
symbol_write_include_hhi = false
symbolindex_search_provider = NoIndex
use_mini_state = true

...
[2022-03-16 00:44:03.262] Naming write_symbol_info.naming: 0.035868
[2022-03-16 00:44:03.264] Indexing: 6 files
[2022-03-16 00:44:03.265] Writing JSON to:
/tmp/glean-shell-fd4930b0267286f9
[2022-03-16 00:44:03.283] [worker-1] Wrote 7.61133K of JSON facts on 3
files
[2022-03-16 00:44:03.288] [worker-2] Wrote 14.7793K of JSON facts on 3
files
...
xrefs> :stat
 Total: 188 facts (7.67 kB)
```