### PR TITLE
Optimize LSIF parsing and generation

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -1074,11 +1074,12 @@ library lsif
     hs-source-dirs: glean/lang/lsif
     exposed-modules:
         Data.LSIF.Angle
-        Data.LSIF.Types
+        Data.LSIF.Env
         Data.LSIF.JSON
+        Data.LSIF.Types
         Glean.LSIF.Driver
     build-depends:
-        aeson
+        aeson,
 
 -- | A generic LSIF-based external indexer
 executable glean-lsif

--- a/glean.cabal
+++ b/glean.cabal
@@ -1080,6 +1080,7 @@ library lsif
         Glean.LSIF.Driver
     build-depends:
         aeson,
+        split,
 
 -- | A generic LSIF-based external indexer
 executable glean-lsif

--- a/glean/lang/lsif/Data/LSIF/Angle.hs
+++ b/glean/lang/lsif/Data/LSIF/Angle.hs
@@ -17,222 +17,40 @@ make developer iteration quicker.
 
 {-# LANGUAGE OverloadedStrings #-}
 
-module Data.LSIF.Angle (toAngle) where
+module Data.LSIF.Angle (
+    factToAngle, Predicate, PredicateMap,
+    generateJSON,
+    insertPredicateMap,
+    emitFileFactSets,
+    -- parse state
+    Env(..), emptyEnv
+  ) where
 
 import Control.Monad.Extra ( concatMapM )
 import Control.Monad.State.Strict
-import Data.Aeson ( object, Value(String, Array), KeyValue(..) )
+import Data.Aeson
 import Data.Aeson.Types ( Pair )
-import Data.Function ( on )
-import Data.List ( groupBy, sortOn )
+import Data.List
 import Data.Maybe ( catMaybes, fromMaybe, listToMaybe, mapMaybe )
-import Data.IntMap ( IntMap )
+import Data.HashMap.Strict ( HashMap )
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.IntMap.Strict as IMap
 import Data.Text ( Text )
 import qualified Data.Text as Text
 import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
 
 import Data.LSIF.Types
+import Data.LSIF.Env
 import Data.LSIF.JSON ({- instances -})
 
---
--- LSIF represents xrefs and target uses with cyclical graphs. Groups of related
--- vertices are shared via "result set" nodes, to which they point.
--- definitionResult or other nodes will refer to these result sets.
---
--- To embed into Glean, we process in two steps:
---  - first, find all anchor facts (files, ranges) and capture all edges between
---    files, refs, defs, result sets
---  - then, using that complete graph environment, extract
---    ref -> (file,def) pairs
---    to generate File-keyed definition, hover and xref facts
---
--- We can't rely on ordering between different vertex and edge types
--- in LSIF, only that facts will be defined before they are used.
---
-
--- | Parser env, to track command statements in LSIF that change scope
-data Env =
-  Env {
-    root :: [Text], -- ^ a list of path prefixes to strip from file paths
-
-    -- type environment. We often learn the inferred type of an id in its use
-    typeEnv :: IntMap VertexType,
-
-    -- tracking graph edges we care about
-
-    -- "next" edges associate ranges (defs, decls or xres) with resultsets
-    resultSet :: IntMap (Id_ ResultSetTy),
-
-    -- textDocument/definition, edge from resultset back to ([def range], file)
-    definitionFile :: IntMap FileDefs,
-
-    -- textDocument/hover, edge from resultset to hovertext/lang
-    hoverText :: IntMap (Id_ HoverTextTy),
-
-    -- track file "contains" edge associations from file to any ranges
-    fileContains :: IntMap [V.Vector Id]
-
-  }
-
--- It is useful to record the type of ids along the way
--- We can infer these types from the use of the id, as edges lightly typed
-data VertexType
-  = ResultDefinitionType
-  | ResultDeclarationType
-  | ResultReferenceType
-  | ResultSetType
-  | ProjectType
-  | FileType
-  | DefinitionType
-  | ReferenceType
-  | DeclarationType
-  deriving (Eq, Show)
-
--- Payload for an xref is a file id and the id of the definition range
-data FileDefs
-   = FileDefs
-      {-# UNPACK #-}!(Id_ FileTy)
-      !(V.Vector (Id_ DefinitionTy))
-
--- tag the Id with a type when we put it in the env
-type Id_ a = Id
-
-data DefinitionTy
--- data DeclarationTy
--- data ReferenceTy
-data ResultSetTy
-data FileTy
-data HoverTextTy
-
-tagResultSet :: Id -> Id_ ResultSetTy
-tagResultSet = id
-
-tagFile :: Id -> Id_ FileTy
-tagFile = id
-
-tagDefinitions :: V.Vector Id -> V.Vector (Id_ DefinitionTy)
-tagDefinitions = id
-
--- Build up some lookup tables for the assoc lists between refs/defs/decls/files
--- to aid in generaing flatter angle facts
-empty :: Env
-empty = Env [] IMap.empty IMap.empty IMap.empty IMap.empty IMap.empty
-
--- Drop projectRoot prefix from URI to yield repo-relative paths for Glean
--- Some indexers generate uris outside of the repo. In those cases we
--- just try to remove local environment specific-stuff
-filterRoot :: Text -> State Env Text
-filterRoot path = do
-  prefixes <- root <$> get -- try a few paths
-  let clean = mapMaybe (\p -> Text.stripPrefix (p <> "/") path) prefixes
-  pure (fromMaybe path (listToMaybe clean))
-
-appendRoot :: Text -> State Env ()
-appendRoot path = modify' (\e -> e { root = path : root e })
-
-setRoot :: [Text] -> State Env ()
-setRoot paths = modify' (\e -> e { root = paths })
-
-insertType :: Id -> VertexType -> State Env ()
-insertType (Id n) ty = modify' $ \e -> e { typeEnv =
-    IMap.insert (fromIntegral n) ty (typeEnv e)
-  }
-
--- Add a bunch of types in one go
-insertTypes :: V.Vector Id -> VertexType -> State Env ()
-insertTypes ids ty = modify' $ \e -> e { typeEnv = IMap.union imap (typeEnv e) }
+-- | Given a hashmap keyed by predicate names, emit an array of json pred/facts
+-- with one entry per predicate.
+generateJSON :: HashMap Text [Value] -> [Value]
+generateJSON hm = mapMaybe (\k -> gen k <$> HashMap.lookup k hm) keys
   where
-    imap =
-      IMap.fromAscList .
-      V.toList .
-      V.map (\(Id i) -> (fromIntegral i, ty)) $
-      ids
-
-getTypeOf :: Id -> State Env (Maybe VertexType)
-getTypeOf = lookupIMapEnv typeEnv
-
-addToResultSet :: Id -> Id_ ResultSetTy -> State Env ()
-addToResultSet (Id n) resultSetId  = modify' $ \e ->
-  e { resultSet = IMap.insert (fromIntegral n) resultSetId (resultSet e) }
-
-getResultSetOf :: Id -> State Env (Maybe (Id_ ResultSetTy))
-getResultSetOf = lookupIMapEnv resultSet
-
-addToDefinitionFile
-  :: Id_ ResultSetTy
-  -> Id_ FileTy
-  -> V.Vector (Id_ DefinitionTy)
-  -> State Env ()
-addToDefinitionFile (Id resultSetId) fileId defIds  = modify' $ \e ->
-  e { definitionFile = IMap.insert
-        (fromIntegral resultSetId) (FileDefs fileId defIds) (definitionFile e)
-  }
-
--- like addToDefinition but shares a reference (i.e. another edge) to exixting
--- file defs. We can use this to walk chains of resultsets/definition results
-shareDefinitionFile :: Id_ ResultSetTy -> FileDefs -> State Env ()
-shareDefinitionFile (Id resultSetId) fileDefs  = modify' $ \e ->
-  e { definitionFile = IMap.insert
-        (fromIntegral resultSetId) fileDefs (definitionFile e)
-  }
-
-getDefinitionFile :: Id_ ResultSetTy -> State Env (Maybe FileDefs)
-getDefinitionFile = lookupIMapEnv definitionFile
-
-addHoverToResultSet :: Id_ HoverTextTy -> Id_ ResultSetTy -> State Env ()
-addHoverToResultSet hoverId (Id resultSetId) = modify' $ \e ->
-  e { hoverText = IMap.insert
-        (fromIntegral resultSetId) hoverId (hoverText e)
-  }
-
-getHoverTextId :: Id_ ResultSetTy -> State Env (Maybe (Id_ HoverTextTy))
-getHoverTextId = lookupIMapEnv hoverText
-
-addFileContainsIds :: Id_ FileTy -> V.Vector Id -> State Env ()
-addFileContainsIds (Id fileId) contents = modify' $ \e ->
-  e { fileContains = IMap.insertWith (<>)
-        (fromIntegral fileId) [contents] (fileContains e)
-  }
-
-lookupIMapEnv :: (Env -> IntMap a) -> Id -> State Env (Maybe a)
-lookupIMapEnv f (Id n) = do
-  imap <- f <$> get
-  pure (IMap.lookup (fromIntegral n) imap)
-
--- A predicate "block", containing multiple facts
-data Predicate
-  = Predicate { pName :: !Text, pFacts :: [Value] }
-
--- emit Glean-friendly JSON in "predicate/fact" form
-emitPredicateBlocks :: [Predicate] -> [Value]
-emitPredicateBlocks facts = map emitPredicate sets
-  where
-    -- set of one fact block per predicate
-    sets = map (\ps -> Predicate
-             (pName (head ps))
-             (concatMap pFacts ps)
-           )
-         . groupBy ((==) `on` pName)
-         . sortOn dependencyOrder
-         $ facts
-
--- | Emit predicate batches in topologically sorted order, so that later facts
--- can refer to facts in predicates previously issued.
--- This is a bit janky.
-dependencyOrder :: Predicate -> Text
-dependencyOrder p = case pName p of
-  "lsif.Document.1" -> "0"
-  "lsif.Range.1" -> "1"
-  -- these refer to Range.1
-  "lsif.Definition.1" -> "3"
-  "lsif.Declaration.1" -> "4"
-  -- these refer to Declaration.1, Range.1
-  "lsif.Reference.1" -> "5"
-  "lsif.DefinitionHover.1" -> "6"
-  "lsif.DefinitionUse.1" -> "7"
-  -- everything else
-  p -> "2"  <> p
+    gen k = emitPredicate . Predicate k
+    keys = sortOn dependencyOrder (HashMap.keys hm)
 
 emitPredicate :: Predicate -> Value
 emitPredicate (Predicate name facts) = object
@@ -240,8 +58,36 @@ emitPredicate (Predicate name facts) = object
   , "facts" .= Array (V.fromList facts)
   ]
 
+dependencyOrder :: Text -> Int
+dependencyOrder p = case p of
+  "lsif.Document.1" -> 0
+  "lsif.Project" -> 0
+  "lsif.Range.1" -> 1
+  "lsif.HoverContent" -> 2
+  -- these refer to Range.1
+  "lsif.Definition.1" -> 10
+  "lsif.Declaration.1" -> 11
+  -- these refer to Declaration.1, Range.1
+  "lsif.Reference.1" -> 12
+  "lsif.DefinitionHover.1" ->  13
+  "lsif.DefinitionUse.1" -> 14
+  "lsif.ProjectDocument.1" -> 15
+  -- everything else, in the middle
+  _ -> 5
+
+-- Drop projectRoot prefix from URI to yield repo-relative paths for Glean
+-- Some indexers generate uris outside of the repo. In those cases we
+-- just try to remove local environment specific-stuff
+filterRoot :: Text -> Parse Text
+filterRoot path = do
+  prefixes <- root <$> get -- try a few paths
+  let clean = mapMaybe (\p -> Text.stripPrefix (p <> "/") path) prefixes
+  pure (fromMaybe path (listToMaybe clean))
+
 --
 -- | Convert LSIF json to Glean json
+--
+-- Process each key/fact pair
 --
 -- We map over the statements, in order, generating 0 or more facts for Glean
 -- LSIF guarantees things are defined before references to them are used, and
@@ -250,22 +96,7 @@ emitPredicate (Predicate name facts) = object
 -- vertexes correspond to facts holding new data
 -- edges relate existnig vertex facts to each other (with new facts)
 --
-toAngle :: [Text] -> LSIF -> Value
-toAngle prefixPaths (LSIF lsif) =
-  -- first pass, get all types and edges, emit range/file facts
- let (facts,env) = runState (do
-          setRoot prefixPaths
-          V.mapM factToAngle lsif
-        ) empty
-  -- second pass, build xrefs and hover maps
-     moreFacts = evalState emitFileFactSets env
-
-  -- group by predicate, flatten and generate all data
- in Array $ V.fromList $ emitPredicateBlocks $
-      concat (V.toList facts) ++ moreFacts
-
--- | Process each key/fact pair
-factToAngle :: KeyFact -> State Env [Predicate]
+factToAngle :: KeyFact -> Parse [Predicate]
 factToAngle (KeyFact _ MetaData{..}) = do
   appendRoot projectRoot
   predicate "lsif.Metadata.1" ([
@@ -383,15 +214,12 @@ factToAngle (KeyFact n (HoverResult contents)) = do
         ]
   return $ concat (V.toList facts)
 
--- These declare some types of output nodes (things pointed to by resultsets)
-factToAngle (KeyFact n DefinitionResult) =
-  [] <$ insertType n ResultDefinitionType
-factToAngle (KeyFact n DeclarationResult) =
-  [] <$ insertType n ResultDeclarationType
-factToAngle (KeyFact n ReferenceResult) =
-  [] <$ insertType n ResultReferenceType
-factToAngle (KeyFact n ResultSet) =
-  [] <$ insertType n ResultSetType
+-- These are output nodes. We generally don't need their type, as it
+-- can be inferred by context in Item edges
+factToAngle (KeyFact _ DefinitionResult) = pure []
+factToAngle (KeyFact _ DeclarationResult) = pure []
+factToAngle (KeyFact _ ReferenceResult) = pure []
+factToAngle (KeyFact _ ResultSet) = pure []
 
 -- record the range ids that are contained in a file id
 -- or from file id to project id.
@@ -404,7 +232,7 @@ factToAngle _ = pure []
 -- After consuming the LSIF graph, we should have the full set of
 -- {def,decl,ref} -> resutlset -> definitionResult data
 --
-emitFileFactSets :: State Env [Predicate]
+emitFileFactSets :: Parse [Predicate]
 emitFileFactSets = do
   fileSet <- IMap.toList . fileContains <$> get
   ps <- mapM (\(k,v) ->
@@ -414,40 +242,37 @@ emitFileFactSets = do
 
 data IdSet =
     IdSet {
-      defIds :: V.Vector Id,
-      declIds :: V.Vector Id,
-      refIds :: V.Vector Id,
-      fileIds :: V.Vector Id
+      defIds :: !IdVector,
+      declIds :: !IdVector,
+      refIds :: !IdVector,
+      fileIds :: !IdVector
     }
 
 -- Lookup the type of each id as we recorded it in the env
-partitionByType :: V.Vector Id -> State Env IdSet
+partitionByType :: IdVector -> Parse IdSet
 partitionByType ids = do
-  -- lookup the types for each range id
-  tys <- V.mapM (\i -> (,i) <$> getTypeOf i) ids
+  -- get types of all identifiers
+  tys <- V.generateM (U.length ids)
+           (\i -> getTypeOf (Id (ids `U.unsafeIndex` i)))
 
   -- partition by type, we don't care about ordering
-  let (defIds, rest1) = V.unstablePartition
-        ((== Just DefinitionType) . fst) tys
-      (declIds, rest2) = V.unstablePartition
-        ((== Just DeclarationType) . fst) rest1
-      (refIds, rest3) = V.unstablePartition
-        ((== Just ReferenceType) . fst) rest2
-      (fileIds, _remains) = V.unstablePartition
-        ((== Just FileType) . fst) rest3
+  let defIds = U.ifilter
+        (\i _ -> tys `V.unsafeIndex` i == Just DefinitionType) ids
+      declIds = U.ifilter
+        (\i _ -> tys `V.unsafeIndex` i == Just DeclarationType) ids
+      refIds = U.ifilter
+        (\i _ -> tys `V.unsafeIndex` i == Just ReferenceType) ids
+      fileIds = U.ifilter
+        (\i _ -> tys `V.unsafeIndex` i == Just FileType) ids
 
-  return $ IdSet
-    (V.map snd defIds)
-    (V.map snd declIds)
-    (V.map snd refIds)
-    (V.map snd fileIds)
+  return $ IdSet defIds declIds refIds fileIds
 
-emitFileFacts :: Id_ FileTy -> [V.Vector Id] -> State Env [Predicate]
+emitFileFacts :: Id_ FileTy -> [IdVector] -> Parse [Predicate]
 emitFileFacts fileId = concatMapM (emitFileFacts_ fileId)
 
 -- We delay this until the post-processing phase to ensure all
 -- - item, textDocument/definition, etc.. nodes are added
-emitFileFacts_ :: Id_ FileTy -> V.Vector Id -> State Env [Predicate]
+emitFileFacts_ :: Id_ FileTy -> IdVector -> Parse [Predicate]
 emitFileFacts_ fileId rawIds = do
   IdSet{..} <- partitionByType rawIds
 
@@ -460,37 +285,39 @@ emitFileFacts_ fileId rawIds = do
   return $ catMaybes
     [defFacts, declFacts, xrefFacts, useFacts, hoverFacts, projectFacts]
 
-emitProjects :: Id -> V.Vector Id -> Maybe Predicate
+emitProjects :: Id -> IdVector -> Maybe Predicate
 emitProjects projId ids
-  | V.null ids = Nothing
+  | U.null ids = Nothing
   | otherwise = Just $
       Predicate "lsif.ProjectDocument.1"
-        (V.toList $ V.map (\rangeId -> (object . pure . key)
+        (map (\rangeId -> (object . pure . key)
           [ "file" .= rangeId
           , "project" .= projId
           ]
-        ) ids)
+        ) (U.toList ids))
 
-emitHovers :: Id -> V.Vector Id -> State Env (Maybe Predicate)
+emitHovers :: Id -> IdVector -> Parse (Maybe Predicate)
 emitHovers fileId ids = do
-  hoverBodies <- V.mapMaybe id <$> V.mapM (generateHoverFacts fileId) ids
-  if V.null hoverBodies
+  hoverBodies <- catMaybes <$>
+    mapM (generateHoverFacts fileId . Id) (U.toList ids)
+  if null hoverBodies
     then pure Nothing
-    else return $ Just $ Predicate "lsif.DefinitionHover.1" $
-      V.toList hoverBodies
+    else return $ Just $ Predicate "lsif.DefinitionHover.1" hoverBodies
 
-emitReferences :: Id -> V.Vector Id -> State Env (Maybe Predicate)
+emitReferences :: Id -> IdVector -> Parse (Maybe Predicate)
 emitReferences fileId ids = do
-  xrefBodies <- concat. V.toList <$> V.mapM (generateFileReferences fileId) ids
+  xrefBodies <- concat <$> mapM
+    (generateFileReferences fileId . Id) (U.toList ids)
   if null xrefBodies
     then pure Nothing
     else return $ Just $
       Predicate "lsif.Reference.1" $
         map (object . pure . key) xrefBodies
 
-emitTargetUses :: Id -> V.Vector Id -> State Env (Maybe Predicate)
+emitTargetUses :: Id -> IdVector -> Parse (Maybe Predicate)
 emitTargetUses fileId ids = do
-  useBodies <- concat. V.toList <$> V.mapM (generateTargetUses fileId) ids
+  useBodies <- concat <$>
+    mapM (generateTargetUses fileId . Id) (U.toList ids)
   if null useBodies
     then pure Nothing
     else return $ Just $
@@ -499,7 +326,7 @@ emitTargetUses fileId ids = do
 
 -- For each refId, look up the result set, find the result sets file and defs
 -- and generate a single flat file -> ref -> targetDef fat
-generateFileReferences :: Id -> Id -> State Env [[Pair]]
+generateFileReferences :: Id -> Id -> Parse [[Pair]]
 generateFileReferences fileId refRangeId =
   withResultSet refRangeId getDefinitionFile $ \case
     FileDefs targetFileId targetRanges -> pure
@@ -510,12 +337,12 @@ generateFileReferences fileId refRangeId =
             , "range" .= targetRange
             ]
         ]
-      | targetRange <- V.toList targetRanges
+      | targetRange <- U.toList targetRanges
       ]
 
 -- inverse of file references, emit them here since they're handy
 -- maybe later we want to use textDocument/reference edges
-generateTargetUses :: Id -> Id -> State Env [[Pair]]
+generateTargetUses :: Id -> Id -> Parse [[Pair]]
 generateTargetUses fileId refRangeId =
   withResultSet refRangeId getDefinitionFile $ \case
     FileDefs targetFileId targetRanges -> pure
@@ -526,28 +353,27 @@ generateTargetUses fileId refRangeId =
         , "file" .= fileId
         , "range" .= refRangeId
         ]
-      | targetRange <- V.toList targetRanges
+      | targetRange <- U.toList targetRanges
       ]
 
-emitDefinitions :: Id_ FileTy -> V.Vector (Id_ DefinitionTy) -> Maybe Predicate
+emitDefinitions :: Id_ FileTy -> IdVector -> Maybe Predicate
 emitDefinitions = emitDeclDefs "lsif.Definition.1"
 
-emitDeclarations :: Id_ FileTy -> V.Vector Id -> Maybe Predicate
+emitDeclarations :: Id_ FileTy -> IdVector -> Maybe Predicate
 emitDeclarations = emitDeclDefs "lsif.Declaration.1"
 
-emitDeclDefs
-  :: Text -> Id_ FileTy -> V.Vector (Id_ DefinitionTy) -> Maybe Predicate
+emitDeclDefs :: Text -> Id_ FileTy -> IdVector -> Maybe Predicate
 emitDeclDefs name fileId ids
-  | V.null ids = Nothing
+  | U.null ids = Nothing
   | otherwise = Just $
       Predicate name
-        (V.toList $ V.map (\rangeId -> (object . pure . key)
+        (map (\rangeId -> (object . pure . key)
           [ "file" .= fileId
           , "range" .= rangeId
           ]
-        ) ids)
+        ) (U.toList ids))
 
-generateHoverFacts :: Id -> Id -> State Env (Maybe Value)
+generateHoverFacts :: Id -> Id -> Parse (Maybe Value)
 generateHoverFacts fileId defRangeId =
   withResultSet defRangeId getHoverTextId $ \hoverFactId ->
     pure $ pure $ object $ pure $ key
@@ -561,10 +387,11 @@ generateHoverFacts fileId defRangeId =
 -- get the result set of an id, use that result set id to look up another
 -- environment, then apply a function to the result.
 -- used to jump from A to B via a [resultset] node
-withResultSet
-  :: MonadPlus m
- => Id -> (Id_ ResultSetTy -> State Env (Maybe t)) -> (t -> State Env (m a))
- -> State Env (m a)
+withResultSet :: (MonadPlus m)
+  => Id
+  -> (Id_ ResultSetTy -> Parse (Maybe t))
+  -> (t -> Parse (m a))
+  -> Parse (m a)
 withResultSet id f g = do
   mResultSet <- getResultSetOf id
   case mResultSet of

--- a/glean/lang/lsif/Data/LSIF/Env.hs
+++ b/glean/lang/lsif/Data/LSIF/Env.hs
@@ -1,0 +1,237 @@
+
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+module Data.LSIF.Env (
+
+    Env(..),
+    FileDefs(..),
+    emptyEnv,
+
+    -- some silly type tags
+    tagFile,
+    tagResultSet,
+    tagDefinitions,
+
+    -- tags as values
+    Id(..),
+    Id_,
+    VertexType(..),
+    ResultSetTy,
+    FileTy,
+    DefinitionTy,
+    IdVector,
+
+    -- modify env
+    appendRoot,
+    insertType,
+    insertTypes,
+    addToResultSet,
+    addToDefinitionFile,
+    addHoverToResultSet,
+    addFileContainsIds,
+    shareDefinitionFile,
+
+    -- lookups in env
+    getTypeOf,
+    getResultSetOf,
+    getDefinitionFile,
+    getHoverTextId,
+
+    -- running a parser and getting results
+    Parse,
+    Predicate(..),
+    PredicateMap,
+    insertPredicateMap
+
+  ) where
+
+import Control.Monad.State.Strict
+import Data.Aeson
+import Data.HashMap.Strict ( HashMap )
+import Data.IntMap ( IntMap )
+import Data.List ( foldl' )
+import Data.Text ( Text )
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.IntMap.Strict as IMap
+import qualified Data.Vector as V
+import Data.Int ( Int64 )
+import qualified Data.Vector.Unboxed as U
+
+import Data.LSIF.Types
+
+-- Environment used to track things when we analyze the LSIF graph.
+-- We can mostly process LSIF linearly, but for xrefs and related predicates
+-- we track a few chains of values.
+--
+-- We also need to track types of identifiers (decls, refs, defns, files,
+-- projects, and synthetic lsif node types, to distinguish things)
+--
+
+--
+-- LSIF represents xrefs and target uses with cyclical graphs. Groups of related
+-- vertices are shared via "result set" nodes, to which they point.
+-- definitionResult or other nodes will refer to these result sets.
+--
+-- To embed into Glean, we process in two steps:
+--  - first, find all anchor facts (files, ranges) and capture all edges between
+--    files, refs, defs, result sets
+--  - then, using that complete graph environment, extract ref -> (file,def) pairs
+--    to generate File-keyed definition, hover and xref facts
+--
+-- We can't rely on ordering between different vertex and edge types in LSIF, only
+-- that facts will be defined before they are used.
+--
+
+-- | Parser env, to track command statements in LSIF that change scope
+data Env =
+  Env {
+    root :: [Text], -- ^ a list of path prefixes to strip from file paths
+
+    -- type environment. We often learn the inferred type of an id in its use
+    typeEnv :: !(IntMap VertexType),
+
+    -- tracking graph edges we care about
+
+    -- "next" edges associate ranges (defs, decls or xres) with resultsets
+    resultSet :: !(IntMap (Id_ ResultSetTy)),
+
+    -- textDocument/definition, edge from resultset back to ([def range], file)
+    definitionFile :: !(IntMap FileDefs),
+
+    -- textDocument/hover, edge from resultset to hovertext/lang
+    hoverText :: !(IntMap (Id_ HoverTextTy)),
+
+    -- track file "contains" edge associations from file to any ranges
+    fileContains :: !(IntMap [IdVector])
+
+  }
+
+
+-- | Tracking output by predicate
+type PredicateMap = HashMap Text [Value]
+
+-- | Run the fact generate with state Env
+type Parse a = forall m . Monad m => StateT Env m a
+
+-- It is useful to record the type of ids along the way
+-- We can infer these types from the use of the id, as edges lightly typed
+data VertexType
+  = ProjectType -- lsif.Project.1
+  | FileType -- src.File / lsif.Document.1
+  | DefinitionType -- Item property:null
+  | ReferenceType -- Item property:references
+  | DeclarationType
+  deriving (Eq, Show)
+
+-- Payload for an xref is a file id and the id of the definition range
+data FileDefs
+   = FileDefs
+      {-# UNPACK #-}!(Id_ FileTy)
+      !IdVector
+
+-- | vectors of ids can be stored a bit more compactly
+type IdVector = U.Vector Int64
+
+fill :: V.Vector Id -> IdVector
+fill v = U.generate (V.length v) (\i -> case v `V.unsafeIndex` i of Id n -> n)
+
+-- tag the Id with a type when we put it in the env
+type Id_ a = Id
+
+data DefinitionTy
+-- data DeclarationTy
+-- data ReferenceTy
+data ResultSetTy
+data FileTy
+data HoverTextTy
+
+tagResultSet :: Id -> Id_ ResultSetTy
+tagResultSet = id
+
+tagFile :: Id -> Id_ FileTy
+tagFile = id
+
+tagDefinitions :: V.Vector Id -> V.Vector (Id_ DefinitionTy)
+tagDefinitions = id
+
+-- Build up some lookup tables for the assoc lists between refs/defs/decls/files
+-- to aid in generaing flatter angle facts
+emptyEnv :: Env
+emptyEnv = Env [] IMap.empty IMap.empty IMap.empty IMap.empty IMap.empty
+
+appendRoot :: Text -> Parse ()
+appendRoot path = modify' (\e -> e { root = path : root e })
+
+insertType :: Id -> VertexType -> Parse ()
+insertType (Id n) ty = modify' $ \e -> e { typeEnv =
+    IMap.insert (fromIntegral n) ty (typeEnv e)
+  }
+
+-- Add a bunch of types in one go
+insertTypes :: V.Vector Id -> VertexType -> Parse ()
+insertTypes ids ty = modify' $ \e -> e { typeEnv = IMap.union imap (typeEnv e) }
+  where
+    imap = IMap.fromAscList . V.toList .
+              V.map (\(Id i) -> (fromIntegral i, ty)) $ ids
+
+getTypeOf :: Id -> Parse (Maybe VertexType)
+getTypeOf = lookupIMapEnv typeEnv
+
+addToResultSet :: Id -> Id_ ResultSetTy -> Parse ()
+addToResultSet (Id n) resultSetId  = modify' $ \e ->
+  e { resultSet = IMap.insert (fromIntegral n) resultSetId (resultSet e) }
+
+getResultSetOf :: Id -> Parse (Maybe (Id_ ResultSetTy))
+getResultSetOf = lookupIMapEnv resultSet
+
+addToDefinitionFile
+   :: Id_ ResultSetTy -> Id_ FileTy -> V.Vector (Id_ DefinitionTy) -> Parse ()
+addToDefinitionFile (Id resultSetId) fileId defIds  = modify' $ \e ->
+  e { definitionFile = IMap.insert
+        (fromIntegral resultSetId)
+          (FileDefs fileId (fill defIds)) (definitionFile e)
+  }
+
+-- like addToDefinition but shares a reference (i.e. another edge) to exixting
+-- file defs. We can use this to walk chains of resultsets/definition results
+shareDefinitionFile :: Id_ ResultSetTy -> FileDefs -> Parse ()
+shareDefinitionFile (Id resultSetId) fileDefs  = modify' $ \e ->
+  e { definitionFile = IMap.insert
+        (fromIntegral resultSetId) fileDefs (definitionFile e)
+  }
+
+getDefinitionFile :: Id_ ResultSetTy -> Parse (Maybe FileDefs)
+getDefinitionFile = lookupIMapEnv definitionFile
+
+addHoverToResultSet :: Id_ HoverTextTy -> Id_ ResultSetTy -> Parse ()
+addHoverToResultSet hoverId (Id resultSetId) = modify' $ \e ->
+  e { hoverText = IMap.insert
+        (fromIntegral resultSetId) hoverId (hoverText e)
+  }
+
+getHoverTextId :: Id_ ResultSetTy -> Parse (Maybe (Id_ HoverTextTy))
+getHoverTextId = lookupIMapEnv hoverText
+
+addFileContainsIds :: Id_ FileTy -> V.Vector Id -> Parse ()
+addFileContainsIds (Id fileId) contents = modify' $ \e ->
+  e { fileContains = IMap.insertWith (<>)
+        (fromIntegral fileId) [fill contents] (fileContains e)
+  }
+
+lookupIMapEnv :: (Env -> IntMap a) -> Id -> Parse (Maybe a)
+lookupIMapEnv f (Id n) = do
+  imap <- f <$> get
+  pure (IMap.lookup (fromIntegral n) imap)
+
+-- A predicate "block", containing multiple facts
+data Predicate = Predicate !Text [Value]
+
+insertPredicateMap :: PredicateMap -> [Predicate] -> PredicateMap
+insertPredicateMap = foldl' ins
+  where
+    ins hm (Predicate name vs) = HashMap.insertWith (++) name vs hm

--- a/glean/lang/lsif/Data/LSIF/Types.hs
+++ b/glean/lang/lsif/Data/LSIF/Types.hs
@@ -24,7 +24,7 @@ import GHC.Generics ( Generic )
 
 -- | LSIF document facts. Fact with id N is at vector index N+1
 newtype LSIF = LSIF (Vector KeyFact)
-  deriving (Generic, Show)
+  deriving (Generic)
 
 -- | A single  "fact" in an LSIF dump, keyed by id
 data KeyFact
@@ -32,11 +32,13 @@ data KeyFact
       id_ :: {-# UNPACK #-}!Id,
       fact :: !Fact
   }
-  deriving Show
 
 -- | An Id to identify a vertex or an edge.
 newtype Id = Id Int64
-  deriving (Generic, Show, Eq)
+  deriving (Generic, Eq)
+
+-- let's put these in unboxed vectors when we find them
+
 
 -- | LSIF records of various sorts. Constructors correspond to labels
 -- We flatten edges and vertices here, as they will all be serialized back to
@@ -92,7 +94,7 @@ data Fact
       diagnostics :: Vector Diagnostic
   }
   | LsifDocumentSymbolResult {
-      documentSymbols :: Vector Id
+      documentSymbols :: !(Vector Id)
   }
   | LsifUnknown
   --
@@ -114,7 +116,7 @@ data Fact
     document :: {-# UNPACK #-}!Id,
     property :: Maybe Property
   }
-  deriving (Generic, Show, Eq)
+  deriving (Generic)
 
 data HoverContents
   = HoverSignature {
@@ -122,7 +124,6 @@ data HoverContents
       value :: !Text
   }
   | HoverText !Text
-  deriving (Eq, Show)
 
 data Diagnostic
   = Diagnostic {
@@ -131,29 +132,25 @@ data Diagnostic
       message :: !Text,
       diagnosticRange :: {-# UNPACK #-}!Range
   }
-  deriving (Eq, Show)
 
 data MonikerKind = Export | Local | Import | Implementation
-  deriving (Show, Eq)
 
 data Marker = Begin | End
-  deriving (Show, Eq)
 
 data Scope = DocumentScope | ProjectScope
-  deriving (Show, Eq)
 
 -- | A 0-indexed line/character-offset point in a document
 data Position = Position {
       line :: {-# UNPACK #-} !Int64,
       character :: {-# UNPACK #-} !Int64
     }
-  deriving (Generic, Eq, Show)
+  deriving (Generic)
 
 data Range = Range {
       start :: {-# UNPACK #-} !Position,
       end :: {-# UNPACK #-} !Position
     }
-  deriving (Generic, Eq, Show)
+  deriving (Generic)
 
 -- | LSIF tags, very close to LSP method call results
 data Tag
@@ -187,7 +184,7 @@ data Tag
   | UnknownSymbol {
       tagText :: !Text
   }
-  deriving (Generic, Eq, Show)
+  deriving (Generic)
 
 -- | Information about the tool that created the dump
 data ToolInfo =
@@ -196,10 +193,9 @@ data ToolInfo =
     toolArgs :: [Text],
     toolVersion :: Maybe Text
   }
-  deriving (Generic, Eq, Ord, Show)
+  deriving (Generic)
 
 data Property = Definitions | References | ReferenceResults
-  deriving (Eq, Show)
 
 data Label
   = EdgeContains
@@ -216,7 +212,6 @@ data Label
   -- added in lsif-go 1.7.x
   | EdgeSourceGraphDocString
   | EdgeSourceGraphDocChildren
-  deriving (Eq, Show)
 
 -- | LSP symbolKind type (c.f. LSP.Types for similar examples)
 -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind
@@ -251,7 +246,7 @@ data SymbolKind
     | SkOperator
     | SkTypeParameter
     | SkUnknown
-    deriving (Generic,Show,Eq,Enum)
+    deriving (Generic,Enum)
 
 -- From https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
 -- Text documents have a language identifier to identify a document on the
@@ -318,4 +313,4 @@ data LanguageId
   | XSL -- "xsl"
   | YAML -- "yaml"
   | UnknownLanguage
-  deriving (Show, Eq, Enum)
+  deriving (Enum)

--- a/glean/lang/lsif/indexer/Main.hs
+++ b/glean/lang/lsif/indexer/Main.hs
@@ -16,16 +16,16 @@ A wrapper over the lsif driver to generate JSON predicates from lsif indexers
 
 module Main ( main ) where
 
+import Data.Char (toLower)
+import Data.List (intercalate)
 import Options.Applicative
-import System.Directory ( getCurrentDirectory, makeAbsolute )
-import System.FilePath
-    ( dropTrailingPathSeparator, (</>), takeBaseName )
+import System.Directory ( makeAbsolute, getCurrentDirectory )
+import System.FilePath ( (</>), takeBaseName, takeDirectory )
+import Data.Maybe ( fromMaybe )
 import qualified Data.Aeson as Aeson
 
 import Glean.Init ( withOptions )
 import qualified Glean.LSIF.Driver as LSIF
-import Data.Char (toLower)
-import Data.List (intercalate)
 
 data Config = Config
   { cfgLanguage :: Maybe (Either String LSIF.Language)
@@ -47,20 +47,21 @@ options = info (parser <**> helper) fullDesc
       cfgUseDumpFile <- optional (strOption $
              long "dump-file"
           <> metavar "PATH"
-          <> (help $ "Use an existing lsif dump file " <>
+          <> help ("Use an existing lsif dump file " <>
                "(instead of running lsif indexer)"))
       cfgOutDir <- optional $ strOption $
              long "output-dir"
           <> short 'o'
           <> metavar "PATH"
-          <> help "Optional path to JSON output directory (default: `pwd`)"
+          <> help ("Optional path to JSON output directory " <>
+                    "(default: a single output file in `pwd`)" )
       cfgLanguage <- fmap parseLang <$> optional (strOption (
              long "language"
           <> metavar "LANGUAGE"
           <> help "Which language to index (typescript, go, ..)"))
       cfgRepoDir <- optional $ strArgument $
              metavar "PATH"
-          <> (help $ "Source repository directory " <>
+          <> help ("Source repository directory " <>
                "(required if not using dump-file)")
       return Config{..}
 
@@ -68,33 +69,29 @@ options = info (parser <**> helper) fullDesc
 main :: IO ()
 main = withOptions options $ \Config{..} -> do
   cwd <- getCurrentDirectory
-  (json,name) <- case cfgUseDumpFile of
+  (json,baseName) <- case cfgUseDumpFile of
     Just lsif -> do
-        let name = takeBaseName lsif
+        let name = takeBaseName (takeDirectory lsif)
         val <- runLsif (Left lsif)
         return (val, name)
-    Nothing ->
-      case (cfgLanguage, cfgRepoDir) of -- must provide language + repo dir
-        (Nothing, _) ->
-          error $ "Missing --language: " <>
-            " should be one of " <> map toLower (intercalate ", " $
-              map show [minBound :: LSIF.Language ..])
-        (Just (Left err), _) ->
-          error $ "Unsupported language: " <> show err <>
-            " should be one of " <> map toLower (intercalate ", " $
-              map show [minBound :: LSIF.Language ..])
-        (Just (Right lang), Nothing) ->
-          error $ "Missing PATH to " <> show lang <> " source repository"
-        (Just (Right lang), Just rawRepoDir) -> do
-          repoDir <- makeAbsolute rawRepoDir
-          let name = takeBaseName (dropTrailingPathSeparator repoDir)
-          val <- runLsif (Right (lang,repoDir))
-          return (val, name)
+    Nothing -> case (cfgLanguage, cfgRepoDir) of -- must provide language + repo dir
+      (Nothing, _) ->
+        error $ "Missing --language: " <>
+          " should be one of " <> map toLower (intercalate ", " $
+            map show [minBound :: LSIF.Language ..])
+      (Just (Left err), _) ->
+        error $ "Unsupported language: " <> show err <>
+          " should be one of " <> map toLower (intercalate ", " $
+            map show [minBound :: LSIF.Language ..])
+      (Just (Right lang), Nothing) ->
+        error $ "Missing PATH to " <> show lang <> " source repository"
+      (Just (Right lang), Just rawRepoDir) -> do
+        repoDir <- makeAbsolute rawRepoDir
+        let name = takeBaseName (takeDirectory repoDir)
+        val <- runLsif (Right (lang,repoDir))
+        return (val, name)
 
-  let outFile = case cfgOutDir of
-        Nothing -> cwd </> name <> ".json"
-        Just f -> f </> name <> ".json"
-  LSIF.writeJSON outFile json
+  LSIF.writeJSON (fromMaybe cwd cfgOutDir </> baseName <> ".json") json
 
 -- | either parse an existing lsif file, or run an indexer and process that
 runLsif :: Either FilePath (LSIF.Language, FilePath) -> IO Aeson.Value

--- a/glean/shell/Glean/Shell/Index.hs
+++ b/glean/shell/Glean/Shell/Index.hs
@@ -87,11 +87,11 @@ indexCmd str = case words str of
   where
     index lang dir =
       withSystemTempDirectory' "glean-shell" $ \tmp -> do
-        fileValues <- liftIO $ runIndexer lang dir tmp
+        fileValue <- liftIO $ runIndexer lang dir tmp
         let name = Text.pack (takeBaseName (dropTrailingPathSeparator dir))
         hash <- pickHash name
         let repo = Glean.Repo name hash
-        case fileValues of
+        case fileValue of
           Left files -> load repo files
           Right val -> loadValue repo val
         setRepo repo
@@ -125,10 +125,10 @@ load repo files = withBackend $ \be ->  liftIO $ do
       Aeson.Success x -> return x
     Glean.sendJsonBatch be repo batches Nothing
 
--- | Load a specific JSON value as a db
+-- | Load a specific set of JSON fact/predicate set as a db
 loadValue :: Glean.Repo -> Value -> Eval ()
 loadValue repo val = withBackend $ \be ->  liftIO $ do
-  let onExisting  = throwIO $ ErrorCall "database already exists"
+  let onExisting = throwIO $ ErrorCall "database already exists"
   void $ fillDatabase be Nothing repo "" onExisting $ do
     batches <- case Aeson.parse parseJsonFactBatches val of
       Error str -> throwIO $ ErrorCall str


### PR DESCRIPTION
After attempting to process some 1G/10M fact LSIF files from vscode/lsif-tsc, this round of diffs optimizes the generation.
The LSIF converter consists of two steps:

step 0. parse file as JSON, convert JSON to LSIF types via fromJSON.
step 1. first, iterate over input rows generating base facts (src.File,
  lsif.Range etc), while tracking edges from refs -> defs
step2.  then, generate xrefs using the state built from the first pass

Finally, we write the result to JSON files.

This patch optimizes step 0 and 1, fusing them with a strict left fold
over the chunks of input, generating base facts and building state in a
runStateT over the lazy bytestring input json file.

We now run in about 2.5-3x the space of the input file, dominated by the size of the Env we need to capture 
for final xref generation.

Future optimisation would be to stream output via encoding (rather than
the JSON value). A latter diff generates chunks at a time which helps.

For now, this is enough to process the vscode/src directory, of about 10M rows/1G of lsif.


Test plan:
- tests pass
- stress test on large lsif files.