### PR TITLE
Consistently set locale on all CI containers

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -1,6 +1,9 @@
 name: CI-ARM64
 on: [push]
 
+env:
+  LANG: en_US.UTF-8
+
 jobs:
   ci-arm64:
     strategy:
@@ -20,10 +23,18 @@ jobs:
           rm -rf "$HOME"/.ghcup/bin
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install additional tools
         run: |
           apt-get update
           apt-get install -y libxxhash-dev wget unzip
+
+      - name: Make utf8 default locale
+        run: |
+          apt-get install -y locales
+          locale-gen en_US.UTF-8
+          update-locale LANG=en_US.UTF-8
+
       - name: Install GHC ${{ matrix.ghc }}
         run: ghcup install ghc ${{ matrix.ghc }} --set --force
       - name: Install cabal-install 3.6

--- a/.github/workflows/ci-clang-rocksdb.yml
+++ b/.github/workflows/ci-clang-rocksdb.yml
@@ -1,6 +1,9 @@
 name: CI-Clang
 on: [push, pull_request]
 
+env:
+  LANG: en_US.UTF-8
+
 jobs:
   ci-clang:
     strategy:
@@ -14,10 +17,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install additional tools
         run: |
           apt-get update
           apt-get install -y libxxhash-dev wget unzip
+
+      - name: Make utf8 default locale
+        run: |
+          apt-get install -y locales
+          locale-gen en_US.UTF-8
+          update-locale LANG=en_US.UTF-8
+
       - name: Install GHC ${{ matrix.ghc }}
         run: ghcup install ghc ${{ matrix.ghc }} --set
       - name: Install cabal-install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@
 name: CI
 on: [push, pull_request]
 
+env:
+  LANG: en_US.UTF-8
+
 jobs:
   ci:
     strategy:
@@ -15,11 +18,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install additional tools
         run: |
           apt-get update
           apt install -y ninja-build libxxhash-dev wget unzip clang-11 libclang-11-dev llvm-11-dev
           apt-get remove -y libfmt-dev
+
+      - name: Make utf8 default locale
+        run: |
+          apt-get install -y locales
+          locale-gen en_US.UTF-8
+          update-locale LANG=en_US.UTF-8
+
       - name: Install GHC ${{ matrix.ghc }}
         run: ghcup install ghc ${{ matrix.ghc }} --set
       - name: Install cabal-install 3.6


### PR DESCRIPTION
This starts to matter when Rust and Haskell talk to each other over
files. We haven't been setting locale, so getting a mixture of C/Posix
and UTF-8 from the optimistic Haskell IO libs.

Fix by uniformly setting utf8 locale globally. No more dreaded
 "commitBuffer: invalid argument (invalid character)"

(cherry picked from commit bbd342c50304f0de4a075d536ffd5b10bf685ed8)