### PR TITLE
Retain compatibility with ghc 8.4.x

### DIFF
--- a/glean/db/Glean/Query/BindOrder.hs
+++ b/glean/db/Glean/Query/BindOrder.hs
@@ -6,7 +6,7 @@
   LICENSE file in the root directory of this source tree.
 -}
 
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DerivingStrategies #-}
 module Glean.Query.BindOrder
   ( Fix


### PR DESCRIPTION
Fixes:

```
glean/db/Glean/Query/BindOrder.hs:9:14: error:
    Unsupported extension: GeneralisedNewtypeDeriving
    Perhaps you meant `GeneralizedNewtypeDeriving' or `NoGeneralizedNewtypeDeriving'
```