### PR TITLE
Use ghc -j parallelism to speed up the Haskell build phase

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Populate hackage index with new packages
         run: cabal update
       - name: Build hsthrift and Glean
-        run: make
+        run: make EXTRA_GHC_OPTS="-j4 +RTS -A128m -n2m -RTS"
       - name: Build glass
         run: make glass
       # no hhvm/hack indexer, so we run without hack regression tests

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,16 @@
 
 CABAL_BIN=cabal
 PWD := $(shell /bin/pwd)
-CABAL = $(CABAL_BIN) --jobs -vnormal+nowrap --project-file=$(PWD)/cabal.project
+
+# There's a lot of parallelism in the schema-generated code
+# If you have >=16G and >=4 cores, trying passing these:
+#
+# EXTRA_GHC_OPTS = '-j4 +RTS -A128m -n2m -RTS'
+#
+EXTRA_GHC_OPTS ?=
+
+CABAL = $(CABAL_BIN) --jobs --ghc-options='$(EXTRA_GHC_OPTS)' \
+            -vnormal+nowrap --project-file=$(PWD)/cabal.project
 
 THRIFT_COMPILE := $(shell $(CABAL) -v0 list-bin exe:thrift-compiler)
 


### PR DESCRIPTION
There's a lot of module-level parallelism in the schema and types code.
Anything under Glean.Schema.*.Types seems to be a good candidate with
4-5x parallelism.

Cost is a bit/a lot more memory, so have to be cautious on the CI github
containers, which are 8G / 2 core. There's marginal benefit there, as the machines are memory constrained.

HOWEVER ..on the arm64 server, where we have 8 cores and 32G ram, this makes a
massive difference to the 'make' phase. E.g. with -j4:

https://github.com/donsbot/Glean/runs/5707150566?check_suite_focus=true
- before: 2h 58m 29s
- after: 1h 20m 43s
== 55% speedup of the build.

On my devserver, 16G ram, 6 core, we can get the make phase down to <30 mins. 

```
$ time make EXTRA_GHC_OPTS="-j4 +RTS -A128m -n2m -RTS"
real	29m49.909s
user	67m55.190s
sys	2m58.837s
```

So this looks like it would be a good option generally for dedicated build machines.

It might suggest further work in how we generate Glean.Schema.$Lang.Types modules too.