### PR TITLE
Fix glean-clang's Setup.hs

### DIFF
--- a/glean/lang/clang/Setup.hs
+++ b/glean/lang/clang/Setup.hs
@@ -8,8 +8,6 @@
 -}
 
 {-# LANGUAGE CPP, FlexibleInstances, TupleSections #-}
-module Setup (main) where
-
 import Control.Exception (SomeException, try)
 import Control.Monad
 import Data.Char


### PR DESCRIPTION
Addresses the issue described by @donsbot in https://github.com/facebookincubator/Glean/issues/95#issuecomment-1072023437

I made sure this works by getting `glean-clang` to build in a fresh, vanilla checkout of the repo, with the tiny teeny change from this PR.