### PR TITLE
Refactor C++ indexer build infra and build it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make
       - name: Build glass
         run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make glass
+      - name: Build glean-clang
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make glean-clang
       - name: Run tests
         run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make test
   # check the vscode extension builds

--- a/glean.cabal
+++ b/glean.cabal
@@ -603,6 +603,24 @@ library client-hs-local
         glean:client-hs,
         glean:db,
 
+-- things needed by glean-clang
+library client-cpp
+    import: fb-cpp, deps
+    visibility: public
+    cxx-sources:
+        glean/cpp/sender.cpp,
+        glean/cpp/glean.cpp,
+        glean/interprocess/cpp/worklist.cpp,
+        glean/interprocess/cpp/counters.cpp
+    cxx-options: -DOSS=1
+    if arch(x86_64)
+      cxx-options: -DGLEAN_X86_64
+    include-dirs: .
+    install-includes:
+        glean/cpp/glean.h
+    build-depends:
+        glean:rts
+
 library schema
     import: fb-haskell, fb-cpp, deps
     visibility: public

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -154,12 +154,9 @@ library
         glean:util,
         vector-algorithms
 
--- TODO: the relative paths below are annoying, but the files in
---       question are not part of any glean sub-library.
 executable glean-clang-index
     import: fb-cpp
     ghc-options: -no-hs-main
-    include-dirs: ../../../
     main-is: index.cpp
     cxx-sources:
         action.cpp,
@@ -167,15 +164,12 @@ executable glean-clang-index
         db.cpp,
         path.cpp,
         preprocessor.cpp,
-        ../../cpp/sender.cpp,
-        ../../cpp/glean.cpp,
-        ../../interprocess/cpp/worklist.cpp,
-        ../../interprocess/cpp/counters.cpp
     build-depends:
         glean:rts,
         glean:config,
         glean:if-glean-cpp,
-        glean:if-internal-cpp
+        glean:if-internal-cpp,
+        glean:client-cpp
     extra-libraries: clangFrontend,
                      clangSerialization,
                      clangDriver,


### PR DESCRIPTION
This takes care of removing relative paths that reach outside glean-clang's directory, as discussed previously, and also adds a step to build `glean-clang` in CI (it doesn't take long so I figured it wouldn't hurt, while making sure it builds fine with different versions of GHC etc).