### PR TITLE
Fix up build: update #include paths for ffi stuff now its in a separate package

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -20,8 +20,10 @@ jobs:
           rm -rf "$HOME"/.ghcup/bin
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install libxxhash wget unzip
-        run: apt-get install -y libxxhash-dev wget unzip
+      - name: Install additional tools
+        run: |
+          apt-get update
+          apt-get install -y libxxhash-dev wget unzip
       - name: Install GHC ${{ matrix.ghc }}
         run: ghcup install ghc ${{ matrix.ghc }} --set --force
       - name: Install cabal-install 3.6

--- a/.github/workflows/ci-clang-rocksdb.yml
+++ b/.github/workflows/ci-clang-rocksdb.yml
@@ -15,7 +15,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install additional tools
-        run: apt-get install -y libxxhash-dev wget unzip
+        run: |
+          apt-get update
+          apt-get install -y libxxhash-dev wget unzip
       - name: Install GHC ${{ matrix.ghc }}
         run: ghcup install ghc ${{ matrix.ghc }} --set
       - name: Install cabal-install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install ninja
-        run: apt install ninja-build
-      - name: Install libxxhash, clang, llvm, wget, unzip
-        run: apt-get update && apt-get install -y libxxhash-dev wget unzip clang-11 libclang-11-dev llvm-11-dev
-      - name: Remove libfmt
-        run: apt-get remove -y libfmt-dev
+      - name: Install additional tools
+        run: |
+          apt-get update
+          apt install -y ninja-build libxxhash-dev wget unzip clang-11 libclang-11-dev llvm-11-dev
+          apt-get remove -y libfmt-dev
       - name: Install GHC ${{ matrix.ghc }}
         run: ghcup install ghc ${{ matrix.ghc }} --set
       - name: Install cabal-install 3.6
@@ -35,7 +34,6 @@ jobs:
           mkdir -p "$HOME"/.hsthrift/bin && mv flow/flow "$HOME"/.hsthrift/bin
       - name: Install indexer (hack)
         run: |
-          apt-get update
           apt-get install -y software-properties-common apt-transport-https
           apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
           add-apt-repository https://dl.hhvm.com/ubuntu

--- a/glean.cabal
+++ b/glean.cabal
@@ -337,6 +337,7 @@ library rocksdb
     -- get linker errors for references to missing typeinfo symbols if
     -- we don't.
     cxx-options: -fno-rtti
+    cxx-options: -DOSS=1
     extra-libraries: rocksdb
     build-depends:
         glean:rocksdb-stats,
@@ -1678,6 +1679,7 @@ test-suite lookup
     main-is: LookupTest.hs
     ghc-options: -main-is LookupTest
     cxx-sources: glean/rts/tests/LookupInvariants.cpp
+    cxx-options: -DOSS=1
     build-depends:
         glean:stubs,
         glean:core,

--- a/glean/interprocess/cpp/counters.cpp
+++ b/glean/interprocess/cpp/counters.cpp
@@ -6,7 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "common/hs/util/cpp/wrap.h"
+#ifdef OSS
+#include <cpp/wrap.h>
+#else
+#include <common/hs/util/cpp/wrap.h>
+#endif
 #include "glean/interprocess/cpp/counters.h"
 #include "glean/interprocess/cpp/counters_ffi.h"
 

--- a/glean/interprocess/cpp/worklist.cpp
+++ b/glean/interprocess/cpp/worklist.cpp
@@ -6,7 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "common/hs/util/cpp/wrap.h"
+#ifdef OSS
+#include <cpp/wrap.h>
+#else
+#include <common/hs/util/cpp/wrap.h>
+#endif
 #include "glean/interprocess/cpp/worklist.h"
 #include "glean/interprocess/cpp/worklist_ffi.h"
 

--- a/glean/rocksdb/ffi.cpp
+++ b/glean/rocksdb/ffi.cpp
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "common/hs/util/cpp/memory.h"
-#include "common/hs/util/cpp/wrap.h"
+#include <cpp/memory.h>
+#include <cpp/wrap.h>
 #include "glean/rocksdb/rocksdb.h"
 #include "glean/rocksdb/ffi.h"
 

--- a/glean/rocksdb/ffi.cpp
+++ b/glean/rocksdb/ffi.cpp
@@ -6,8 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef OSS
 #include <cpp/memory.h>
 #include <cpp/wrap.h>
+#else
+#include <common/hs/util/cpp/memory.h>
+#include <common/hs/util/cpp/wrap.h>
+#endif
 #include "glean/rocksdb/rocksdb.h"
 #include "glean/rocksdb/ffi.h"
 

--- a/glean/rts/binary.h
+++ b/glean/rts/binary.h
@@ -12,7 +12,7 @@
 #include <folly/Range.h>
 #include <folly/Varint.h>
 
-#include "common/hs/util/cpp/memory.h"
+#include <cpp/memory.h>
 #include "glean/rts/id.h"
 #include "glean/rts/error.h"
 #include "glean/rts/nat.h"

--- a/glean/rts/binary.h
+++ b/glean/rts/binary.h
@@ -12,7 +12,11 @@
 #include <folly/Range.h>
 #include <folly/Varint.h>
 
+#ifdef OSS
 #include <cpp/memory.h>
+#else
+#include <common/hs/util/cpp/memory.h>
+#endif
 #include "glean/rts/id.h"
 #include "glean/rts/error.h"
 #include "glean/rts/nat.h"

--- a/glean/rts/ffi.cpp
+++ b/glean/rts/ffi.cpp
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "common/hs/util/cpp/ffi.h"
-#include "common/hs/util/cpp/memory.h"
-#include "common/hs/util/cpp/wrap.h"
+#include <cpp/ffi.h>
+#include <cpp/memory.h>
+#include <cpp/wrap.h>
 #include "glean/if/gen-cpp2/glean_types.h"
 #include "glean/rts/bytecode/subroutine.h"
 #include "glean/rts/cache.h"

--- a/glean/rts/ffi.cpp
+++ b/glean/rts/ffi.cpp
@@ -6,9 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef OSS
 #include <cpp/ffi.h>
 #include <cpp/memory.h>
 #include <cpp/wrap.h>
+#else
+#include <common/hs/util/cpp/ffi.h>
+#include <common/hs/util/cpp/memory.h>
+#include <common/hs/util/cpp/wrap.h>
+#endif
 #include "glean/if/gen-cpp2/glean_types.h"
 #include "glean/rts/bytecode/subroutine.h"
 #include "glean/rts/cache.h"

--- a/glean/rts/json.cpp
+++ b/glean/rts/json.cpp
@@ -6,8 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef OSS
 #include <cpp/memory.h>
 #include <cpp/wrap.h>
+#else
+#include <common/hs/util/cpp/memory.h>
+#include <common/hs/util/cpp/wrap.h>
+#endif
 #include "glean/rts/json.h"
 
 #include <folly/dynamic.h>

--- a/glean/rts/json.cpp
+++ b/glean/rts/json.cpp
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "common/hs/util/cpp/memory.h"
-#include "common/hs/util/cpp/wrap.h"
+#include <cpp/memory.h>
+#include <cpp/wrap.h>
 #include "glean/rts/json.h"
 
 #include <folly/dynamic.h>

--- a/glean/rts/tests/LookupInvariants.cpp
+++ b/glean/rts/tests/LookupInvariants.cpp
@@ -6,7 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "common/hs/util/cpp/wrap.h"
+#ifdef OSS
+#include <cpp/wrap.h>
+#else
+#include <common/hs/util/cpp/wrap.h>
+#endif
 #include "glean/rts/fact.h"
 #include "glean/rts/lookup.h"
 

--- a/glean/test/cpp/compact.cpp
+++ b/glean/test/cpp/compact.cpp
@@ -6,8 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef OSS
 #include <cpp/memory.h>
 #include <cpp/wrap.h>
+#else
+#include <common/hs/util/cpp/memory.h>
+#include <common/hs/util/cpp/wrap.h>
+#endif
 #include "glean/schema/thrift/gen-cpp2/glean_test_types.h"
 
 #include <folly/Range.h>

--- a/glean/test/cpp/compact.cpp
+++ b/glean/test/cpp/compact.cpp
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "common/hs/util/cpp/memory.h"
-#include "common/hs/util/cpp/wrap.h"
+#include <cpp/memory.h>
+#include <cpp/wrap.h>
 #include "glean/schema/thrift/gen-cpp2/glean_test_types.h"
 
 #include <folly/Range.h>

--- a/glean/tools/diff/lib.cpp
+++ b/glean/tools/diff/lib.cpp
@@ -6,7 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "common/hs/util/cpp/wrap.h"
+#ifdef OSS
+#include <cpp/wrap.h>
+#else
+#include <common/hs/util/cpp/wrap.h>
+#endif
 #include "glean/rts/binary.h"
 #include "glean/rts/inventory.h"
 #include "glean/rts/lookup.h"


### PR DESCRIPTION
These are discovered via the package-conf inplace for fb-utils which
adds include-dirs:
    /home/dons/Glean/hsthrift/common/util/.

Fixes build.