### PR TITLE
Enable Hack/HHVM indexer tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/facebookincubator/hsthrift/ci-base:ghcup
-      options: --cpus 2
+      options: --cpus 2 --security-opt=seccomp=unconfined
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install ninja
-        run: apt install ninja-build
-      - name: Install libxxhash wget unzip
-        run: apt-get install -y libxxhash-dev wget unzip
+      - name: Install additional tools
+        run: apt-get install -y ninja-build libxxhash-dev wget unzip
       - name: Remove libfmt
         run: apt-get remove -y libfmt-dev
       - name: Install GHC ${{ matrix.ghc }}
@@ -27,12 +25,20 @@ jobs:
         run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-x86_64-linux.tar.xz 3.6.0.0 --set
       - name: Add GHC and cabal to PATH
         run: echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
-      - name: Install indexers (flow)
+      - name: Install indexer (flow)
         run: |
-          export FLOW=0.172.0
+          export FLOW=0.173.0
           wget "https://github.com/facebook/flow/releases/download/v${FLOW}/flow-linux64-v${FLOW}.zip"
           unzip "flow-linux64-v${FLOW}.zip"
           mkdir -p "$HOME"/.hsthrift/bin && mv flow/flow "$HOME"/.hsthrift/bin
+      - name: Install indexer (hack)
+        run: |
+          apt-get update
+          apt-get install -y software-properties-common apt-transport-https
+          apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
+          add-apt-repository https://dl.hhvm.com/ubuntu
+          apt-get update
+          apt-get install -y hhvm-nightly
       - name: Fetch hsthrift and build folly, fizz, wangle, fbthrift, rocksdb
         run: ./install_deps.sh
       - name: Nuke build artifacts

--- a/glean.cabal
+++ b/glean.cabal
@@ -1707,12 +1707,16 @@ test-suite glass-regression-flow
 test-suite glass-regression-hack
     import: glass-regression-deps, fb-haskell, deps
     type: exitcode-stdio-1.0
-    main-is: Glean/Glass/Regression/Hack.hs
-    ghc-options: -main-is Glean.Glass.Regression.Hack
+    main-is: Glean/Glass/Regression/Hack/Main.hs
+    ghc-options: -main-is Glean.Glass.Regression.Hack.Main
+    other-modules: Glean.Glass.Regression.Hack
     build-depends:
         glean:client-hs,
         glean:util,
-    buildable: False
+    if arch(x86_64) -- hhvm is x86 only currently
+        buildable: True
+    else
+        buildable: False
 
 test-suite glass-regression-python
     import: glass-regression-deps, fb-haskell, deps

--- a/glean.cabal
+++ b/glean.cabal
@@ -1239,9 +1239,11 @@ library regression-test-lib
     hs-source-dirs:
         glean/test/regression
         glean/lang/flow
+        glean/lang/hack
     exposed-modules:
         Glean.Regression.Config
         Glean.Regression.Driver.Args.Flow
+        Glean.Regression.Driver.Args.Hack
         Glean.Regression.Driver.External
         Glean.Regression.Indexer
         Glean.Regression.Indexer.External
@@ -1637,6 +1639,19 @@ test-suite glean-snapshot-flow
     main-is: Glean/Regression/Flow/Main.hs
     ghc-options: -main-is Glean.Regression.Flow.Main
     build-depends: glean:regression-test-lib
+
+test-suite glean-snapshot-hack
+    import: fb-haskell, deps
+    hs-source-dirs: glean/lang/codemarkup/tests/hack
+    type: exitcode-stdio-1.0
+    main-is: Glean/Regression/Hack/Main.hs
+    ghc-options: -main-is Glean.Regression.Hack.Main
+    build-depends: glean:regression-test-lib
+    -- no regular hhvm builds for arm64
+    if arch(x86_64)
+        buildable: True
+    else
+        buildable: False
 
 ------------------------------------------------------------------------
 -- glass regression tests

--- a/glean/glass/test/regression/Glean/Glass/Regression/Hack.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/Hack.hs
@@ -13,8 +13,8 @@ import Data.Text (Text)
 import Test.HUnit
 
 import Glean
-import Glean.Regression.Test
 import Glean.Util.Some
+import Glean.Regression.Test
 
 import Glean.Glass.Types
 import Glean.Glass.Regression.Tests

--- a/glean/glass/test/regression/Glean/Glass/Regression/Hack/Main.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/Hack/Main.hs
@@ -1,0 +1,18 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Glean.Glass.Regression.Hack.Main ( main ) where
+
+import System.Environment
+import Glean.Regression.Driver.Args.Hack as Hack
+import qualified Glean.Glass.Regression.Hack as Glass
+
+main :: IO ()
+main = withArgs (Hack.args path) Glass.main
+  where
+    path = "glean/lang/codemarkup/tests/hack/cases/xrefs"

--- a/glean/lang/codemarkup/tests/hack/Glean/Regression/Hack/Main.hs
+++ b/glean/lang/codemarkup/tests/hack/Glean/Regression/Hack/Main.hs
@@ -1,0 +1,19 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Glean.Regression.Hack.Main ( main ) where
+
+import System.Environment ( withArgs )
+
+import qualified Glean.Regression.Driver.External as Driver ( main )
+import qualified Glean.Regression.Driver.Args.Hack as Hack
+
+main :: IO ()
+main = withArgs (Hack.args path) Driver.main
+  where
+    path = "glean/lang/codemarkup/tests/hack/cases"

--- a/glean/lang/hack/Glean/Regression/Driver/Args/Hack.hs
+++ b/glean/lang/hack/Glean/Regression/Driver/Args/Hack.hs
@@ -1,0 +1,46 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Glean.Regression.Driver.Args.Hack ( args ) where
+
+import Data.List ( intercalate )
+
+-- | How to run the hack (hhvm) external indexer from regression tests
+args :: FilePath -> [String]
+args path =
+    ["--binary", "hh_server"
+    ,"--json"
+    ,"--args"
+    ,"${TEST_ROOT} --write-symbol-info ${JSON_BATCH_DIR} " <> hhvmConfig
+    ,"--root", path
+    ,"--derive", derives
+    ]
+  where
+    derives = intercalate ","
+      [ "hack.NameLowerCase"
+      , "hack.AttributeToDefinition"
+      , "hack.AttributeHasParameter"
+      , "hack.NamespaceMember"
+      , "hack.ContainerParent"
+      , "hack.ContainerChild"
+      , "hack.MethodOverridden"
+      , "hack.TargetUses"
+      , "hack.DeclarationSource"
+      ]
+
+    -- Required hhvm configuration to match Meta defaults
+    hhvmConfig = unwords . map ("--config " <>) $
+      [ "symbol_write_include_hhi=false"
+      , "symbolindex_search_provider=NoIndex"
+      , "use_mini_state=true"
+      , "lazy_decl=true"
+      , "lazy_parse=true"
+      , "lazy_init2=true"
+      , "enable_enum_classes=true"
+      , "enable_enum_supertyping=true"
+      ]

--- a/glean/website/docs/indexer/hack.md
+++ b/glean/website/docs/indexer/hack.md
@@ -7,19 +7,27 @@ sidebar_label: Hack
 import {OssOnly, FbInternalOnly} from 'internaldocs-fb-helpers';
 import {SrcFile,SrcFileLink} from '@site/utils';
 
-The [Hack](https://hacklang.org/) indexer is built into the [Hack
-typechecker](https://github.com/facebook/hhvm/tree/master/hphp/hack).
+The [Hack](https://hacklang.org/) indexer is built into the [Hack typechecker](https://github.com/facebook/hhvm/tree/master/hphp/hack). Stable and nightly binaries of the Hack indexer [are available](https://docs.hhvm.com/hhvm/installation/linux).
 
 ## Run the indexer
 
 ```
-hh_server DIR --write-symbol-info JSON
+hh_server DIR --write-symbol-info JSON \
+  --config symbol_write_include_hhi=false \
+  --config symbolindex_search_provider=NoIndex \
+  --config use_mini_state=true \
+  --config lazy_decl=true \
+  --config lazy_parse=true \
+  --config lazy_init2=true \
+  --config enable_enum_classes=true \
+  --config enable_enum_supertyping=true
 ```
 
 where
 
 * `DIR` is the root directory containing the `.php` files
 * `JSON` is the directory in which to write the output `.json` files
+* We need several config flags to instantiate hh_server for indexing
 
 The generated files can be ingested into a Glean database using [`glean create`](../cli.md#glean-create).
 


### PR DESCRIPTION
- sets wrapper for flags to hh_server
- updates CI with hh_server nightly (n.b. we might want to use stable once the latest hack schema version is fixed)
- enables the codemarkup snapshot tests for hack.6
- enable glass regression tests
- update readme for hack indexer

hhvm makes a couple of syscalls that are blocked by default on github's docker seccomp policy. We need to allow those. Unblocking all for now (see https://docs.docker.com/engine/security/seccomp/ )

hhvm isn't available in regular binaries for arm64 yet. TBD if we use an open source/built from scratch one.

We need a bunch of config flags to replicate the default Meta environment, or the PHP files don't parse , nor does the indexer run. Those flags are duplicated between :index in the shell, and in the regression tests. We should share them out of glean:lib I think. 

finally, clang-ci isn't expected to run yet, as it doesn't have hhvm installed. Waiting on #107 to land 