### PR TITLE
Add minimal test case for the raiseError/cxx exception catcher

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -1417,6 +1417,18 @@ test-suite angle
         glean:if-glean-hs,
         glean:schema
 
+test-suite cppexception
+    import: test
+    type: exitcode-stdio-1.0
+    main-is: CppCatchTest.hs
+    ghc-options: -main-is CppCatchTest
+    build-depends:
+        glean:stubs,
+        glean:core,
+        glean:db,
+        glean:if-glean-hs,
+        glean:schema
+
 test-suite timeout
     import: test
     type: exitcode-stdio-1.0

--- a/glean/test/tests/CppCatchTest.hs
+++ b/glean/test/tests/CppCatchTest.hs
@@ -1,0 +1,54 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+{-# LANGUAGE TypeApplications #-}
+module CppCatchTest (main) where
+
+import Control.Exception
+import qualified Data.Text as Text
+import Test.HUnit
+
+import TestRunner
+
+import Glean.Backend as Backend
+import Glean.Init
+import Glean.Query.Thrift as Thrift
+import Glean.Query.Thrift.Internal
+import qualified Glean.Schema.Cxx1.Types as Cxx
+import Glean.Typed hiding (end)
+import Glean.Types
+
+import TestData
+import TestDB
+
+catchTest :: Test
+catchTest = dbTestCase $ \env repo -> do
+
+  -- Pick some fact ids of type Cxx.Name
+  names <- runQuery_ env repo $ allFacts @Cxx.Name
+  let factId x = Text.pack (show (fromFid (idOf (getId x))))
+
+  -- Now query for it but assert the wrong type. Show raise
+  r <- try $ runQuery_ env repo $ angle @Cxx.Type $
+      "$cxx1.Type " <> factId (head names)
+  print (r :: Either SomeException [Cxx.Type])
+    -- should be caught and have a nice trace
+
+{-
+Correct trace looks like:
+
+Left fact has the wrong type
+Stack trace:
+  facebook::glean::rts::raiseError(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
+  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > facebook::glean::rts::error<>(folly::Range<char const*>)
+  facebook::glean::rts::Subroutine::execute(unsigned long const*) const
+-}
+
+main :: IO ()
+main = withUnitTest $ testRunner $
+  TestLabel "catch from C++" catchTest


### PR DESCRIPTION
Since this has come up twice now on different, more exotic builds, we
want a standalone test that passes, rather than triaging AngleTest.hs
each time. See #119 and #79 for prior instances. There's something lurking here, but changing up the OS or compiler versions tends to make it go away sadly. 

On mis-compiled stacks, this will segfault or sigabrt. E.g.

```
    fmt=fmt@entry=0x7fd0b9f67298 "%s\n") at ../sysdeps/posix/libc_fatal.c:155
    str=str@entry=0x7fd0b9f69670 "double free or corruption (out)") at malloc.c:5347
    have_lock=<optimized out>) at malloc.c:4314
    at rts/Capability.c:601
```

Or 
```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f7f7c7fc859 in __GI_abort () at abort.c:79
#2  0x00007f7f7c86729e in __libc_message (action=action@entry=do_abort,
    fmt=fmt@entry=0x7f7f7c991298 "%s\n") at ../sysdeps/posix/libc_fatal.c:155
#3  0x00007f7f7c86f32c in malloc_printerr (
    str=str@entry=0x7f7f7c993670 "double free or corruption (out)") at malloc.c:5347
#4  0x00007f7f7c870fd0 in _int_free (av=0x7f7f7c9c6b80 <main_arena>, p=0x7ffe1eca4b70,
    have_lock=<optimized out>) at malloc.c:4314
#5  0x0000000000f7a376 in glean_query_execute_compiled ()
#6  0x00000000021b20b5 in releaseCapability_ (cap=0x3eff9c0, always_wakeup=false)
    at rts/Capability.c:601
#7  0x0000000000e098ea in ?? ()
#8  0x0000000000000000 in ?? ()
(gdb)
```