### PR TITLE
Workaround #119 (clang miscompile on ubuntu 20)

### DIFF
--- a/.github/workflows/ci-clang-rocksdb.yml
+++ b/.github/workflows/ci-clang-rocksdb.yml
@@ -29,14 +29,7 @@ jobs:
           wget "https://github.com/facebook/flow/releases/download/v${FLOW}/flow-linux64-v${FLOW}.zip"
           unzip "flow-linux64-v${FLOW}.zip"
           mkdir -p "$HOME"/.hsthrift/bin && mv flow/flow "$HOME"/.hsthrift/bin
-      - name: Install indexer (hack)
-        run: |
-          apt-get update
-          apt-get install -y software-properties-common apt-transport-https
-          apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
-          add-apt-repository https://dl.hhvm.com/ubuntu
-          apt-get update
-          apt-get install -y hhvm-nightly
+    # no hhvm builds yet for jammy/22:00 so we skip that indexer
       - name: Fetch hsthrift and build folly, fizz, wangle, fbthrift
         run: ./install_deps.sh --use-system-libs
       - name: Nuke build artifacts
@@ -50,4 +43,4 @@ jobs:
       - name: Build glass
         run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make glass
       - name: Run tests
-        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make test
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal test glean:tests -f-hack-tests

--- a/glean.cabal
+++ b/glean.cabal
@@ -63,6 +63,10 @@ flag opt
 flag benchmarks
      default: False
 
+-- run tests that require hhvm, typically Linux/x86_64
+flag hack-tests
+     default: True
+
 common deps
     build-depends:
         fb-util,
@@ -1648,9 +1652,7 @@ test-suite glean-snapshot-hack
     ghc-options: -main-is Glean.Regression.Hack.Main
     build-depends: glean:regression-test-lib
     -- no regular hhvm builds for arm64
-    if arch(x86_64)
-        buildable: True
-    else
+    if !flag(hack-tests)
         buildable: False
 
 ------------------------------------------------------------------------
@@ -1713,9 +1715,7 @@ test-suite glass-regression-hack
     build-depends:
         glean:client-hs,
         glean:util,
-    if arch(x86_64) -- hhvm is x86 only currently
-        buildable: True
-    else
+    if !flag(hack-tests)
         buildable: False
 
 test-suite glass-regression-python


### PR DESCRIPTION
We use ubuntu 22 for the clang container. However, hhvm doesn't have
images for ubuntu 22 yet, so we just won't run the hhvm tests on that
container.

To summarize:
- clang builds miscompile glean:cppexception on ubuntu 20, but passes on ubuntu 22
- hhvm runs on ubuntu 20, but not on 22 yet
Conclusion: retain the fast clang build for useful signal. For hhvm
tests , watch the regular CI until we get hhvm for ubuntu/jammy