### PR TITLE
Make glean.cabal build cleanly with -Wall

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -44,6 +44,8 @@ common fb-haskell
         TypeFamilies
         TypeSynonymInstances
         NondecreasingIndentation
+
+  ghc-options: -Wall -Wno-orphans -Wno-name-shadowing
   if flag(opt)
      ghc-options: -O2
 

--- a/glean/client/hs/Glean/Util/ShellPrint.hs
+++ b/glean/client/hs/Glean/Util/ShellPrint.hs
@@ -354,7 +354,7 @@ data StatsFormatOpts = StatsFormatOpts
   deriving (Eq)
 
 instance ShellFormat StatsFormatOpts (PredStatsFilter, PredStatsList) where
-    shellFormatText Context{..} opts (filterPred, preds) = vsep $
+    shellFormatText _context opts (filterPred, preds) = vsep $
         [ nest 2 $ vsep
             [ case ref of
                 Left id -> pretty id

--- a/glean/db/Glean/Backend.hs
+++ b/glean/db/Glean/Backend.hs
@@ -384,7 +384,7 @@ runLogQuery
   -> Thrift.UserQuery
   -> GleanServerLogger
   -> IO ()
-runLogQuery cmd env@Database.Env{..} repo Thrift.UserQuery{..} log = do
+runLogQuery cmd env repo Thrift.UserQuery{..} log = do
   runLogRepo cmd env repo $ mconcat
     [ log
     , Logger.setQuery (Text.decodeUtf8 userQuery_query)

--- a/glean/db/Glean/Database/Backup.hs
+++ b/glean/db/Glean/Database/Backup.hs
@@ -128,7 +128,7 @@ getTodo env@Env{..} sinbin = getFinalize <|> getRestore <|> getBackup
         Item{..} : _ -> do
           dsite <- getSite env (repo_name itemRepo)
           case dsite of
-            Just (prefix, Some site, DatabaseBackupPolicy{..}) ->
+            Just (prefix, Some site, _policy) ->
                 return (itemRepo, doBackup env itemRepo prefix site)
             Nothing -> retry
 

--- a/glean/db/Glean/Database/CompletePredicates.hs
+++ b/glean/db/Glean/Database/CompletePredicates.hs
@@ -34,7 +34,7 @@ import Glean.Util.Mutex
 
 -- For internal use: actually perform completion for a DB
 syncCompletePredicates :: Env -> Repo -> IO ()
-syncCompletePredicates env@Env{..} repo =
+syncCompletePredicates env repo =
   withOpenDatabase env repo $ \OpenDB{..} -> do
     own <- Storage.computeOwnership odbHandle
       (schemaInventory odbSchema)

--- a/glean/db/Glean/Database/Janitor.hs
+++ b/glean/db/Glean/Database/Janitor.hs
@@ -65,8 +65,8 @@ runDatabaseJanitor env =
   config@ServerConfig.Config{..} <- Observed.get (envServerConfig env)
 
   let
-    !ServerConfig.DatabaseRetentionPolicy{..} = config_retention
-    !ServerConfig.DatabaseRestorePolicy{..} = config_restore
+    !ServerConfig.DatabaseRetentionPolicy{} = config_retention
+    !ServerConfig.DatabaseRestorePolicy{} = config_restore
     !ServerConfig.DatabaseClosePolicy{..} = config_close
 
   mostRecent <- newestDbs env

--- a/glean/db/Glean/Database/Schema.hs
+++ b/glean/db/Glean/Database/Schema.hs
@@ -346,7 +346,7 @@ mkDbSchema override getPids dbContent source base addition = do
       mkPredicatesByName predicates = HashMap.fromListWith latest
         [ (predicateRef_name ref, deets)
         | ref <- predicates
-        , Just deets@PredicateDetails{..} <- [HashMap.lookup ref byRef] ]
+        , Just deets <- [HashMap.lookup ref byRef] ]
         where
         latest a b
           | predicateRef_version (predicateRef a) >
@@ -356,7 +356,7 @@ mkDbSchema override getPids dbContent source base addition = do
       mkSchemaTypesByName types = HashMap.fromListWith latest
         [ (typeRef_name ref, deets)
         | ref <- types
-        , Just deets@TypeDetails{..} <- [HashMap.lookup ref (tcEnvTypes env)] ]
+        , Just deets@TypeDetails{} <- [HashMap.lookup ref (tcEnvTypes env)] ]
         where
         latest a b
           | typeRef_version (typeRef a) >

--- a/glean/db/Glean/Database/Tailer.hs
+++ b/glean/db/Glean/Database/Tailer.hs
@@ -199,7 +199,7 @@ startTailer env repo task_name settings progress = do
                     HashMap.adjust
                       (\task@Task{..} -> case task_state of
                           TaskState_running (TaskRunning parcels)
-                            | ParcelState_running parcel@ParcelRunning{..}
+                            | ParcelState_running parcel
                                   <- V.head parcels -> task
                                 { task_state = TaskState_running
                                     $ TaskRunning

--- a/glean/db/Glean/Database/Work.hs
+++ b/glean/db/Glean/Database/Work.hs
@@ -507,7 +507,7 @@ workFinished env Thrift.WorkFinished{..} = do
   logInfo $ "workFinished_outcome " ++ show workFinished_outcome
   time <- getCurrentTime
   immediately $ do
-    info@ParcelInfo{..} <- lift $ runningParcelInfo env workFinished_work
+    info <- lift $ runningParcelInfo env workFinished_work
     lift $ deleteHeartbeat (envHeartbeats env) workFinished_work
     case workFinished_outcome of
       Thrift.Outcome_success{} ->

--- a/glean/db/Glean/Database/Work/Controller.hs
+++ b/glean/db/Glean/Database/Work/Controller.hs
@@ -125,7 +125,7 @@ externalBinaryController = Controller
     in forM indices $ \idx -> startParcel idx ctx
   , resumeTask = \ctx parcels -> flip Vector.imapM_ parcels $ \idx parcel ->
     case parcel of
-      ParcelState_running ParcelRunning{..} -> startParcel idx ctx
+      ParcelState_running ParcelRunning{} -> startParcel idx ctx
       x -> return x
   }
   where

--- a/glean/db/Glean/Database/Writes.hs
+++ b/glean/db/Glean/Database/Writes.hs
@@ -255,7 +255,7 @@ reportQueueSizes repo repoQueueCount repoQueueSize totalQueueSize mLatency = do
         elapsedMilliSeconds Avg
 
 enqueueBatch :: Env -> ComputedBatch -> Maybe DefineOwnership -> IO SendResponse
-enqueueBatch env@Env{..} ComputedBatch{..} ownership = do
+enqueueBatch env ComputedBatch{..} ownership = do
   -- NOTE: we use UUIDs here rather than, say, consecutive
   -- numbers because we want to avoid conflicts when the
   -- server restarts/crashes
@@ -278,7 +278,7 @@ enqueueJsonBatch
   -> Repo
   -> Thrift.SendJsonBatch
   -> IO Thrift.SendJsonBatchResponse
-enqueueJsonBatch env@Env{..} repo batch = do
+enqueueJsonBatch env repo batch = do
   handle <- UUID.toText <$> UUID.nextRandom
   let
     jsonFactBatchSize JsonFactBatch{..} =
@@ -305,7 +305,7 @@ enqueueJsonBatchByteString
   -> SendJsonBatchOptions
   -> Bool -- ^ remember?
   -> IO Thrift.SendJsonBatchResponse
-enqueueJsonBatchByteString env@Env{..} repo pred facts opts remember = do
+enqueueJsonBatchByteString env repo pred facts opts remember = do
   handle <- UUID.toText <$> UUID.nextRandom
   let
     size = sum (map ByteString.length facts)

--- a/glean/db/Glean/Query/Derive.hs
+++ b/glean/db/Glean/Query/Derive.hs
@@ -283,7 +283,7 @@ runDerivation
   -> Thrift.DerivePredicateQuery
   -> IO ()
 runDerivation env repo pred Thrift.DerivePredicateQuery{..} = do
-  readDatabase env repo $ \odb@OpenDB{..} lookup ->
+  readDatabase env repo $ \odb lookup ->
     case derivePredicateQuery_parallel of
       Nothing -> deriveQuery odb lookup (query (allFacts pred))
       Just par -> parallelDerivation odb lookup par
@@ -440,7 +440,7 @@ finishDerivation
   -> Repo
   -> PredicateRef
   -> IO Derivation
-finishDerivation env@Env{..} log repo pred = do
+finishDerivation env log repo pred = do
   derivation <- atomically (getDerivation env repo pred)
   finished <- finishedWrites derivation
   when (isNothing (derivationError derivation) && isRight finished)

--- a/glean/db/Glean/Query/Flatten.hs
+++ b/glean/db/Glean/Query/Flatten.hs
@@ -50,7 +50,7 @@ flatten dbSchema _ver deriveStored typechecked = do
         dbSchema
         (qiNumVars typechecked)
         deriveStoredPred
-  (qi, FlattenState{..}) <- flip runStateT state $ do
+  (qi,_) <- flip runStateT state $ do
       query <- evolve (qiQuery typechecked)
       q <- flattenQuery query
         `catchError` \e -> throwError $ e <> " in\n" <>

--- a/glean/db/Glean/Query/Typecheck.hs
+++ b/glean/db/Glean/Query/Typecheck.hs
@@ -89,7 +89,7 @@ typecheckDeriving
   -> SourceDerivingInfo' s
   -> Except Text (DerivingInfo TypecheckedQuery)
 typecheckDeriving tcEnv ver policy PredicateDetails{..} derivingInfo = do
-  (d, TypecheckState{..}) <-
+  (d, _) <-
     let state = initialTypecheckState tcEnv ver policy TcModePredicate
     in
     flip runStateT state $ do

--- a/glean/db/Glean/Query/UserQuery.hs
+++ b/glean/db/Glean/Query/UserQuery.hs
@@ -471,7 +471,7 @@ userQueryImpl
 userQueryImpl
   env
   odb
-  config@ServerConfig.Config{..}
+  config
   lookup
   repo
   Thrift.UserQuery{..}
@@ -647,7 +647,7 @@ userQueryImpl
 userQueryImpl
   env
   odb
-  config@ServerConfig.Config{..}
+  config
   lookup
   repo
   Thrift.UserQuery{..} = do

--- a/glean/github/Facebook/Fb303.hs
+++ b/glean/github/Facebook/Fb303.hs
@@ -59,5 +59,5 @@ fb303BaseHandler Fb303State{..} AliveSince = return $ fromIntegral t
 -- | Handler for all things fb303. All services should send `Fb303State`
 -- commands through this handler
 fb303Handler :: Fb303State -> FacebookServiceCommand a -> IO a
-fb303Handler state@Fb303State{..} (SuperBaseService c) =
+fb303Handler state (SuperBaseService c) =
   fb303BaseHandler state c

--- a/glean/github/Glean/DefaultConfigs.hs
+++ b/glean/github/Glean/DefaultConfigs.hs
@@ -13,7 +13,6 @@ module Glean.DefaultConfigs (
     schemaConfigPath,
   ) where
 
-import Data.Default
 import Data.Text (Text)
 
 import Glean.Util.ThriftSource

--- a/glean/github/Glean/Init.hsc
+++ b/glean/github/Glean/Init.hsc
@@ -20,7 +20,6 @@ import Foreign.C
 import Options.Applicative
 import qualified System.Environment as Sys
 
-import Util.Encoding (setDefaultEncodingToUTF8)
 import Util.OptParse
 import Util.Text (withCStrings)
 import Util.Control.Exception (tryAll)

--- a/glean/github/Glean/Server/Shard.hs
+++ b/glean/github/Glean/Server/Shard.hs
@@ -12,8 +12,6 @@ module Glean.Server.Shard
   , updateShards
   ) where
 
-import Util.EventBase
-
 data ShardKey = ShardKey
 
 getShardKey :: eventBaseDataplane -> port -> IO ShardKey

--- a/glean/github/Logger/GleanDatabaseStats.hs
+++ b/glean/github/Logger/GleanDatabaseStats.hs
@@ -8,8 +8,6 @@
 
 module Logger.GleanDatabaseStats (module Logger.GleanDatabaseStats) where
 
-import Data.Monoid
-import Data.Semigroup
 import Data.Text
 
 import Logger.IO

--- a/glean/github/Logger/GleanGlass.hs
+++ b/glean/github/Logger/GleanGlass.hs
@@ -8,8 +8,6 @@
 
 module Logger.GleanGlass (module Logger.GleanGlass) where
 
-import Data.Monoid
-import Data.Semigroup
 import Data.Text
 
 import Logger.IO

--- a/glean/github/Logger/GleanGlassErrors.hs
+++ b/glean/github/Logger/GleanGlassErrors.hs
@@ -8,8 +8,6 @@
 
 module Logger.GleanGlassErrors (module Logger.GleanGlassErrors) where
 
-import Data.Monoid
-import Data.Semigroup
 import Data.Text
 
 import Logger.IO

--- a/glean/github/Logger/GleanServer.hs
+++ b/glean/github/Logger/GleanServer.hs
@@ -8,8 +8,6 @@
 
 module Logger.GleanServer (module Logger.GleanServer) where
 
-import Data.Monoid
-import Data.Semigroup
 import Data.Text
 
 import Logger.IO

--- a/glean/glass/Glean/Glass/Handler.hs
+++ b/glean/glass/Glean/Glass/Handler.hs
@@ -616,7 +616,7 @@ fetchDocumentSymbolIndex
   -> GleanBackend b
   -> Maybe Language
   -> IO (DocumentSymbolIndex, Maybe ErrorLogger)
-fetchDocumentSymbolIndex latest req opts be@GleanBackend{..} mlang = do
+fetchDocumentSymbolIndex latest req opts be mlang = do
   (DocumentSymbolListXResult refs defs revision, merr1) <-
     fetchSymbolsAndAttributes latest req opts be mlang
 
@@ -807,7 +807,7 @@ withLog
   -> req
   -> (GleanGlassLogger -> IO (res, GleanGlassLogger, Maybe ErrorLogger))
   -> IO res
-withLog cmd env@Glass.Env{..} req action = do
+withLog cmd env req action = do
   fst <$> loggingAction
     (runLog env cmd)
     logResult

--- a/glean/tools/gleancli/GleanCLI/Write.hs
+++ b/glean/tools/gleancli/GleanCLI/Write.hs
@@ -302,7 +302,8 @@ instance Plugin WriteCommand where
               scribeWriteBatches
                 writeFromScribe_category
                 (case writeFromScribe_bucket of
-                  Just (PickScribeBucket_bucket n) -> Just (fromIntegral n)
+                  Just (PickScribeBucket_bucket n) ->
+                      Just (fromIntegral n :: Int)
                   Nothing -> Nothing)
                 batches
                 scribeCompress


### PR DESCRIPTION
This enables -Wall for the open source build. A few little things were creeping in, notably unused modules.

We don't try to clean up:

- orphan instances (lots from gen-schema)
- name shadowing

Fix up a bunch of cases of record wild cards that were unused.