### PR TITLE
Move lsif.angle a bit closer to codemarkup.angle

### DIFF
--- a/glean/lang/go/tests/cases/xrefs/filedefinitions.out
+++ b/glean/lang/go/tests/cases/xrefs/filedefinitions.out
@@ -6,41 +6,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 10,
-            "columnBegin": 8,
-            "lineEnd": 10,
-            "columnEnd": 16
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 23,
-            "columnBegin": 5,
-            "lineEnd": 23,
-            "columnEnd": 12
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 23,
-            "columnBegin": 13,
-            "lineEnd": 23,
+            "lineBegin": 11,
+            "columnBegin": 9,
+            "lineEnd": 11,
             "columnEnd": 17
-          }
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -52,25 +23,11 @@
         "key": {
           "range": {
             "lineBegin": 24,
-            "columnBegin": 1,
+            "columnBegin": 6,
             "lineEnd": 24,
-            "columnEnd": 6
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 26,
-            "columnBegin": 5,
-            "lineEnd": 26,
             "columnEnd": 13
-          }
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -81,11 +38,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 27,
-            "columnBegin": 1,
-            "lineEnd": 27,
-            "columnEnd": 13
-          }
+            "lineBegin": 24,
+            "columnBegin": 14,
+            "lineEnd": 24,
+            "columnEnd": 18
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -96,41 +54,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 27,
-            "columnBegin": 22,
-            "lineEnd": 27,
-            "columnEnd": 23
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 34,
-            "columnBegin": 5,
-            "lineEnd": 34,
-            "columnEnd": 6
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 43,
-            "columnBegin": 3,
-            "lineEnd": 43,
+            "lineBegin": 25,
+            "columnBegin": 2,
+            "lineEnd": 25,
             "columnEnd": 7
-          }
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -141,11 +70,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 45,
-            "columnBegin": 3,
-            "lineEnd": 45,
-            "columnEnd": 13
-          }
+            "lineBegin": 27,
+            "columnBegin": 6,
+            "lineEnd": 27,
+            "columnEnd": 14
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -156,11 +86,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 55,
-            "columnBegin": 1,
-            "lineEnd": 55,
-            "columnEnd": 5
-          }
+            "lineBegin": 28,
+            "columnBegin": 2,
+            "lineEnd": 28,
+            "columnEnd": 14
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -171,11 +102,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 57,
-            "columnBegin": 5,
-            "lineEnd": 57,
-            "columnEnd": 16
-          }
+            "lineBegin": 28,
+            "columnBegin": 23,
+            "lineEnd": 28,
+            "columnEnd": 24
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -186,11 +118,92 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 59,
-            "columnBegin": 5,
-            "lineEnd": 59,
+            "lineBegin": 35,
+            "columnBegin": 6,
+            "lineEnd": 35,
+            "columnEnd": 7
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 44,
+            "columnBegin": 4,
+            "lineEnd": 44,
+            "columnEnd": 8
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 46,
+            "columnBegin": 4,
+            "lineEnd": 46,
+            "columnEnd": 14
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 56,
+            "columnBegin": 2,
+            "lineEnd": 56,
             "columnEnd": 6
-          }
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 58,
+            "columnBegin": 6,
+            "lineEnd": 58,
+            "columnEnd": 17
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 60,
+            "columnBegin": 6,
+            "lineEnd": 60,
+            "columnEnd": 7
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }

--- a/glean/lang/go/tests/cases/xrefs/filereferences.out
+++ b/glean/lang/go/tests/cases/xrefs/filereferences.out
@@ -6,161 +6,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 24,
-            "columnBegin": 31,
-            "lineEnd": 24,
-            "columnEnd": 35
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 23,
-                "columnBegin": 13,
-                "lineEnd": 23,
-                "columnEnd": 17
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 28,
-            "columnBegin": 5,
-            "lineEnd": 28,
-            "columnEnd": 6
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 22,
-                "lineEnd": 27,
-                "columnEnd": 23
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 28,
-            "columnBegin": 17,
-            "lineEnd": 28,
-            "columnEnd": 18
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 22,
-                "lineEnd": 27,
-                "columnEnd": 23
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 31,
-            "columnBegin": 9,
-            "lineEnd": 31,
-            "columnEnd": 10
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 22,
-                "lineEnd": 27,
-                "columnEnd": 23
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 34,
-            "columnBegin": 13,
-            "lineEnd": 34,
-            "columnEnd": 14
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 34,
-            "columnBegin": 21,
-            "lineEnd": 34,
-            "columnEnd": 26
-          }
+            "lineBegin": 25,
+            "columnBegin": 32,
+            "lineEnd": 25,
+            "columnEnd": 36
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -170,10 +21,11 @@
             "key": {
               "range": {
                 "lineBegin": 24,
-                "columnBegin": 1,
+                "columnBegin": 14,
                 "lineEnd": 24,
-                "columnEnd": 6
-              }
+                "columnEnd": 18
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -186,11 +38,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 34,
-            "columnBegin": 29,
-            "lineEnd": 34,
-            "columnEnd": 30
-          }
+            "lineBegin": 29,
+            "columnBegin": 6,
+            "lineEnd": 29,
+            "columnEnd": 7
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -199,11 +52,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
+                "lineBegin": 28,
+                "columnBegin": 23,
+                "lineEnd": 28,
+                "columnEnd": 24
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -216,11 +70,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 35,
-            "columnBegin": 23,
-            "lineEnd": 35,
-            "columnEnd": 28
-          }
+            "lineBegin": 29,
+            "columnBegin": 18,
+            "lineEnd": 29,
+            "columnEnd": 19
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -229,11 +84,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
+                "lineBegin": 28,
+                "columnBegin": 23,
+                "lineEnd": 28,
+                "columnEnd": 24
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -246,101 +102,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 35,
-            "columnBegin": 29,
-            "lineEnd": 35,
-            "columnEnd": 30
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 35,
-            "columnBegin": 60,
-            "lineEnd": 35,
-            "columnEnd": 65
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 35,
-            "columnBegin": 66,
-            "lineEnd": 35,
-            "columnEnd": 67
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 3,
-            "lineEnd": 38,
+            "lineBegin": 32,
+            "columnBegin": 10,
+            "lineEnd": 32,
             "columnEnd": 11
-          }
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -349,11 +116,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 26,
-                "columnBegin": 5,
-                "lineEnd": 26,
-                "columnEnd": 13
-              }
+                "lineBegin": 28,
+                "columnBegin": 23,
+                "lineEnd": 28,
+                "columnEnd": 24
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -366,11 +134,236 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 38,
-            "columnBegin": 27,
-            "lineEnd": 38,
-            "columnEnd": 39
+            "lineBegin": 35,
+            "columnBegin": 14,
+            "lineEnd": 35,
+            "columnEnd": 15
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
           }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 22,
+            "lineEnd": 35,
+            "columnEnd": 27
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 30,
+            "lineEnd": 35,
+            "columnEnd": 31
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 24,
+            "lineEnd": 36,
+            "columnEnd": 29
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 30,
+            "lineEnd": 36,
+            "columnEnd": 31
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 61,
+            "lineEnd": 36,
+            "columnEnd": 66
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 67,
+            "lineEnd": 36,
+            "columnEnd": 68
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 4,
+            "lineEnd": 39,
+            "columnEnd": 12
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -380,130 +373,11 @@
             "key": {
               "range": {
                 "lineBegin": 27,
-                "columnBegin": 1,
+                "columnBegin": 6,
                 "lineEnd": 27,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 41,
-            "lineEnd": 38,
-            "columnEnd": 46
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 47,
-            "lineEnd": 38,
-            "columnEnd": 48
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 56,
-            "lineEnd": 38,
-            "columnEnd": 61
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 62,
-            "lineEnd": 38,
-            "columnEnd": 63
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -517,10 +391,11 @@
         "key": {
           "range": {
             "lineBegin": 39,
-            "columnBegin": 30,
+            "columnBegin": 28,
             "lineEnd": 39,
-            "columnEnd": 35
-          }
+            "columnEnd": 40
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -529,11 +404,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
+                "lineBegin": 28,
+                "columnBegin": 2,
+                "lineEnd": 28,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -547,10 +423,11 @@
         "key": {
           "range": {
             "lineBegin": 39,
-            "columnBegin": 36,
+            "columnBegin": 42,
             "lineEnd": 39,
-            "columnEnd": 37
-          }
+            "columnEnd": 47
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -559,101 +436,236 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 43,
-            "columnBegin": 11,
-            "lineEnd": 43,
-            "columnEnd": 16
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 43,
-            "columnBegin": 17,
-            "lineEnd": 43,
-            "columnEnd": 18
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 45,
-            "columnBegin": 31,
-            "lineEnd": 45,
-            "columnEnd": 35
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 43,
-                "columnBegin": 3,
-                "lineEnd": 43,
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
                 "columnEnd": 7
-              }
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 48,
+            "lineEnd": 39,
+            "columnEnd": 49
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 57,
+            "lineEnd": 39,
+            "columnEnd": 62
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 63,
+            "lineEnd": 39,
+            "columnEnd": 64
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 40,
+            "columnBegin": 31,
+            "lineEnd": 40,
+            "columnEnd": 36
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 40,
+            "columnBegin": 37,
+            "lineEnd": 40,
+            "columnEnd": 38
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 44,
+            "columnBegin": 12,
+            "lineEnd": 44,
+            "columnEnd": 17
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 44,
+            "columnBegin": 18,
+            "lineEnd": 44,
+            "columnEnd": 19
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -667,10 +679,107 @@
         "key": {
           "range": {
             "lineBegin": 46,
-            "columnBegin": 6,
+            "columnBegin": 32,
             "lineEnd": 46,
+            "columnEnd": 36
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 8
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 47,
+            "columnBegin": 7,
+            "lineEnd": 47,
+            "columnEnd": 17
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 46,
+                "columnBegin": 4,
+                "lineEnd": 46,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 48,
+            "columnBegin": 5,
+            "lineEnd": 48,
+            "columnEnd": 9
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 8
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 48,
+            "columnBegin": 12,
+            "lineEnd": 48,
             "columnEnd": 16
-          }
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -679,11 +788,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 45,
-                "columnBegin": 3,
-                "lineEnd": 45,
-                "columnEnd": 13
-              }
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 8
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -696,131 +806,44 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 47,
+            "lineBegin": 48,
+            "columnBegin": 21,
+            "lineEnd": 48,
+            "columnEnd": 31
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 46,
+                "columnBegin": 4,
+                "lineEnd": 46,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 51,
             "columnBegin": 4,
-            "lineEnd": 47,
-            "columnEnd": 8
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 43,
-                "columnBegin": 3,
-                "lineEnd": 43,
-                "columnEnd": 7
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 47,
-            "columnBegin": 11,
-            "lineEnd": 47,
-            "columnEnd": 15
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 43,
-                "columnBegin": 3,
-                "lineEnd": 43,
-                "columnEnd": 7
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 47,
-            "columnBegin": 20,
-            "lineEnd": 47,
-            "columnEnd": 30
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 45,
-                "columnBegin": 3,
-                "lineEnd": 45,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 50,
-            "columnBegin": 3,
-            "lineEnd": 50,
-            "columnEnd": 11
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 26,
-                "columnBegin": 5,
-                "lineEnd": 26,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 50,
-            "columnBegin": 27,
-            "lineEnd": 50,
-            "columnEnd": 39
-          }
+            "lineEnd": 51,
+            "columnEnd": 12
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -830,10 +853,11 @@
             "key": {
               "range": {
                 "lineBegin": 27,
-                "columnBegin": 1,
+                "columnBegin": 6,
                 "lineEnd": 27,
-                "columnEnd": 13
-              }
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -846,11 +870,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 50,
-            "columnBegin": 41,
-            "lineEnd": 50,
-            "columnEnd": 45
-          }
+            "lineBegin": 51,
+            "columnBegin": 28,
+            "lineEnd": 51,
+            "columnEnd": 40
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -859,11 +884,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 43,
-                "columnBegin": 3,
-                "lineEnd": 43,
-                "columnEnd": 7
-              }
+                "lineBegin": 28,
+                "columnBegin": 2,
+                "lineEnd": 28,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -876,11 +902,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 55,
-            "columnBegin": 43,
-            "lineEnd": 55,
-            "columnEnd": 51
-          }
+            "lineBegin": 51,
+            "columnBegin": 42,
+            "lineEnd": 51,
+            "columnEnd": 46
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -889,11 +916,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 26,
-                "columnBegin": 5,
-                "lineEnd": 26,
-                "columnEnd": 13
-              }
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 8
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -906,11 +934,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 59,
-            "columnBegin": 13,
-            "lineEnd": 59,
-            "columnEnd": 14
-          }
+            "lineBegin": 56,
+            "columnBegin": 44,
+            "lineEnd": 56,
+            "columnEnd": 52
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -919,41 +948,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 59,
-                "columnBegin": 5,
-                "lineEnd": 59,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 59,
-            "columnBegin": 20,
-            "lineEnd": 59,
-            "columnEnd": 21
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 59,
-                "columnBegin": 5,
-                "lineEnd": 59,
-                "columnEnd": 6
-              }
+                "lineBegin": 27,
+                "columnBegin": 6,
+                "lineEnd": 27,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -967,10 +967,11 @@
         "key": {
           "range": {
             "lineBegin": 60,
-            "columnBegin": 5,
+            "columnBegin": 14,
             "lineEnd": 60,
-            "columnEnd": 16
-          }
+            "columnEnd": 15
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -979,11 +980,44 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 57,
-                "columnBegin": 5,
-                "lineEnd": 57,
-                "columnEnd": 16
-              }
+                "lineBegin": 60,
+                "columnBegin": 6,
+                "lineEnd": 60,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 60,
+            "columnBegin": 21,
+            "lineEnd": 60,
+            "columnEnd": 22
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 60,
+                "columnBegin": 6,
+                "lineEnd": 60,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -997,10 +1031,75 @@
         "key": {
           "range": {
             "lineBegin": 61,
-            "columnBegin": 3,
+            "columnBegin": 6,
             "lineEnd": 61,
+            "columnEnd": 17
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 58,
+                "columnBegin": 6,
+                "lineEnd": 58,
+                "columnEnd": 17
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 62,
+            "columnBegin": 4,
+            "lineEnd": 62,
+            "columnEnd": 15
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 58,
+                "columnBegin": 6,
+                "lineEnd": 58,
+                "columnEnd": 17
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 64,
+            "columnBegin": 3,
+            "lineEnd": 64,
             "columnEnd": 14
-          }
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -1009,11 +1108,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 57,
-                "columnBegin": 5,
-                "lineEnd": 57,
-                "columnEnd": 16
-              }
+                "lineBegin": 58,
+                "columnBegin": 6,
+                "lineEnd": 58,
+                "columnEnd": 17
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -1026,11 +1126,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 63,
-            "columnBegin": 2,
-            "lineEnd": 63,
-            "columnEnd": 13
-          }
+            "lineBegin": 64,
+            "columnBegin": 18,
+            "lineEnd": 64,
+            "columnEnd": 22
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -1039,71 +1140,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 57,
-                "columnBegin": 5,
-                "lineEnd": 57,
-                "columnEnd": 16
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 63,
-            "columnBegin": 17,
-            "lineEnd": 63,
-            "columnEnd": 21
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 55,
-                "columnBegin": 1,
-                "lineEnd": 55,
-                "columnEnd": 5
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 63,
-            "columnBegin": 22,
-            "lineEnd": 63,
-            "columnEnd": 23
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 59,
-                "columnBegin": 5,
-                "lineEnd": 59,
+                "lineBegin": 56,
+                "columnBegin": 2,
+                "lineEnd": 56,
                 "columnEnd": 6
-              }
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -1116,11 +1158,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 63,
-            "columnBegin": 29,
-            "lineEnd": 63,
-            "columnEnd": 30
-          }
+            "lineBegin": 64,
+            "columnBegin": 23,
+            "lineEnd": 64,
+            "columnEnd": 24
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -1129,11 +1172,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 59,
-                "columnBegin": 5,
-                "lineEnd": 59,
-                "columnEnd": 6
-              }
+                "lineBegin": 60,
+                "columnBegin": 6,
+                "lineEnd": 60,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -1146,11 +1190,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 66,
-            "columnBegin": 8,
-            "lineEnd": 66,
-            "columnEnd": 19
-          }
+            "lineBegin": 64,
+            "columnBegin": 30,
+            "lineEnd": 64,
+            "columnEnd": 31
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -1159,11 +1204,44 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 57,
-                "columnBegin": 5,
-                "lineEnd": 57,
-                "columnEnd": 16
-              }
+                "lineBegin": 60,
+                "columnBegin": 6,
+                "lineEnd": 60,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 67,
+            "columnBegin": 9,
+            "lineEnd": 67,
+            "columnEnd": 20
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 58,
+                "columnBegin": 6,
+                "lineEnd": 58,
+                "columnEnd": 17
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }

--- a/glean/lang/go/tests/cases/xrefs/hovercontent.out
+++ b/glean/lang/go/tests/cases/xrefs/hovercontent.out
@@ -8,11 +8,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 10,
-                "columnBegin": 8,
-                "lineEnd": 10,
-                "columnEnd": 16
-              }
+                "lineBegin": 11,
+                "columnBegin": 9,
+                "lineEnd": 11,
+                "columnEnd": 17
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -33,11 +34,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 23,
-                "columnBegin": 5,
-                "lineEnd": 23,
-                "columnEnd": 12
-              }
+                "lineBegin": 24,
+                "columnBegin": 6,
+                "lineEnd": 24,
+                "columnEnd": 13
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -60,11 +62,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 23,
-                "columnBegin": 13,
-                "lineEnd": 23,
-                "columnEnd": 17
-              }
+                "lineBegin": 24,
+                "columnBegin": 14,
+                "lineEnd": 24,
+                "columnEnd": 18
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -85,11 +88,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -110,11 +114,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 26,
-                "columnBegin": 5,
-                "lineEnd": 26,
-                "columnEnd": 13
-              }
+                "lineBegin": 27,
+                "columnBegin": 6,
+                "lineEnd": 27,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -135,11 +140,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 27,
-                "columnBegin": 1,
-                "lineEnd": 27,
-                "columnEnd": 13
-              }
+                "lineBegin": 28,
+                "columnBegin": 2,
+                "lineEnd": 28,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -162,11 +168,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 27,
-                "columnBegin": 22,
-                "lineEnd": 27,
-                "columnEnd": 23
-              }
+                "lineBegin": 28,
+                "columnBegin": 23,
+                "lineEnd": 28,
+                "columnEnd": 24
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -187,11 +194,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -212,11 +220,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 43,
-                "columnBegin": 3,
-                "lineEnd": 43,
-                "columnEnd": 7
-              }
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 8
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -237,11 +246,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 45,
-                "columnBegin": 3,
-                "lineEnd": 45,
-                "columnEnd": 13
-              }
+                "lineBegin": 46,
+                "columnBegin": 4,
+                "lineEnd": 46,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -262,11 +272,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 55,
-                "columnBegin": 1,
-                "lineEnd": 55,
-                "columnEnd": 5
-              }
+                "lineBegin": 56,
+                "columnBegin": 2,
+                "lineEnd": 56,
+                "columnEnd": 6
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -287,11 +298,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 57,
-                "columnBegin": 5,
-                "lineEnd": 57,
-                "columnEnd": 16
-              }
+                "lineBegin": 58,
+                "columnBegin": 6,
+                "lineEnd": 58,
+                "columnEnd": 17
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -312,11 +324,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 59,
-                "columnBegin": 5,
-                "lineEnd": 59,
-                "columnEnd": 6
-              }
+                "lineBegin": 60,
+                "columnBegin": 6,
+                "lineEnd": 60,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }

--- a/glean/lang/go/tests/cases/xrefs/name.out
+++ b/glean/lang/go/tests/cases/xrefs/name.out
@@ -1,1 +1,1 @@
-[ "@generated" ]
+[ "@generated", { "key": "anonymous" } ]

--- a/glean/lang/go/tests/cases/xrefs/range.out
+++ b/glean/lang/go/tests/cases/xrefs/range.out
@@ -3,731 +3,804 @@
   {
     "key": {
       "range": {
-        "lineBegin": 10,
-        "columnBegin": 8,
-        "lineEnd": 10,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 13,
-        "columnBegin": 2,
-        "lineEnd": 13,
-        "columnEnd": 13
-      }
+        "lineBegin": 11,
+        "columnBegin": 9,
+        "lineEnd": 11,
+        "columnEnd": 17
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 14,
-        "columnBegin": 2,
+        "columnBegin": 3,
         "lineEnd": 14,
-        "columnEnd": 5
-      }
+        "columnEnd": 14
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 15,
-        "columnBegin": 2,
+        "columnBegin": 3,
         "lineEnd": 15,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 23,
-        "columnBegin": 5,
-        "lineEnd": 23,
-        "columnEnd": 12
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 23,
-        "columnBegin": 13,
-        "lineEnd": 23,
-        "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 24,
-        "columnBegin": 1,
-        "lineEnd": 24,
         "columnEnd": 6
-      }
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 24,
-        "columnBegin": 10,
-        "lineEnd": 24,
-        "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 24,
-        "columnBegin": 18,
-        "lineEnd": 24,
-        "columnEnd": 23
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 24,
-        "columnBegin": 31,
-        "lineEnd": 24,
-        "columnEnd": 35
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 26,
-        "columnBegin": 5,
-        "lineEnd": 26,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 27,
-        "columnBegin": 1,
-        "lineEnd": 27,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 27,
-        "columnBegin": 22,
-        "lineEnd": 27,
-        "columnEnd": 23
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 28,
-        "columnBegin": 5,
-        "lineEnd": 28,
-        "columnEnd": 6
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 28,
-        "columnBegin": 17,
-        "lineEnd": 28,
-        "columnEnd": 18
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 31,
-        "columnBegin": 9,
-        "lineEnd": 31,
+        "lineBegin": 16,
+        "columnBegin": 3,
+        "lineEnd": 16,
         "columnEnd": 10
-      }
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 34,
-        "columnBegin": 5,
-        "lineEnd": 34,
-        "columnEnd": 6
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 34,
-        "columnBegin": 13,
-        "lineEnd": 34,
-        "columnEnd": 14
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 34,
-        "columnBegin": 21,
-        "lineEnd": 34,
-        "columnEnd": 26
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 34,
-        "columnBegin": 29,
-        "lineEnd": 34,
-        "columnEnd": 30
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 35,
-        "columnBegin": 5,
-        "lineEnd": 35,
-        "columnEnd": 12
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 35,
-        "columnBegin": 13,
-        "lineEnd": 35,
-        "columnEnd": 22
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 35,
-        "columnBegin": 23,
-        "lineEnd": 35,
-        "columnEnd": 28
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 35,
-        "columnBegin": 29,
-        "lineEnd": 35,
-        "columnEnd": 30
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 35,
-        "columnBegin": 42,
-        "lineEnd": 35,
-        "columnEnd": 49
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 35,
-        "columnBegin": 50,
-        "lineEnd": 35,
-        "columnEnd": 59
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 35,
-        "columnBegin": 60,
-        "lineEnd": 35,
-        "columnEnd": 65
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 35,
-        "columnBegin": 66,
-        "lineEnd": 35,
-        "columnEnd": 67
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 38,
-        "columnBegin": 3,
-        "lineEnd": 38,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 38,
-        "columnBegin": 15,
-        "lineEnd": 38,
-        "columnEnd": 22
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 38,
-        "columnBegin": 23,
-        "lineEnd": 38,
-        "columnEnd": 26
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 38,
-        "columnBegin": 27,
-        "lineEnd": 38,
-        "columnEnd": 39
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 38,
-        "columnBegin": 41,
-        "lineEnd": 38,
-        "columnEnd": 46
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 38,
-        "columnBegin": 47,
-        "lineEnd": 38,
-        "columnEnd": 48
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 38,
-        "columnBegin": 56,
-        "lineEnd": 38,
-        "columnEnd": 61
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 38,
-        "columnBegin": 62,
-        "lineEnd": 38,
-        "columnEnd": 63
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 39,
-        "columnBegin": 12,
-        "lineEnd": 39,
-        "columnEnd": 19
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 39,
-        "columnBegin": 20,
-        "lineEnd": 39,
-        "columnEnd": 29
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 39,
-        "columnBegin": 30,
-        "lineEnd": 39,
-        "columnEnd": 35
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 39,
-        "columnBegin": 36,
-        "lineEnd": 39,
-        "columnEnd": 37
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 43,
-        "columnBegin": 3,
-        "lineEnd": 43,
-        "columnEnd": 7
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 43,
-        "columnBegin": 11,
-        "lineEnd": 43,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 43,
-        "columnBegin": 17,
-        "lineEnd": 43,
-        "columnEnd": 18
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 45,
-        "columnBegin": 3,
-        "lineEnd": 45,
+        "lineBegin": 24,
+        "columnBegin": 6,
+        "lineEnd": 24,
         "columnEnd": 13
-      }
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 45,
-        "columnBegin": 17,
-        "lineEnd": 45,
+        "lineBegin": 24,
+        "columnBegin": 14,
+        "lineEnd": 24,
+        "columnEnd": 18
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 25,
+        "columnBegin": 2,
+        "lineEnd": 25,
+        "columnEnd": 7
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 25,
+        "columnBegin": 11,
+        "lineEnd": 25,
+        "columnEnd": 18
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 25,
+        "columnBegin": 19,
+        "lineEnd": 25,
         "columnEnd": 24
-      }
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 45,
-        "columnBegin": 25,
-        "lineEnd": 45,
+        "lineBegin": 25,
+        "columnBegin": 32,
+        "lineEnd": 25,
+        "columnEnd": 36
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 27,
+        "columnBegin": 6,
+        "lineEnd": 27,
+        "columnEnd": 14
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 28,
+        "columnBegin": 2,
+        "lineEnd": 28,
+        "columnEnd": 14
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 28,
+        "columnBegin": 23,
+        "lineEnd": 28,
+        "columnEnd": 24
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 29,
+        "columnBegin": 6,
+        "lineEnd": 29,
+        "columnEnd": 7
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 29,
+        "columnBegin": 18,
+        "lineEnd": 29,
+        "columnEnd": 19
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 32,
+        "columnBegin": 10,
+        "lineEnd": 32,
+        "columnEnd": 11
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 35,
+        "columnBegin": 6,
+        "lineEnd": 35,
+        "columnEnd": 7
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 35,
+        "columnBegin": 14,
+        "lineEnd": 35,
+        "columnEnd": 15
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 35,
+        "columnBegin": 22,
+        "lineEnd": 35,
+        "columnEnd": 27
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 35,
+        "columnBegin": 30,
+        "lineEnd": 35,
+        "columnEnd": 31
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 6,
+        "lineEnd": 36,
+        "columnEnd": 13
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 14,
+        "lineEnd": 36,
+        "columnEnd": 23
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 24,
+        "lineEnd": 36,
+        "columnEnd": 29
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 30,
+        "lineEnd": 36,
+        "columnEnd": 31
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 43,
+        "lineEnd": 36,
+        "columnEnd": 50
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 51,
+        "lineEnd": 36,
+        "columnEnd": 60
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 61,
+        "lineEnd": 36,
+        "columnEnd": 66
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 67,
+        "lineEnd": 36,
+        "columnEnd": 68
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 4,
+        "lineEnd": 39,
+        "columnEnd": 12
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 16,
+        "lineEnd": 39,
+        "columnEnd": 23
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 24,
+        "lineEnd": 39,
+        "columnEnd": 27
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 28,
+        "lineEnd": 39,
+        "columnEnd": 40
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 42,
+        "lineEnd": 39,
+        "columnEnd": 47
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 48,
+        "lineEnd": 39,
+        "columnEnd": 49
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 57,
+        "lineEnd": 39,
+        "columnEnd": 62
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 63,
+        "lineEnd": 39,
+        "columnEnd": 64
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 40,
+        "columnBegin": 13,
+        "lineEnd": 40,
+        "columnEnd": 20
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 40,
+        "columnBegin": 21,
+        "lineEnd": 40,
         "columnEnd": 30
-      }
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 45,
+        "lineBegin": 40,
         "columnBegin": 31,
-        "lineEnd": 45,
-        "columnEnd": 35
-      }
+        "lineEnd": 40,
+        "columnEnd": 36
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 40,
+        "columnBegin": 37,
+        "lineEnd": 40,
+        "columnEnd": 38
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 44,
+        "columnBegin": 4,
+        "lineEnd": 44,
+        "columnEnd": 8
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 44,
+        "columnBegin": 12,
+        "lineEnd": 44,
+        "columnEnd": 17
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 44,
+        "columnBegin": 18,
+        "lineEnd": 44,
+        "columnEnd": 19
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 46,
-        "columnBegin": 6,
-        "lineEnd": 46,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 47,
         "columnBegin": 4,
-        "lineEnd": 47,
-        "columnEnd": 8
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 47,
-        "columnBegin": 11,
-        "lineEnd": 47,
-        "columnEnd": 15
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 47,
-        "columnBegin": 20,
-        "lineEnd": 47,
-        "columnEnd": 30
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 50,
-        "columnBegin": 3,
-        "lineEnd": 50,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 50,
-        "columnBegin": 15,
-        "lineEnd": 50,
-        "columnEnd": 22
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 50,
-        "columnBegin": 23,
-        "lineEnd": 50,
-        "columnEnd": 26
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 50,
-        "columnBegin": 27,
-        "lineEnd": 50,
-        "columnEnd": 39
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 50,
-        "columnBegin": 41,
-        "lineEnd": 50,
-        "columnEnd": 45
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 55,
-        "columnBegin": 1,
-        "lineEnd": 55,
-        "columnEnd": 5
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 55,
-        "columnBegin": 9,
-        "lineEnd": 55,
-        "columnEnd": 12
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 55,
-        "columnBegin": 13,
-        "lineEnd": 55,
-        "columnEnd": 20
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 55,
-        "columnBegin": 27,
-        "lineEnd": 55,
-        "columnEnd": 31
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 55,
-        "columnBegin": 32,
-        "lineEnd": 55,
-        "columnEnd": 35
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 55,
-        "columnBegin": 43,
-        "lineEnd": 55,
-        "columnEnd": 51
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 57,
-        "columnBegin": 5,
-        "lineEnd": 57,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 59,
-        "columnBegin": 5,
-        "lineEnd": 59,
-        "columnEnd": 6
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 59,
-        "columnBegin": 13,
-        "lineEnd": 59,
+        "lineEnd": 46,
         "columnEnd": 14
-      }
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 59,
-        "columnBegin": 20,
-        "lineEnd": 59,
+        "lineBegin": 46,
+        "columnBegin": 18,
+        "lineEnd": 46,
+        "columnEnd": 25
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 46,
+        "columnBegin": 26,
+        "lineEnd": 46,
+        "columnEnd": 31
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 46,
+        "columnBegin": 32,
+        "lineEnd": 46,
+        "columnEnd": 36
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 47,
+        "columnBegin": 7,
+        "lineEnd": 47,
+        "columnEnd": 17
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 48,
+        "columnBegin": 5,
+        "lineEnd": 48,
+        "columnEnd": 9
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 48,
+        "columnBegin": 12,
+        "lineEnd": 48,
+        "columnEnd": 16
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 48,
+        "columnBegin": 21,
+        "lineEnd": 48,
+        "columnEnd": 31
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 51,
+        "columnBegin": 4,
+        "lineEnd": 51,
+        "columnEnd": 12
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 51,
+        "columnBegin": 16,
+        "lineEnd": 51,
+        "columnEnd": 23
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 51,
+        "columnBegin": 24,
+        "lineEnd": 51,
+        "columnEnd": 27
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 51,
+        "columnBegin": 28,
+        "lineEnd": 51,
+        "columnEnd": 40
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 51,
+        "columnBegin": 42,
+        "lineEnd": 51,
+        "columnEnd": 46
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 56,
+        "columnBegin": 2,
+        "lineEnd": 56,
+        "columnEnd": 6
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 56,
+        "columnBegin": 10,
+        "lineEnd": 56,
+        "columnEnd": 13
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 56,
+        "columnBegin": 14,
+        "lineEnd": 56,
         "columnEnd": 21
-      }
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 56,
+        "columnBegin": 28,
+        "lineEnd": 56,
+        "columnEnd": 32
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 56,
+        "columnBegin": 33,
+        "lineEnd": 56,
+        "columnEnd": 36
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 56,
+        "columnBegin": 44,
+        "lineEnd": 56,
+        "columnEnd": 52
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 58,
+        "columnBegin": 6,
+        "lineEnd": 58,
+        "columnEnd": 17
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 60,
-        "columnBegin": 5,
+        "columnBegin": 6,
         "lineEnd": 60,
-        "columnEnd": 16
-      }
+        "columnEnd": 7
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 60,
+        "columnBegin": 14,
+        "lineEnd": 60,
+        "columnEnd": 15
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 60,
+        "columnBegin": 21,
+        "lineEnd": 60,
+        "columnEnd": 22
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 61,
-        "columnBegin": 3,
+        "columnBegin": 6,
         "lineEnd": 61,
+        "columnEnd": 17
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 62,
+        "columnBegin": 4,
+        "lineEnd": 62,
+        "columnEnd": 15
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 64,
+        "columnBegin": 3,
+        "lineEnd": 64,
         "columnEnd": 14
-      }
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 63,
-        "columnBegin": 2,
-        "lineEnd": 63,
-        "columnEnd": 13
-      }
+        "lineBegin": 64,
+        "columnBegin": 18,
+        "lineEnd": 64,
+        "columnEnd": 22
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 63,
-        "columnBegin": 17,
-        "lineEnd": 63,
-        "columnEnd": 21
-      }
+        "lineBegin": 64,
+        "columnBegin": 23,
+        "lineEnd": 64,
+        "columnEnd": 24
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 63,
-        "columnBegin": 22,
-        "lineEnd": 63,
-        "columnEnd": 23
-      }
+        "lineBegin": 64,
+        "columnBegin": 30,
+        "lineEnd": 64,
+        "columnEnd": 31
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 63,
-        "columnBegin": 29,
-        "lineEnd": 63,
-        "columnEnd": 30
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 66,
-        "columnBegin": 8,
-        "lineEnd": 66,
-        "columnEnd": 19
-      }
+        "lineBegin": 67,
+        "columnBegin": 9,
+        "lineEnd": 67,
+        "columnEnd": 20
+      },
+      "text": { "key": "anonymous" }
     }
   }
 ]

--- a/glean/lang/go/tests/cases/xrefs/uses.out
+++ b/glean/lang/go/tests/cases/xrefs/uses.out
@@ -8,11 +8,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 23,
-                "columnBegin": 13,
-                "lineEnd": 23,
-                "columnEnd": 17
-              }
+                "lineBegin": 24,
+                "columnBegin": 14,
+                "lineEnd": 24,
+                "columnEnd": 18
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -21,11 +22,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 24,
-            "columnBegin": 31,
-            "lineEnd": 24,
-            "columnEnd": 35
-          }
+            "lineBegin": 25,
+            "columnBegin": 32,
+            "lineEnd": 25,
+            "columnEnd": 36
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -38,41 +40,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 34,
-            "columnBegin": 21,
-            "lineEnd": 34,
-            "columnEnd": 26
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -82,10 +55,11 @@
         "key": {
           "range": {
             "lineBegin": 35,
-            "columnBegin": 23,
+            "columnBegin": 22,
             "lineEnd": 35,
-            "columnEnd": 28
-          }
+            "columnEnd": 27
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -98,11 +72,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -111,11 +86,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 35,
-            "columnBegin": 60,
-            "lineEnd": 35,
-            "columnEnd": 65
-          }
+            "lineBegin": 36,
+            "columnBegin": 24,
+            "lineEnd": 36,
+            "columnEnd": 29
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -128,11 +104,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -141,11 +118,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 38,
-            "columnBegin": 41,
-            "lineEnd": 38,
-            "columnEnd": 46
-          }
+            "lineBegin": 36,
+            "columnBegin": 61,
+            "lineEnd": 36,
+            "columnEnd": 66
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -158,41 +136,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 56,
-            "lineEnd": 38,
-            "columnEnd": 61
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -202,10 +151,11 @@
         "key": {
           "range": {
             "lineBegin": 39,
-            "columnBegin": 30,
+            "columnBegin": 42,
             "lineEnd": 39,
-            "columnEnd": 35
-          }
+            "columnEnd": 47
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -218,461 +168,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 24,
-                "columnBegin": 1,
-                "lineEnd": 24,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 43,
-            "columnBegin": 11,
-            "lineEnd": 43,
-            "columnEnd": 16
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 26,
-                "columnBegin": 5,
-                "lineEnd": 26,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 3,
-            "lineEnd": 38,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 26,
-                "columnBegin": 5,
-                "lineEnd": 26,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 50,
-            "columnBegin": 3,
-            "lineEnd": 50,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 26,
-                "columnBegin": 5,
-                "lineEnd": 26,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 55,
-            "columnBegin": 43,
-            "lineEnd": 55,
-            "columnEnd": 51
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 1,
-                "lineEnd": 27,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 27,
-            "lineEnd": 38,
-            "columnEnd": 39
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 1,
-                "lineEnd": 27,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 50,
-            "columnBegin": 27,
-            "lineEnd": 50,
-            "columnEnd": 39
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 22,
-                "lineEnd": 27,
-                "columnEnd": 23
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 28,
-            "columnBegin": 5,
-            "lineEnd": 28,
-            "columnEnd": 6
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 22,
-                "lineEnd": 27,
-                "columnEnd": 23
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 28,
-            "columnBegin": 17,
-            "lineEnd": 28,
-            "columnEnd": 18
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 22,
-                "lineEnd": 27,
-                "columnEnd": 23
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 31,
-            "columnBegin": 9,
-            "lineEnd": 31,
-            "columnEnd": 10
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 34,
-            "columnBegin": 13,
-            "lineEnd": 34,
-            "columnEnd": 14
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 34,
-            "columnBegin": 29,
-            "lineEnd": 34,
-            "columnEnd": 30
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 35,
-            "columnBegin": 29,
-            "lineEnd": 35,
-            "columnEnd": 30
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 35,
-            "columnBegin": 66,
-            "lineEnd": 35,
-            "columnEnd": 67
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 47,
-            "lineEnd": 38,
-            "columnEnd": 48
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 62,
-            "lineEnd": 38,
-            "columnEnd": 63
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -682,10 +183,11 @@
         "key": {
           "range": {
             "lineBegin": 39,
-            "columnBegin": 36,
+            "columnBegin": 57,
             "lineEnd": 39,
-            "columnEnd": 37
-          }
+            "columnEnd": 62
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -698,41 +200,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 5,
-                "lineEnd": 34,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 43,
-            "columnBegin": 17,
-            "lineEnd": 43,
-            "columnEnd": 18
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 43,
-                "columnBegin": 3,
-                "lineEnd": 43,
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
                 "columnEnd": 7
-              }
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -741,11 +214,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 45,
+            "lineBegin": 40,
             "columnBegin": 31,
-            "lineEnd": 45,
-            "columnEnd": 35
-          }
+            "lineEnd": 40,
+            "columnEnd": 36
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -758,11 +232,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 43,
-                "columnBegin": 3,
-                "lineEnd": 43,
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
                 "columnEnd": 7
-              }
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -771,11 +246,44 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 47,
+            "lineBegin": 44,
+            "columnBegin": 12,
+            "lineEnd": 44,
+            "columnEnd": 17
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 27,
+                "columnBegin": 6,
+                "lineEnd": 27,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
             "columnBegin": 4,
-            "lineEnd": 47,
-            "columnEnd": 8
-          }
+            "lineEnd": 39,
+            "columnEnd": 12
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -788,11 +296,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 43,
-                "columnBegin": 3,
-                "lineEnd": 43,
-                "columnEnd": 7
-              }
+                "lineBegin": 27,
+                "columnBegin": 6,
+                "lineEnd": 27,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -801,11 +310,236 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 47,
-            "columnBegin": 11,
-            "lineEnd": 47,
+            "lineBegin": 51,
+            "columnBegin": 4,
+            "lineEnd": 51,
+            "columnEnd": 12
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 27,
+                "columnBegin": 6,
+                "lineEnd": 27,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 56,
+            "columnBegin": 44,
+            "lineEnd": 56,
+            "columnEnd": 52
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 28,
+                "columnBegin": 2,
+                "lineEnd": 28,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 28,
+            "lineEnd": 39,
+            "columnEnd": 40
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 28,
+                "columnBegin": 2,
+                "lineEnd": 28,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 51,
+            "columnBegin": 28,
+            "lineEnd": 51,
+            "columnEnd": 40
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 28,
+                "columnBegin": 23,
+                "lineEnd": 28,
+                "columnEnd": 24
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 29,
+            "columnBegin": 6,
+            "lineEnd": 29,
+            "columnEnd": 7
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 28,
+                "columnBegin": 23,
+                "lineEnd": 28,
+                "columnEnd": 24
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 29,
+            "columnBegin": 18,
+            "lineEnd": 29,
+            "columnEnd": 19
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 28,
+                "columnBegin": 23,
+                "lineEnd": 28,
+                "columnEnd": 24
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 32,
+            "columnBegin": 10,
+            "lineEnd": 32,
+            "columnEnd": 11
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 14,
+            "lineEnd": 35,
             "columnEnd": 15
-          }
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -818,11 +552,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 43,
-                "columnBegin": 3,
-                "lineEnd": 43,
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
                 "columnEnd": 7
-              }
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -831,11 +566,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 50,
-            "columnBegin": 41,
-            "lineEnd": 50,
-            "columnEnd": 45
-          }
+            "lineBegin": 35,
+            "columnBegin": 30,
+            "lineEnd": 35,
+            "columnEnd": 31
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -848,11 +584,204 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 45,
-                "columnBegin": 3,
-                "lineEnd": 45,
-                "columnEnd": 13
-              }
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 30,
+            "lineEnd": 36,
+            "columnEnd": 31
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 67,
+            "lineEnd": 36,
+            "columnEnd": 68
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 48,
+            "lineEnd": 39,
+            "columnEnd": 49
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 63,
+            "lineEnd": 39,
+            "columnEnd": 64
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 40,
+            "columnBegin": 37,
+            "lineEnd": 40,
+            "columnEnd": 38
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 44,
+            "columnBegin": 18,
+            "lineEnd": 44,
+            "columnEnd": 19
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 8
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -862,10 +791,11 @@
         "key": {
           "range": {
             "lineBegin": 46,
-            "columnBegin": 6,
+            "columnBegin": 32,
             "lineEnd": 46,
-            "columnEnd": 16
-          }
+            "columnEnd": 36
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -878,11 +808,108 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 45,
-                "columnBegin": 3,
-                "lineEnd": 45,
-                "columnEnd": 13
-              }
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 8
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 48,
+            "columnBegin": 5,
+            "lineEnd": 48,
+            "columnEnd": 9
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 8
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 48,
+            "columnBegin": 12,
+            "lineEnd": 48,
+            "columnEnd": 16
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 8
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 51,
+            "columnBegin": 42,
+            "lineEnd": 51,
+            "columnEnd": 46
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 46,
+                "columnBegin": 4,
+                "lineEnd": 46,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -892,10 +919,11 @@
         "key": {
           "range": {
             "lineBegin": 47,
-            "columnBegin": 20,
+            "columnBegin": 7,
             "lineEnd": 47,
-            "columnEnd": 30
-          }
+            "columnEnd": 17
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -908,11 +936,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 55,
-                "columnBegin": 1,
-                "lineEnd": 55,
-                "columnEnd": 5
-              }
+                "lineBegin": 46,
+                "columnBegin": 4,
+                "lineEnd": 46,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -921,11 +950,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 63,
-            "columnBegin": 17,
-            "lineEnd": 63,
-            "columnEnd": 21
-          }
+            "lineBegin": 48,
+            "columnBegin": 21,
+            "lineEnd": 48,
+            "columnEnd": 31
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -938,11 +968,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 57,
-                "columnBegin": 5,
-                "lineEnd": 57,
-                "columnEnd": 16
-              }
+                "lineBegin": 56,
+                "columnBegin": 2,
+                "lineEnd": 56,
+                "columnEnd": 6
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -951,11 +982,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 60,
-            "columnBegin": 5,
-            "lineEnd": 60,
-            "columnEnd": 16
-          }
+            "lineBegin": 64,
+            "columnBegin": 18,
+            "lineEnd": 64,
+            "columnEnd": 22
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -968,11 +1000,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 57,
-                "columnBegin": 5,
-                "lineEnd": 57,
-                "columnEnd": 16
-              }
+                "lineBegin": 58,
+                "columnBegin": 6,
+                "lineEnd": 58,
+                "columnEnd": 17
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -982,10 +1015,75 @@
         "key": {
           "range": {
             "lineBegin": 61,
-            "columnBegin": 3,
+            "columnBegin": 6,
             "lineEnd": 61,
+            "columnEnd": 17
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 58,
+                "columnBegin": 6,
+                "lineEnd": 58,
+                "columnEnd": 17
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 62,
+            "columnBegin": 4,
+            "lineEnd": 62,
+            "columnEnd": 15
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 58,
+                "columnBegin": 6,
+                "lineEnd": 58,
+                "columnEnd": 17
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 64,
+            "columnBegin": 3,
+            "lineEnd": 64,
             "columnEnd": 14
-          }
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -998,11 +1096,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 57,
-                "columnBegin": 5,
-                "lineEnd": 57,
-                "columnEnd": 16
-              }
+                "lineBegin": 58,
+                "columnBegin": 6,
+                "lineEnd": 58,
+                "columnEnd": 17
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -1011,11 +1110,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 63,
-            "columnBegin": 2,
-            "lineEnd": 63,
-            "columnEnd": 13
-          }
+            "lineBegin": 67,
+            "columnBegin": 9,
+            "lineEnd": 67,
+            "columnEnd": 20
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -1028,11 +1128,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 57,
-                "columnBegin": 5,
-                "lineEnd": 57,
-                "columnEnd": 16
-              }
+                "lineBegin": 60,
+                "columnBegin": 6,
+                "lineEnd": 60,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -1041,11 +1142,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 66,
-            "columnBegin": 8,
-            "lineEnd": 66,
-            "columnEnd": 19
-          }
+            "lineBegin": 60,
+            "columnBegin": 14,
+            "lineEnd": 60,
+            "columnEnd": 15
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -1058,11 +1160,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 59,
-                "columnBegin": 5,
-                "lineEnd": 59,
-                "columnEnd": 6
-              }
+                "lineBegin": 60,
+                "columnBegin": 6,
+                "lineEnd": 60,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -1071,11 +1174,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 59,
-            "columnBegin": 13,
-            "lineEnd": 59,
-            "columnEnd": 14
-          }
+            "lineBegin": 60,
+            "columnBegin": 21,
+            "lineEnd": 60,
+            "columnEnd": 22
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -1088,11 +1192,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 59,
-                "columnBegin": 5,
-                "lineEnd": 59,
-                "columnEnd": 6
-              }
+                "lineBegin": 60,
+                "columnBegin": 6,
+                "lineEnd": 60,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -1101,11 +1206,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 59,
-            "columnBegin": 20,
-            "lineEnd": 59,
-            "columnEnd": 21
-          }
+            "lineBegin": 64,
+            "columnBegin": 23,
+            "lineEnd": 64,
+            "columnEnd": 24
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -1118,11 +1224,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 59,
-                "columnBegin": 5,
-                "lineEnd": 59,
-                "columnEnd": 6
-              }
+                "lineBegin": 60,
+                "columnBegin": 6,
+                "lineEnd": 60,
+                "columnEnd": 7
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -1131,41 +1238,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 63,
-            "columnBegin": 22,
-            "lineEnd": 63,
-            "columnEnd": 23
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 59,
-                "columnBegin": 5,
-                "lineEnd": 59,
-                "columnEnd": 6
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 63,
-            "columnBegin": 29,
-            "lineEnd": 63,
-            "columnEnd": 30
-          }
+            "lineBegin": 64,
+            "columnBegin": 30,
+            "lineEnd": 64,
+            "columnEnd": 31
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }

--- a/glean/lang/lsif/Data/LSIF/Angle.hs
+++ b/glean/lang/lsif/Data/LSIF/Angle.hs
@@ -588,11 +588,11 @@ predicateId name id_ facts =
 
 toRange :: Range -> Value
 toRange Range{..} =
-  object [ -- lsif.Range data type
-    "lineBegin" .= line start,
-    "columnBegin" .= character start,
-    "lineEnd" .= line end,
-    "columnEnd" .= character end
+  object [ -- lsif.Range data type, we convert to 1-indexed
+    "lineBegin" .= (line start + 1),
+    "columnBegin" .= (character start + 1),
+    "lineEnd" .= (line end + 1),
+    "columnEnd" .= (character end + 1)
   ]
 
 key :: KeyValue kv => [Pair] -> kv
@@ -615,11 +615,7 @@ tagToTy _ = Nothing
 
 -- | Identifier text string
 toName :: Tag -> Value
-toName t = string $ case t of
-  Definition{..} -> tagText
-  Declaration{..} -> tagText
-  Reference{..} -> tagText
-  UnknownSymbol{..} -> tagText
+toName = string . tagText
 
 tagToRange :: KeyValue a => Tag -> Maybe [a]
 tagToRange Definition{..} = Just ["fullRange" .= toRange fullRange]

--- a/glean/lang/rust/tests/cases/xrefs/defhover.out
+++ b/glean/lang/rust/tests/cases/xrefs/defhover.out
@@ -8,11 +8,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 13
-              }
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -35,11 +36,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 11,
-                "columnBegin": 14,
-                "lineEnd": 11,
-                "columnEnd": 15
-              }
+                "lineBegin": 12,
+                "columnBegin": 15,
+                "lineEnd": 12,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -60,11 +62,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 3,
-                "lineEnd": 15,
-                "columnEnd": 8
-              }
+                "lineBegin": 16,
+                "columnBegin": 4,
+                "lineEnd": 16,
+                "columnEnd": 9
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -87,11 +90,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 9,
-                "lineEnd": 15,
-                "columnEnd": 10
-              }
+                "lineBegin": 16,
+                "columnBegin": 10,
+                "lineEnd": 16,
+                "columnEnd": 11
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -112,11 +116,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 17,
-                "lineEnd": 15,
-                "columnEnd": 20
-              }
+                "lineBegin": 16,
+                "columnBegin": 18,
+                "lineEnd": 16,
+                "columnEnd": 21
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -137,11 +142,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 21,
-                "columnBegin": 7,
-                "lineEnd": 21,
-                "columnEnd": 13
-              }
+                "lineBegin": 22,
+                "columnBegin": 8,
+                "lineEnd": 22,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -164,11 +170,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 21,
-                "columnBegin": 14,
-                "lineEnd": 21,
-                "columnEnd": 15
-              }
+                "lineBegin": 22,
+                "columnBegin": 15,
+                "lineEnd": 22,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -189,11 +196,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 22,
-                "columnBegin": 12,
-                "lineEnd": 22,
-                "columnEnd": 15
-              }
+                "lineBegin": 23,
+                "columnBegin": 13,
+                "lineEnd": 23,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -214,11 +222,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 23,
-                "columnBegin": 12,
-                "lineEnd": 23,
-                "columnEnd": 13
-              }
+                "lineBegin": 24,
+                "columnBegin": 13,
+                "lineEnd": 24,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -239,11 +248,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 36,
-                "columnBegin": 7,
-                "lineEnd": 36,
-                "columnEnd": 13
-              }
+                "lineBegin": 37,
+                "columnBegin": 8,
+                "lineEnd": 37,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -266,11 +276,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 36,
-                "columnBegin": 14,
-                "lineEnd": 36,
-                "columnEnd": 15
-              }
+                "lineBegin": 37,
+                "columnBegin": 15,
+                "lineEnd": 37,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -291,11 +302,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 37,
-                "columnBegin": 12,
-                "lineEnd": 37,
-                "columnEnd": 15
-              }
+                "lineBegin": 38,
+                "columnBegin": 13,
+                "lineEnd": 38,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -316,11 +328,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 38,
-                "columnBegin": 8,
-                "lineEnd": 38,
-                "columnEnd": 9
-              }
+                "lineBegin": 39,
+                "columnBegin": 9,
+                "lineEnd": 39,
+                "columnEnd": 10
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }

--- a/glean/lang/rust/tests/cases/xrefs/definition.out
+++ b/glean/lang/rust/tests/cases/xrefs/definition.out
@@ -6,11 +6,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 11,
-            "columnBegin": 7,
-            "lineEnd": 11,
-            "columnEnd": 13
-          }
+            "lineBegin": 12,
+            "columnBegin": 8,
+            "lineEnd": 12,
+            "columnEnd": 14
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -21,11 +22,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 11,
-            "columnBegin": 14,
-            "lineEnd": 11,
-            "columnEnd": 15
-          }
+            "lineBegin": 12,
+            "columnBegin": 15,
+            "lineEnd": 12,
+            "columnEnd": 16
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -36,11 +38,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 15,
-            "columnBegin": 3,
-            "lineEnd": 15,
-            "columnEnd": 8
-          }
+            "lineBegin": 16,
+            "columnBegin": 4,
+            "lineEnd": 16,
+            "columnEnd": 9
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -51,11 +54,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 15,
-            "columnBegin": 9,
-            "lineEnd": 15,
-            "columnEnd": 10
-          }
+            "lineBegin": 16,
+            "columnBegin": 10,
+            "lineEnd": 16,
+            "columnEnd": 11
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -66,41 +70,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 15,
-            "columnBegin": 17,
-            "lineEnd": 15,
-            "columnEnd": 20
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 21,
-            "columnBegin": 7,
-            "lineEnd": 21,
-            "columnEnd": 13
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 21,
-            "columnBegin": 14,
-            "lineEnd": 21,
-            "columnEnd": 15
-          }
+            "lineBegin": 16,
+            "columnBegin": 18,
+            "lineEnd": 16,
+            "columnEnd": 21
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -112,10 +87,27 @@
         "key": {
           "range": {
             "lineBegin": 22,
-            "columnBegin": 12,
+            "columnBegin": 8,
             "lineEnd": 22,
-            "columnEnd": 15
-          }
+            "columnEnd": 14
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 22,
+            "columnBegin": 15,
+            "lineEnd": 22,
+            "columnEnd": 16
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -127,10 +119,11 @@
         "key": {
           "range": {
             "lineBegin": 23,
-            "columnBegin": 12,
+            "columnBegin": 13,
             "lineEnd": 23,
-            "columnEnd": 13
-          }
+            "columnEnd": 16
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -141,26 +134,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 36,
-            "columnBegin": 7,
-            "lineEnd": 36,
-            "columnEnd": 13
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 36,
-            "columnBegin": 14,
-            "lineEnd": 36,
-            "columnEnd": 15
-          }
+            "lineBegin": 24,
+            "columnBegin": 13,
+            "lineEnd": 24,
+            "columnEnd": 14
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -172,10 +151,27 @@
         "key": {
           "range": {
             "lineBegin": 37,
-            "columnBegin": 12,
+            "columnBegin": 8,
             "lineEnd": 37,
-            "columnEnd": 15
-          }
+            "columnEnd": 14
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 37,
+            "columnBegin": 15,
+            "lineEnd": 37,
+            "columnEnd": 16
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -187,10 +183,27 @@
         "key": {
           "range": {
             "lineBegin": 38,
-            "columnBegin": 8,
+            "columnBegin": 13,
             "lineEnd": 38,
-            "columnEnd": 9
-          }
+            "columnEnd": 16
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 9,
+            "lineEnd": 39,
+            "columnEnd": 10
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }

--- a/glean/lang/rust/tests/cases/xrefs/range.out
+++ b/glean/lang/rust/tests/cases/xrefs/range.out
@@ -3,431 +3,474 @@
   {
     "key": {
       "range": {
-        "lineBegin": 10,
-        "columnBegin": 2,
-        "lineEnd": 10,
-        "columnEnd": 8
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
         "lineBegin": 11,
-        "columnBegin": 7,
-        "lineEnd": 11,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 11,
-        "columnBegin": 14,
-        "lineEnd": 11,
-        "columnEnd": 15
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 11,
-        "columnBegin": 17,
-        "lineEnd": 11,
-        "columnEnd": 20
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 11,
-        "columnBegin": 25,
-        "lineEnd": 11,
-        "columnEnd": 28
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 12,
-        "columnBegin": 4,
-        "lineEnd": 12,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 12,
-        "columnBegin": 10,
-        "lineEnd": 12,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 15,
         "columnBegin": 3,
-        "lineEnd": 15,
-        "columnEnd": 8
-      }
+        "lineEnd": 11,
+        "columnEnd": 9
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 15,
-        "columnBegin": 9,
-        "lineEnd": 15,
+        "lineBegin": 12,
+        "columnBegin": 8,
+        "lineEnd": 12,
+        "columnEnd": 14
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 12,
+        "columnBegin": 15,
+        "lineEnd": 12,
+        "columnEnd": 16
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 12,
+        "columnBegin": 18,
+        "lineEnd": 12,
+        "columnEnd": 21
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 12,
+        "columnBegin": 26,
+        "lineEnd": 12,
+        "columnEnd": 29
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 13,
+        "columnBegin": 5,
+        "lineEnd": 13,
         "columnEnd": 10
-      }
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 15,
-        "columnBegin": 12,
-        "lineEnd": 15,
-        "columnEnd": 15
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 15,
-        "columnBegin": 17,
-        "lineEnd": 15,
-        "columnEnd": 20
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 15,
-        "columnBegin": 22,
-        "lineEnd": 15,
-        "columnEnd": 25
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 15,
-        "columnBegin": 30,
-        "lineEnd": 15,
-        "columnEnd": 33
-      }
+        "lineBegin": 13,
+        "columnBegin": 11,
+        "lineEnd": 13,
+        "columnEnd": 12
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 16,
-        "columnBegin": 7,
+        "columnBegin": 4,
         "lineEnd": 16,
-        "columnEnd": 8
-      }
+        "columnEnd": 9
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 16,
-        "columnBegin": 16,
+        "columnBegin": 10,
         "lineEnd": 16,
-        "columnEnd": 19
-      }
+        "columnEnd": 11
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 16,
-        "columnBegin": 29,
+        "columnBegin": 13,
+        "lineEnd": 16,
+        "columnEnd": 16
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 16,
+        "columnBegin": 18,
+        "lineEnd": 16,
+        "columnEnd": 21
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 16,
+        "columnBegin": 23,
+        "lineEnd": 16,
+        "columnEnd": 26
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 16,
+        "columnBegin": 31,
         "lineEnd": 16,
         "columnEnd": 34
-      }
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 16,
-        "columnBegin": 35,
-        "lineEnd": 16,
-        "columnEnd": 36
-      }
+        "lineBegin": 17,
+        "columnBegin": 8,
+        "lineEnd": 17,
+        "columnEnd": 9
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 16,
-        "columnBegin": 42,
-        "lineEnd": 16,
-        "columnEnd": 45
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 16,
-        "columnBegin": 48,
-        "lineEnd": 16,
-        "columnEnd": 49
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 20,
-        "columnBegin": 2,
-        "lineEnd": 20,
-        "columnEnd": 8
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 21,
-        "columnBegin": 7,
-        "lineEnd": 21,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 21,
-        "columnBegin": 14,
-        "lineEnd": 21,
-        "columnEnd": 15
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 21,
+        "lineBegin": 17,
         "columnBegin": 17,
-        "lineEnd": 21,
+        "lineEnd": 17,
         "columnEnd": 20
-      }
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 17,
+        "columnBegin": 30,
+        "lineEnd": 17,
+        "columnEnd": 35
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 17,
+        "columnBegin": 36,
+        "lineEnd": 17,
+        "columnEnd": 37
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 17,
+        "columnBegin": 43,
+        "lineEnd": 17,
+        "columnEnd": 46
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 17,
+        "columnBegin": 49,
+        "lineEnd": 17,
+        "columnEnd": 50
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 21,
-        "columnBegin": 25,
+        "columnBegin": 3,
         "lineEnd": 21,
-        "columnEnd": 28
-      }
+        "columnEnd": 9
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 22,
-        "columnBegin": 12,
+        "columnBegin": 8,
         "lineEnd": 22,
-        "columnEnd": 15
-      }
+        "columnEnd": 14
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 22,
+        "columnBegin": 15,
+        "lineEnd": 22,
+        "columnEnd": 16
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 22,
+        "columnBegin": 18,
+        "lineEnd": 22,
+        "columnEnd": 21
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 22,
+        "columnBegin": 26,
+        "lineEnd": 22,
+        "columnEnd": 29
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 23,
-        "columnBegin": 12,
+        "columnBegin": 13,
         "lineEnd": 23,
-        "columnEnd": 13
-      }
+        "columnEnd": 16
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 23,
-        "columnBegin": 16,
-        "lineEnd": 23,
-        "columnEnd": 17
-      }
+        "lineBegin": 24,
+        "columnBegin": 13,
+        "lineEnd": 24,
+        "columnEnd": 14
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 25,
-        "columnBegin": 11,
-        "lineEnd": 25,
-        "columnEnd": 12
-      }
+        "lineBegin": 24,
+        "columnBegin": 17,
+        "lineEnd": 24,
+        "columnEnd": 18
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 26,
-        "columnBegin": 19,
-        "lineEnd": 26,
-        "columnEnd": 22
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 28,
         "columnBegin": 12,
-        "lineEnd": 28,
-        "columnEnd": 15
-      }
+        "lineEnd": 26,
+        "columnEnd": 13
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 28,
-        "columnBegin": 19,
-        "lineEnd": 28,
-        "columnEnd": 20
-      }
+        "lineBegin": 27,
+        "columnBegin": 20,
+        "lineEnd": 27,
+        "columnEnd": 23
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 29,
-        "columnBegin": 12,
+        "columnBegin": 13,
         "lineEnd": 29,
-        "columnEnd": 13
-      }
+        "columnEnd": 16
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 35,
-        "columnBegin": 2,
-        "lineEnd": 35,
-        "columnEnd": 8
-      }
+        "lineBegin": 29,
+        "columnBegin": 20,
+        "lineEnd": 29,
+        "columnEnd": 21
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 36,
-        "columnBegin": 7,
-        "lineEnd": 36,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 36,
-        "columnBegin": 14,
-        "lineEnd": 36,
-        "columnEnd": 15
-      }
+        "lineBegin": 30,
+        "columnBegin": 13,
+        "lineEnd": 30,
+        "columnEnd": 14
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 36,
-        "columnBegin": 17,
+        "columnBegin": 3,
         "lineEnd": 36,
-        "columnEnd": 20
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 36,
-        "columnBegin": 25,
-        "lineEnd": 36,
-        "columnEnd": 28
-      }
+        "columnEnd": 9
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
         "lineBegin": 37,
-        "columnBegin": 12,
+        "columnBegin": 8,
         "lineEnd": 37,
-        "columnEnd": 15
-      }
+        "columnEnd": 14
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 38,
-        "columnBegin": 8,
-        "lineEnd": 38,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 38,
-        "columnBegin": 17,
-        "lineEnd": 38,
-        "columnEnd": 18
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 39,
-        "columnBegin": 8,
-        "lineEnd": 39,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 39,
+        "lineBegin": 37,
         "columnBegin": 15,
-        "lineEnd": 39,
+        "lineEnd": 37,
         "columnEnd": 16
-      }
+      },
+      "text": { "key": "anonymous" }
     }
   },
   {
     "key": {
       "range": {
-        "lineBegin": 41,
-        "columnBegin": 4,
-        "lineEnd": 41,
-        "columnEnd": 7
-      }
+        "lineBegin": 37,
+        "columnBegin": 18,
+        "lineEnd": 37,
+        "columnEnd": 21
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 37,
+        "columnBegin": 26,
+        "lineEnd": 37,
+        "columnEnd": 29
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 38,
+        "columnBegin": 13,
+        "lineEnd": 38,
+        "columnEnd": 16
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 9,
+        "lineEnd": 39,
+        "columnEnd": 10
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 18,
+        "lineEnd": 39,
+        "columnEnd": 19
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 40,
+        "columnBegin": 9,
+        "lineEnd": 40,
+        "columnEnd": 12
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 40,
+        "columnBegin": 16,
+        "lineEnd": 40,
+        "columnEnd": 17
+      },
+      "text": { "key": "anonymous" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 42,
+        "columnBegin": 5,
+        "lineEnd": 42,
+        "columnEnd": 8
+      },
+      "text": { "key": "anonymous" }
     }
   }
 ]

--- a/glean/lang/rust/tests/cases/xrefs/uses.out
+++ b/glean/lang/rust/tests/cases/xrefs/uses.out
@@ -8,11 +8,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 11,
-                "columnBegin": 14,
-                "lineEnd": 11,
-                "columnEnd": 15
-              }
+                "lineBegin": 12,
+                "columnBegin": 15,
+                "lineEnd": 12,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -21,341 +22,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 12,
-            "columnBegin": 10,
-            "lineEnd": 12,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 3,
-                "lineEnd": 15,
-                "columnEnd": 8
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 12,
-            "columnBegin": 4,
-            "lineEnd": 12,
-            "columnEnd": 9
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 3,
-                "lineEnd": 15,
-                "columnEnd": 8
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 29,
-            "lineEnd": 16,
-            "columnEnd": 34
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 9,
-                "lineEnd": 15,
-                "columnEnd": 10
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 7,
-            "lineEnd": 16,
-            "columnEnd": 8
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 9,
-                "lineEnd": 15,
-                "columnEnd": 10
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 35,
-            "lineEnd": 16,
-            "columnEnd": 36
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 9,
-                "lineEnd": 15,
-                "columnEnd": 10
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 48,
-            "lineEnd": 16,
-            "columnEnd": 49
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 17,
-                "lineEnd": 15,
-                "columnEnd": 20
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 16,
-            "lineEnd": 16,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 17,
-                "lineEnd": 15,
-                "columnEnd": 20
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 42,
-            "lineEnd": 16,
-            "columnEnd": 45
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 21,
-                "columnBegin": 14,
-                "lineEnd": 21,
-                "columnEnd": 15
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 23,
-            "columnBegin": 16,
-            "lineEnd": 23,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 22,
-                "columnBegin": 12,
-                "lineEnd": 22,
-                "columnEnd": 15
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 26,
-            "columnBegin": 19,
-            "lineEnd": 26,
-            "columnEnd": 22
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 22,
-                "columnBegin": 12,
-                "lineEnd": 22,
-                "columnEnd": 15
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 28,
-            "columnBegin": 12,
-            "lineEnd": 28,
-            "columnEnd": 15
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 23,
-                "columnBegin": 12,
-                "lineEnd": 23,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 25,
+            "lineBegin": 13,
             "columnBegin": 11,
-            "lineEnd": 25,
+            "lineEnd": 13,
             "columnEnd": 12
-          }
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -368,11 +40,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 23,
-                "columnBegin": 12,
-                "lineEnd": 23,
-                "columnEnd": 13
-              }
+                "lineBegin": 16,
+                "columnBegin": 4,
+                "lineEnd": 16,
+                "columnEnd": 9
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -381,11 +54,236 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 28,
-            "columnBegin": 19,
-            "lineEnd": 28,
-            "columnEnd": 20
+            "lineBegin": 13,
+            "columnBegin": 5,
+            "lineEnd": 13,
+            "columnEnd": 10
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 4,
+                "lineEnd": 16,
+                "columnEnd": 9
+              },
+              "text": { "key": "anonymous" }
+            }
           }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 30,
+            "lineEnd": 17,
+            "columnEnd": 35
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 10,
+                "lineEnd": 16,
+                "columnEnd": 11
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 8,
+            "lineEnd": 17,
+            "columnEnd": 9
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 10,
+                "lineEnd": 16,
+                "columnEnd": 11
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 36,
+            "lineEnd": 17,
+            "columnEnd": 37
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 10,
+                "lineEnd": 16,
+                "columnEnd": 11
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 49,
+            "lineEnd": 17,
+            "columnEnd": 50
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 18,
+                "lineEnd": 16,
+                "columnEnd": 21
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 17,
+            "lineEnd": 17,
+            "columnEnd": 20
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 18,
+                "lineEnd": 16,
+                "columnEnd": 21
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 43,
+            "lineEnd": 17,
+            "columnEnd": 46
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 22,
+                "columnBegin": 15,
+                "lineEnd": 22,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 24,
+            "columnBegin": 17,
+            "lineEnd": 24,
+            "columnEnd": 18
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -399,10 +297,43 @@
             "key": {
               "range": {
                 "lineBegin": 23,
-                "columnBegin": 12,
+                "columnBegin": 13,
                 "lineEnd": 23,
-                "columnEnd": 13
-              }
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 27,
+            "columnBegin": 20,
+            "lineEnd": 27,
+            "columnEnd": 23
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 23,
+                "columnBegin": 13,
+                "lineEnd": 23,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -412,10 +343,11 @@
         "key": {
           "range": {
             "lineBegin": 29,
-            "columnBegin": 12,
+            "columnBegin": 13,
             "lineEnd": 29,
-            "columnEnd": 13
-          }
+            "columnEnd": 16
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -428,11 +360,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 36,
-                "columnBegin": 14,
-                "lineEnd": 36,
-                "columnEnd": 15
-              }
+                "lineBegin": 24,
+                "columnBegin": 13,
+                "lineEnd": 24,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -441,11 +374,76 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 38,
-            "columnBegin": 17,
-            "lineEnd": 38,
-            "columnEnd": 18
+            "lineBegin": 26,
+            "columnBegin": 12,
+            "lineEnd": 26,
+            "columnEnd": 13
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 24,
+                "columnBegin": 13,
+                "lineEnd": 24,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
+            }
           }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 29,
+            "columnBegin": 20,
+            "lineEnd": 29,
+            "columnEnd": 21
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 24,
+                "columnBegin": 13,
+                "lineEnd": 24,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 30,
+            "columnBegin": 13,
+            "lineEnd": 30,
+            "columnEnd": 14
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -459,10 +457,11 @@
             "key": {
               "range": {
                 "lineBegin": 37,
-                "columnBegin": 12,
+                "columnBegin": 15,
                 "lineEnd": 37,
-                "columnEnd": 15
-              }
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -472,40 +471,11 @@
         "key": {
           "range": {
             "lineBegin": 39,
-            "columnBegin": 8,
+            "columnBegin": 18,
             "lineEnd": 39,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 37,
-                "columnBegin": 12,
-                "lineEnd": 37,
-                "columnEnd": 15
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 41,
-            "columnBegin": 4,
-            "lineEnd": 41,
-            "columnEnd": 7
-          }
+            "columnEnd": 19
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }
@@ -519,10 +489,11 @@
             "key": {
               "range": {
                 "lineBegin": 38,
-                "columnBegin": 8,
+                "columnBegin": 13,
                 "lineEnd": 38,
-                "columnEnd": 9
-              }
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -531,11 +502,76 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 39,
-            "columnBegin": 15,
-            "lineEnd": 39,
-            "columnEnd": 16
+            "lineBegin": 40,
+            "columnBegin": 9,
+            "lineEnd": 40,
+            "columnEnd": 12
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 38,
+                "columnBegin": 13,
+                "lineEnd": 38,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
+            }
           }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 42,
+            "columnBegin": 5,
+            "lineEnd": 42,
+            "columnEnd": 8
+          },
+          "text": { "key": "anonymous" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 39,
+                "columnBegin": 9,
+                "lineEnd": 39,
+                "columnEnd": 10
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      },
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 40,
+            "columnBegin": 16,
+            "lineEnd": 40,
+            "columnEnd": 17
+          },
+          "text": { "key": "anonymous" }
         }
       }
     }

--- a/glean/lang/rust/tests/cases/xrefs/xrefs.out
+++ b/glean/lang/rust/tests/cases/xrefs/xrefs.out
@@ -6,11 +6,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 12,
-            "columnBegin": 4,
-            "lineEnd": 12,
-            "columnEnd": 9
-          }
+            "lineBegin": 13,
+            "columnBegin": 5,
+            "lineEnd": 13,
+            "columnEnd": 10
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -19,11 +20,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 3,
-                "lineEnd": 15,
-                "columnEnd": 8
-              }
+                "lineBegin": 16,
+                "columnBegin": 4,
+                "lineEnd": 16,
+                "columnEnd": 9
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -36,251 +38,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 12,
-            "columnBegin": 10,
-            "lineEnd": 12,
-            "columnEnd": 11
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 11,
-                "columnBegin": 14,
-                "lineEnd": 11,
-                "columnEnd": 15
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 7,
-            "lineEnd": 16,
-            "columnEnd": 8
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 9,
-                "lineEnd": 15,
-                "columnEnd": 10
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 16,
-            "lineEnd": 16,
-            "columnEnd": 19
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 17,
-                "lineEnd": 15,
-                "columnEnd": 20
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 29,
-            "lineEnd": 16,
-            "columnEnd": 34
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 3,
-                "lineEnd": 15,
-                "columnEnd": 8
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 35,
-            "lineEnd": 16,
-            "columnEnd": 36
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 9,
-                "lineEnd": 15,
-                "columnEnd": 10
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 42,
-            "lineEnd": 16,
-            "columnEnd": 45
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 17,
-                "lineEnd": 15,
-                "columnEnd": 20
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 48,
-            "lineEnd": 16,
-            "columnEnd": 49
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 9,
-                "lineEnd": 15,
-                "columnEnd": 10
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 23,
-            "columnBegin": 16,
-            "lineEnd": 23,
-            "columnEnd": 17
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 21,
-                "columnBegin": 14,
-                "lineEnd": 21,
-                "columnEnd": 15
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 25,
+            "lineBegin": 13,
             "columnBegin": 11,
-            "lineEnd": 25,
+            "lineEnd": 13,
             "columnEnd": 12
-          }
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -289,11 +52,236 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 23,
-                "columnBegin": 12,
-                "lineEnd": 23,
-                "columnEnd": 13
-              }
+                "lineBegin": 12,
+                "columnBegin": 15,
+                "lineEnd": 12,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 8,
+            "lineEnd": 17,
+            "columnEnd": 9
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 10,
+                "lineEnd": 16,
+                "columnEnd": 11
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 17,
+            "lineEnd": 17,
+            "columnEnd": 20
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 18,
+                "lineEnd": 16,
+                "columnEnd": 21
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 30,
+            "lineEnd": 17,
+            "columnEnd": 35
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 4,
+                "lineEnd": 16,
+                "columnEnd": 9
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 36,
+            "lineEnd": 17,
+            "columnEnd": 37
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 10,
+                "lineEnd": 16,
+                "columnEnd": 11
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 43,
+            "lineEnd": 17,
+            "columnEnd": 46
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 18,
+                "lineEnd": 16,
+                "columnEnd": 21
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 49,
+            "lineEnd": 17,
+            "columnEnd": 50
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 10,
+                "lineEnd": 16,
+                "columnEnd": 11
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 24,
+            "columnBegin": 17,
+            "lineEnd": 24,
+            "columnEnd": 18
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 22,
+                "columnBegin": 15,
+                "lineEnd": 22,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -307,40 +295,11 @@
         "key": {
           "range": {
             "lineBegin": 26,
-            "columnBegin": 19,
-            "lineEnd": 26,
-            "columnEnd": 22
-          }
-        }
-      },
-      "target": {
-        "key": {
-          "file": { "key": "src/lib.rs" },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 22,
-                "columnBegin": 12,
-                "lineEnd": 22,
-                "columnEnd": 15
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "src/lib.rs" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 28,
             "columnBegin": 12,
-            "lineEnd": 28,
-            "columnEnd": 15
-          }
+            "lineEnd": 26,
+            "columnEnd": 13
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -349,11 +308,12 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 22,
-                "columnBegin": 12,
-                "lineEnd": 22,
-                "columnEnd": 15
-              }
+                "lineBegin": 24,
+                "columnBegin": 13,
+                "lineEnd": 24,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -366,11 +326,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 28,
-            "columnBegin": 19,
-            "lineEnd": 28,
-            "columnEnd": 20
-          }
+            "lineBegin": 27,
+            "columnBegin": 20,
+            "lineEnd": 27,
+            "columnEnd": 23
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -380,10 +341,11 @@
             "key": {
               "range": {
                 "lineBegin": 23,
-                "columnBegin": 12,
+                "columnBegin": 13,
                 "lineEnd": 23,
-                "columnEnd": 13
-              }
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -397,10 +359,11 @@
         "key": {
           "range": {
             "lineBegin": 29,
-            "columnBegin": 12,
+            "columnBegin": 13,
             "lineEnd": 29,
-            "columnEnd": 13
-          }
+            "columnEnd": 16
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -410,10 +373,11 @@
             "key": {
               "range": {
                 "lineBegin": 23,
-                "columnBegin": 12,
+                "columnBegin": 13,
                 "lineEnd": 23,
-                "columnEnd": 13
-              }
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -426,11 +390,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 38,
-            "columnBegin": 17,
-            "lineEnd": 38,
-            "columnEnd": 18
-          }
+            "lineBegin": 29,
+            "columnBegin": 20,
+            "lineEnd": 29,
+            "columnEnd": 21
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -439,11 +404,44 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 36,
-                "columnBegin": 14,
-                "lineEnd": 36,
-                "columnEnd": 15
-              }
+                "lineBegin": 24,
+                "columnBegin": 13,
+                "lineEnd": 24,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 30,
+            "columnBegin": 13,
+            "lineEnd": 30,
+            "columnEnd": 14
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 24,
+                "columnBegin": 13,
+                "lineEnd": 24,
+                "columnEnd": 14
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -457,10 +455,11 @@
         "key": {
           "range": {
             "lineBegin": 39,
-            "columnBegin": 8,
+            "columnBegin": 18,
             "lineEnd": 39,
-            "columnEnd": 11
-          }
+            "columnEnd": 19
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -470,10 +469,11 @@
             "key": {
               "range": {
                 "lineBegin": 37,
-                "columnBegin": 12,
+                "columnBegin": 15,
                 "lineEnd": 37,
-                "columnEnd": 15
-              }
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -486,11 +486,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 39,
-            "columnBegin": 15,
-            "lineEnd": 39,
-            "columnEnd": 16
-          }
+            "lineBegin": 40,
+            "columnBegin": 9,
+            "lineEnd": 40,
+            "columnEnd": 12
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -500,10 +501,11 @@
             "key": {
               "range": {
                 "lineBegin": 38,
-                "columnBegin": 8,
+                "columnBegin": 13,
                 "lineEnd": 38,
-                "columnEnd": 9
-              }
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }
@@ -516,11 +518,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 41,
-            "columnBegin": 4,
-            "lineEnd": 41,
-            "columnEnd": 7
-          }
+            "lineBegin": 40,
+            "columnBegin": 16,
+            "lineEnd": 40,
+            "columnEnd": 17
+          },
+          "text": { "key": "anonymous" }
         }
       },
       "target": {
@@ -529,11 +532,44 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 37,
-                "columnBegin": 12,
-                "lineEnd": 37,
-                "columnEnd": 15
-              }
+                "lineBegin": 39,
+                "columnBegin": 9,
+                "lineEnd": 39,
+                "columnEnd": 10
+              },
+              "text": { "key": "anonymous" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "src/lib.rs" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 42,
+            "columnBegin": 5,
+            "lineEnd": 42,
+            "columnEnd": 8
+          },
+          "text": { "key": "anonymous" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": { "key": "src/lib.rs" },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 38,
+                "columnBegin": 13,
+                "lineEnd": 38,
+                "columnEnd": 16
+              },
+              "text": { "key": "anonymous" }
             }
           }
         }

--- a/glean/lang/typescript/tests/cases/xrefs/definition.out
+++ b/glean/lang/typescript/tests/cases/xrefs/definition.out
@@ -6,16 +6,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 0,
-            "columnBegin": 0,
-            "lineEnd": 0,
-            "columnEnd": 0
+            "lineBegin": 1,
+            "columnBegin": 1,
+            "lineEnd": 1,
+            "columnEnd": 1
           },
           "fullRange": {
-            "lineBegin": 0,
-            "columnBegin": 0,
-            "lineEnd": 52,
-            "columnEnd": 0
+            "lineBegin": 1,
+            "columnBegin": 1,
+            "lineEnd": 53,
+            "columnEnd": 1
           },
           "text": { "key": "" }
         }
@@ -28,16 +28,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 8,
-            "columnBegin": 7,
-            "lineEnd": 8,
-            "columnEnd": 9
+            "lineBegin": 9,
+            "columnBegin": 8,
+            "lineEnd": 9,
+            "columnEnd": 10
           },
           "fullRange": {
-            "lineBegin": 8,
-            "columnBegin": 7,
-            "lineEnd": 8,
-            "columnEnd": 9
+            "lineBegin": 9,
+            "columnBegin": 8,
+            "lineEnd": 9,
+            "columnEnd": 10
           },
           "text": { "key": "fs" }
         }
@@ -50,16 +50,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 9,
-            "columnBegin": 7,
-            "lineEnd": 9,
-            "columnEnd": 9
+            "lineBegin": 10,
+            "columnBegin": 8,
+            "lineEnd": 10,
+            "columnEnd": 10
           },
           "fullRange": {
-            "lineBegin": 9,
-            "columnBegin": 7,
-            "lineEnd": 9,
-            "columnEnd": 9
+            "lineBegin": 10,
+            "columnBegin": 8,
+            "lineEnd": 10,
+            "columnEnd": 10
           },
           "text": { "key": "os" }
         }
@@ -72,16 +72,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 10,
-            "columnBegin": 7,
-            "lineEnd": 10,
-            "columnEnd": 11
+            "lineBegin": 11,
+            "columnBegin": 8,
+            "lineEnd": 11,
+            "columnEnd": 12
           },
           "fullRange": {
-            "lineBegin": 10,
-            "columnBegin": 7,
-            "lineEnd": 10,
-            "columnEnd": 11
+            "lineBegin": 11,
+            "columnBegin": 8,
+            "lineEnd": 11,
+            "columnEnd": 12
           },
           "text": { "key": "path" }
         }
@@ -94,16 +94,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 11,
-            "columnBegin": 7,
-            "lineEnd": 11,
-            "columnEnd": 12
+            "lineBegin": 12,
+            "columnBegin": 8,
+            "lineEnd": 12,
+            "columnEnd": 13
           },
           "fullRange": {
-            "lineBegin": 11,
-            "columnBegin": 7,
-            "lineEnd": 11,
-            "columnEnd": 12
+            "lineBegin": 12,
+            "columnBegin": 8,
+            "lineEnd": 12,
+            "columnEnd": 13
           },
           "text": { "key": "shell" }
         }
@@ -116,16 +116,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 13,
-            "columnBegin": 6,
-            "lineEnd": 13,
-            "columnEnd": 9
+            "lineBegin": 14,
+            "columnBegin": 7,
+            "lineEnd": 14,
+            "columnEnd": 10
           },
           "fullRange": {
-            "lineBegin": 13,
-            "columnBegin": 0,
-            "lineEnd": 41,
-            "columnEnd": 3
+            "lineBegin": 14,
+            "columnBegin": 1,
+            "lineEnd": 42,
+            "columnEnd": 4
           },
           "text": { "key": "Git" }
         }
@@ -138,16 +138,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 14,
-            "columnBegin": 22,
-            "lineEnd": 14,
-            "columnEnd": 25
+            "lineBegin": 15,
+            "columnBegin": 23,
+            "lineEnd": 15,
+            "columnEnd": 26
           },
           "fullRange": {
-            "lineBegin": 14,
-            "columnBegin": 14,
-            "lineEnd": 14,
-            "columnEnd": 33
+            "lineBegin": 15,
+            "columnBegin": 15,
+            "lineEnd": 15,
+            "columnEnd": 34
           },
           "text": { "key": "dir" }
         }
@@ -160,16 +160,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 15,
-            "columnBegin": 10,
-            "lineEnd": 15,
-            "columnEnd": 13
+            "lineBegin": 16,
+            "columnBegin": 11,
+            "lineEnd": 16,
+            "columnEnd": 14
           },
           "fullRange": {
-            "lineBegin": 15,
-            "columnBegin": 10,
-            "lineEnd": 15,
-            "columnEnd": 64
+            "lineBegin": 16,
+            "columnBegin": 11,
+            "lineEnd": 16,
+            "columnEnd": 65
           },
           "text": { "key": "res" }
         }
@@ -182,16 +182,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 15,
-            "columnBegin": 40,
-            "lineEnd": 15,
-            "columnEnd": 43
+            "lineBegin": 16,
+            "columnBegin": 41,
+            "lineEnd": 16,
+            "columnEnd": 44
           },
           "fullRange": {
-            "lineBegin": 15,
-            "columnBegin": 40,
-            "lineEnd": 15,
-            "columnEnd": 48
+            "lineBegin": 16,
+            "columnBegin": 41,
+            "lineEnd": 16,
+            "columnEnd": 49
           },
           "text": { "key": "cwd" }
         }
@@ -204,105 +204,17 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 15,
-            "columnBegin": 50,
-            "lineEnd": 15,
-            "columnEnd": 56
+            "lineBegin": 16,
+            "columnBegin": 51,
+            "lineEnd": 16,
+            "columnEnd": 57
           },
           "fullRange": {
-            "lineBegin": 15,
-            "columnBegin": 50,
-            "lineEnd": 15,
-            "columnEnd": 62
-          },
-          "text": { "key": "silent" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 23,
-            "columnBegin": 6,
-            "lineEnd": 23,
-            "columnEnd": 9
-          },
-          "fullRange": {
-            "lineBegin": 23,
-            "columnBegin": 6,
-            "lineEnd": 23,
-            "columnEnd": 14
-          },
-          "text": { "key": "cwd" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 24,
-            "columnBegin": 6,
-            "lineEnd": 24,
-            "columnEnd": 12
-          },
-          "fullRange": {
-            "lineBegin": 24,
-            "columnBegin": 6,
-            "lineEnd": 24,
-            "columnEnd": 18
-          },
-          "text": { "key": "silent" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 26,
-            "columnBegin": 47,
-            "lineEnd": 26,
-            "columnEnd": 50
-          },
-          "fullRange": {
-            "lineBegin": 26,
-            "columnBegin": 47,
-            "lineEnd": 26,
-            "columnEnd": 55
-          },
-          "text": { "key": "cwd" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 26,
-            "columnBegin": 57,
-            "lineEnd": 26,
+            "lineBegin": 16,
+            "columnBegin": 51,
+            "lineEnd": 16,
             "columnEnd": 63
           },
-          "fullRange": {
-            "lineBegin": 26,
-            "columnBegin": 57,
-            "lineEnd": 26,
-            "columnEnd": 69
-          },
           "text": { "key": "silent" }
         }
       }
@@ -314,16 +226,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 29,
-            "columnBegin": 6,
-            "lineEnd": 29,
-            "columnEnd": 9
+            "lineBegin": 24,
+            "columnBegin": 7,
+            "lineEnd": 24,
+            "columnEnd": 10
           },
           "fullRange": {
-            "lineBegin": 29,
-            "columnBegin": 6,
-            "lineEnd": 29,
-            "columnEnd": 14
+            "lineBegin": 24,
+            "columnBegin": 7,
+            "lineEnd": 24,
+            "columnEnd": 15
           },
           "text": { "key": "cwd" }
         }
@@ -336,16 +248,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 30,
-            "columnBegin": 6,
-            "lineEnd": 30,
-            "columnEnd": 12
+            "lineBegin": 25,
+            "columnBegin": 7,
+            "lineEnd": 25,
+            "columnEnd": 13
           },
           "fullRange": {
-            "lineBegin": 30,
-            "columnBegin": 6,
-            "lineEnd": 30,
-            "columnEnd": 18
+            "lineBegin": 25,
+            "columnBegin": 7,
+            "lineEnd": 25,
+            "columnEnd": 19
           },
           "text": { "key": "silent" }
         }
@@ -358,16 +270,104 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 33,
-            "columnBegin": 2,
-            "lineEnd": 33,
-            "columnEnd": 8
+            "lineBegin": 27,
+            "columnBegin": 48,
+            "lineEnd": 27,
+            "columnEnd": 51
           },
           "fullRange": {
-            "lineBegin": 33,
-            "columnBegin": 2,
-            "lineEnd": 40,
-            "columnEnd": 5
+            "lineBegin": 27,
+            "columnBegin": 48,
+            "lineEnd": 27,
+            "columnEnd": 56
+          },
+          "text": { "key": "cwd" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 27,
+            "columnBegin": 58,
+            "lineEnd": 27,
+            "columnEnd": 64
+          },
+          "fullRange": {
+            "lineBegin": 27,
+            "columnBegin": 58,
+            "lineEnd": 27,
+            "columnEnd": 70
+          },
+          "text": { "key": "silent" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 30,
+            "columnBegin": 7,
+            "lineEnd": 30,
+            "columnEnd": 10
+          },
+          "fullRange": {
+            "lineBegin": 30,
+            "columnBegin": 7,
+            "lineEnd": 30,
+            "columnEnd": 15
+          },
+          "text": { "key": "cwd" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 31,
+            "columnBegin": 7,
+            "lineEnd": 31,
+            "columnEnd": 13
+          },
+          "fullRange": {
+            "lineBegin": 31,
+            "columnBegin": 7,
+            "lineEnd": 31,
+            "columnEnd": 19
+          },
+          "text": { "key": "silent" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 34,
+            "columnBegin": 3,
+            "lineEnd": 34,
+            "columnEnd": 9
+          },
+          "fullRange": {
+            "lineBegin": 34,
+            "columnBegin": 3,
+            "lineEnd": 41,
+            "columnEnd": 6
           },
           "text": { "key": "commit" }
         }
@@ -380,16 +380,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 33,
-            "columnBegin": 9,
-            "lineEnd": 33,
-            "columnEnd": 12
+            "lineBegin": 34,
+            "columnBegin": 10,
+            "lineEnd": 34,
+            "columnEnd": 13
           },
           "fullRange": {
-            "lineBegin": 33,
-            "columnBegin": 9,
-            "lineEnd": 33,
-            "columnEnd": 20
+            "lineBegin": 34,
+            "columnBegin": 10,
+            "lineEnd": 34,
+            "columnEnd": 21
           },
           "text": { "key": "msg" }
         }
@@ -402,16 +402,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 33,
-            "columnBegin": 22,
-            "lineEnd": 33,
-            "columnEnd": 26
+            "lineBegin": 34,
+            "columnBegin": 23,
+            "lineEnd": 34,
+            "columnEnd": 27
           },
           "fullRange": {
-            "lineBegin": 33,
-            "columnBegin": 22,
-            "lineEnd": 33,
-            "columnEnd": 34
+            "lineBegin": 34,
+            "columnBegin": 23,
+            "lineEnd": 34,
+            "columnEnd": 35
           },
           "text": { "key": "date" }
         }
@@ -424,16 +424,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 33,
-            "columnBegin": 36,
-            "lineEnd": 33,
-            "columnEnd": 42
+            "lineBegin": 34,
+            "columnBegin": 37,
+            "lineEnd": 34,
+            "columnEnd": 43
           },
           "fullRange": {
-            "lineBegin": 33,
-            "columnBegin": 36,
-            "lineEnd": 33,
-            "columnEnd": 50
+            "lineBegin": 34,
+            "columnBegin": 37,
+            "lineEnd": 34,
+            "columnEnd": 51
           },
           "text": { "key": "author" }
         }
@@ -446,16 +446,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 34,
-            "columnBegin": 10,
-            "lineEnd": 34,
-            "columnEnd": 16
+            "lineBegin": 35,
+            "columnBegin": 11,
+            "lineEnd": 35,
+            "columnEnd": 17
           },
           "fullRange": {
-            "lineBegin": 34,
-            "columnBegin": 10,
-            "lineEnd": 34,
-            "columnEnd": 73
+            "lineBegin": 35,
+            "columnBegin": 11,
+            "lineEnd": 35,
+            "columnEnd": 74
           },
           "text": { "key": "addRes" }
         }
@@ -468,16 +468,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 34,
-            "columnBegin": 44,
-            "lineEnd": 34,
-            "columnEnd": 47
+            "lineBegin": 35,
+            "columnBegin": 45,
+            "lineEnd": 35,
+            "columnEnd": 48
           },
           "fullRange": {
-            "lineBegin": 34,
-            "columnBegin": 44,
-            "lineEnd": 34,
-            "columnEnd": 57
+            "lineBegin": 35,
+            "columnBegin": 45,
+            "lineEnd": 35,
+            "columnEnd": 58
           },
           "text": { "key": "cwd" }
         }
@@ -490,16 +490,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 34,
-            "columnBegin": 59,
-            "lineEnd": 34,
-            "columnEnd": 65
+            "lineBegin": 35,
+            "columnBegin": 60,
+            "lineEnd": 35,
+            "columnEnd": 66
           },
           "fullRange": {
-            "lineBegin": 34,
-            "columnBegin": 59,
-            "lineEnd": 34,
-            "columnEnd": 71
+            "lineBegin": 35,
+            "columnBegin": 60,
+            "lineEnd": 35,
+            "columnEnd": 72
           },
           "text": { "key": "silent" }
         }
@@ -512,16 +512,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 45,
-            "columnBegin": 16,
-            "lineEnd": 45,
-            "columnEnd": 30
+            "lineBegin": 46,
+            "columnBegin": 17,
+            "lineEnd": 46,
+            "columnEnd": 31
           },
           "fullRange": {
-            "lineBegin": 45,
-            "columnBegin": 0,
-            "lineEnd": 51,
-            "columnEnd": 1
+            "lineBegin": 46,
+            "columnBegin": 1,
+            "lineEnd": 52,
+            "columnEnd": 2
           },
           "text": { "key": "createTempRepo" }
         }
@@ -534,16 +534,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 45,
-            "columnBegin": 35,
-            "lineEnd": 45,
-            "columnEnd": 42
+            "lineBegin": 46,
+            "columnBegin": 36,
+            "lineEnd": 46,
+            "columnEnd": 43
           },
           "fullRange": {
-            "lineBegin": 45,
-            "columnBegin": 35,
-            "lineEnd": 45,
-            "columnEnd": 51
+            "lineBegin": 46,
+            "columnBegin": 36,
+            "lineEnd": 46,
+            "columnEnd": 52
           },
           "text": { "key": "repoDir" }
         }
@@ -556,16 +556,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 45,
-            "columnBegin": 52,
-            "lineEnd": 45,
-            "columnEnd": 55
+            "lineBegin": 46,
+            "columnBegin": 53,
+            "lineEnd": 46,
+            "columnEnd": 56
           },
           "fullRange": {
-            "lineBegin": 45,
-            "columnBegin": 52,
-            "lineEnd": 45,
-            "columnEnd": 60
+            "lineBegin": 46,
+            "columnBegin": 53,
+            "lineEnd": 46,
+            "columnEnd": 61
           },
           "text": { "key": "git" }
         }
@@ -578,16 +578,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 46,
-            "columnBegin": 8,
-            "lineEnd": 46,
-            "columnEnd": 15
+            "lineBegin": 47,
+            "columnBegin": 9,
+            "lineEnd": 47,
+            "columnEnd": 16
           },
           "fullRange": {
-            "lineBegin": 46,
-            "columnBegin": 8,
-            "lineEnd": 46,
-            "columnEnd": 73
+            "lineBegin": 47,
+            "columnBegin": 9,
+            "lineEnd": 47,
+            "columnEnd": 74
           },
           "text": { "key": "repoDir" }
         }
@@ -600,16 +600,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 48,
-            "columnBegin": 8,
-            "lineEnd": 48,
-            "columnEnd": 11
+            "lineBegin": 49,
+            "columnBegin": 9,
+            "lineEnd": 49,
+            "columnEnd": 12
           },
           "fullRange": {
-            "lineBegin": 48,
-            "columnBegin": 8,
-            "lineEnd": 48,
-            "columnEnd": 30
+            "lineBegin": 49,
+            "columnBegin": 9,
+            "lineEnd": 49,
+            "columnEnd": 31
           },
           "text": { "key": "git" }
         }
@@ -622,16 +622,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 50,
-            "columnBegin": 10,
-            "lineEnd": 50,
-            "columnEnd": 17
+            "lineBegin": 51,
+            "columnBegin": 11,
+            "lineEnd": 51,
+            "columnEnd": 18
           },
           "fullRange": {
-            "lineBegin": 50,
-            "columnBegin": 10,
-            "lineEnd": 50,
-            "columnEnd": 17
+            "lineBegin": 51,
+            "columnBegin": 11,
+            "lineEnd": 51,
+            "columnEnd": 18
           },
           "text": { "key": "repoDir" }
         }
@@ -644,16 +644,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 50,
-            "columnBegin": 19,
-            "lineEnd": 50,
-            "columnEnd": 22
+            "lineBegin": 51,
+            "columnBegin": 20,
+            "lineEnd": 51,
+            "columnEnd": 23
           },
           "fullRange": {
-            "lineBegin": 50,
-            "columnBegin": 19,
-            "lineEnd": 50,
-            "columnEnd": 22
+            "lineBegin": 51,
+            "columnBegin": 20,
+            "lineEnd": 51,
+            "columnEnd": 23
           },
           "text": { "key": "git" }
         }
@@ -666,16 +666,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 971,
-            "columnBegin": 10,
-            "lineEnd": 971,
-            "columnEnd": 15
+            "lineBegin": 972,
+            "columnBegin": 11,
+            "lineEnd": 972,
+            "columnEnd": 16
           },
           "fullRange": {
-            "lineBegin": 971,
-            "columnBegin": 0,
-            "lineEnd": 975,
-            "columnEnd": 1
+            "lineBegin": 972,
+            "columnBegin": 1,
+            "lineEnd": 976,
+            "columnEnd": 2
           },
           "text": { "key": "Error" }
         }
@@ -688,16 +688,16 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 983,
-            "columnBegin": 12,
-            "lineEnd": 983,
-            "columnEnd": 17
+            "lineBegin": 984,
+            "columnBegin": 13,
+            "lineEnd": 984,
+            "columnEnd": 18
           },
           "fullRange": {
-            "lineBegin": 983,
-            "columnBegin": 12,
-            "lineEnd": 983,
-            "columnEnd": 35
+            "lineBegin": 984,
+            "columnBegin": 13,
+            "lineEnd": 984,
+            "columnEnd": 36
           },
           "text": { "key": "Error" }
         }

--- a/glean/lang/typescript/tests/cases/xrefs/hovertext.out
+++ b/glean/lang/typescript/tests/cases/xrefs/hovertext.out
@@ -10,16 +10,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 8,
-                "columnBegin": 7,
-                "lineEnd": 8,
-                "columnEnd": 9
+                "lineBegin": 9,
+                "columnBegin": 8,
+                "lineEnd": 9,
+                "columnEnd": 10
               },
               "fullRange": {
-                "lineBegin": 8,
-                "columnBegin": 7,
-                "lineEnd": 8,
-                "columnEnd": 9
+                "lineBegin": 9,
+                "columnBegin": 8,
+                "lineEnd": 9,
+                "columnEnd": 10
               },
               "text": { "key": "fs" }
             }
@@ -39,16 +39,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 9,
-                "columnBegin": 7,
-                "lineEnd": 9,
-                "columnEnd": 9
+                "lineBegin": 10,
+                "columnBegin": 8,
+                "lineEnd": 10,
+                "columnEnd": 10
               },
               "fullRange": {
-                "lineBegin": 9,
-                "columnBegin": 7,
-                "lineEnd": 9,
-                "columnEnd": 9
+                "lineBegin": 10,
+                "columnBegin": 8,
+                "lineEnd": 10,
+                "columnEnd": 10
               },
               "text": { "key": "os" }
             }
@@ -68,16 +68,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 10,
-                "columnBegin": 7,
-                "lineEnd": 10,
-                "columnEnd": 11
+                "lineBegin": 11,
+                "columnBegin": 8,
+                "lineEnd": 11,
+                "columnEnd": 12
               },
               "fullRange": {
-                "lineBegin": 10,
-                "columnBegin": 7,
-                "lineEnd": 10,
-                "columnEnd": 11
+                "lineBegin": 11,
+                "columnBegin": 8,
+                "lineEnd": 11,
+                "columnEnd": 12
               },
               "text": { "key": "path" }
             }
@@ -97,16 +97,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
               "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
               "text": { "key": "shell" }
             }
@@ -126,16 +126,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 13,
-                "columnBegin": 6,
-                "lineEnd": 13,
-                "columnEnd": 9
+                "lineBegin": 14,
+                "columnBegin": 7,
+                "lineEnd": 14,
+                "columnEnd": 10
               },
               "fullRange": {
-                "lineBegin": 13,
-                "columnBegin": 0,
-                "lineEnd": 41,
-                "columnEnd": 3
+                "lineBegin": 14,
+                "columnBegin": 1,
+                "lineEnd": 42,
+                "columnEnd": 4
               },
               "text": { "key": "Git" }
             }
@@ -155,16 +155,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 26
               },
               "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 34
               },
               "text": { "key": "dir" }
             }
@@ -189,16 +189,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 13
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 14
               },
               "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 64
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 65
               },
               "text": { "key": "res" }
             }
@@ -220,16 +220,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 40,
-                "lineEnd": 15,
-                "columnEnd": 43
+                "lineBegin": 16,
+                "columnBegin": 41,
+                "lineEnd": 16,
+                "columnEnd": 44
               },
               "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 40,
-                "lineEnd": 15,
-                "columnEnd": 48
+                "lineBegin": 16,
+                "columnBegin": 41,
+                "lineEnd": 16,
+                "columnEnd": 49
               },
               "text": { "key": "cwd" }
             }
@@ -251,147 +251,17 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 50,
-                "lineEnd": 15,
-                "columnEnd": 56
+                "lineBegin": 16,
+                "columnBegin": 51,
+                "lineEnd": 16,
+                "columnEnd": 57
               },
               "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 50,
-                "lineEnd": 15,
-                "columnEnd": 62
-              },
-              "text": { "key": "silent" }
-            }
-          }
-        }
-      },
-      "hover": {
-        "key": {
-          "text": { "key": "(property) silent: boolean" },
-          "language": 49
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "defn": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 23,
-                "columnBegin": 6,
-                "lineEnd": 23,
-                "columnEnd": 9
-              },
-              "fullRange": {
-                "lineBegin": 23,
-                "columnBegin": 6,
-                "lineEnd": 23,
-                "columnEnd": 14
-              },
-              "text": { "key": "cwd" }
-            }
-          }
-        }
-      },
-      "hover": {
-        "key": { "text": { "key": "(property) cwd: string" }, "language": 49 }
-      }
-    }
-  },
-  {
-    "key": {
-      "defn": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 24,
-                "columnBegin": 6,
-                "lineEnd": 24,
-                "columnEnd": 12
-              },
-              "fullRange": {
-                "lineBegin": 24,
-                "columnBegin": 6,
-                "lineEnd": 24,
-                "columnEnd": 18
-              },
-              "text": { "key": "silent" }
-            }
-          }
-        }
-      },
-      "hover": {
-        "key": {
-          "text": { "key": "(property) silent: boolean" },
-          "language": 49
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "defn": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 26,
-                "columnBegin": 47,
-                "lineEnd": 26,
-                "columnEnd": 50
-              },
-              "fullRange": {
-                "lineBegin": 26,
-                "columnBegin": 47,
-                "lineEnd": 26,
-                "columnEnd": 55
-              },
-              "text": { "key": "cwd" }
-            }
-          }
-        }
-      },
-      "hover": {
-        "key": { "text": { "key": "(property) cwd: string" }, "language": 49 }
-      }
-    }
-  },
-  {
-    "key": {
-      "defn": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 26,
-                "columnBegin": 57,
-                "lineEnd": 26,
+                "lineBegin": 16,
+                "columnBegin": 51,
+                "lineEnd": 16,
                 "columnEnd": 63
               },
-              "fullRange": {
-                "lineBegin": 26,
-                "columnBegin": 57,
-                "lineEnd": 26,
-                "columnEnd": 69
-              },
               "text": { "key": "silent" }
             }
           }
@@ -415,16 +285,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 29,
-                "columnBegin": 6,
-                "lineEnd": 29,
-                "columnEnd": 9
+                "lineBegin": 24,
+                "columnBegin": 7,
+                "lineEnd": 24,
+                "columnEnd": 10
               },
               "fullRange": {
-                "lineBegin": 29,
-                "columnBegin": 6,
-                "lineEnd": 29,
-                "columnEnd": 14
+                "lineBegin": 24,
+                "columnBegin": 7,
+                "lineEnd": 24,
+                "columnEnd": 15
               },
               "text": { "key": "cwd" }
             }
@@ -446,16 +316,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 30,
-                "columnBegin": 6,
-                "lineEnd": 30,
-                "columnEnd": 12
+                "lineBegin": 25,
+                "columnBegin": 7,
+                "lineEnd": 25,
+                "columnEnd": 13
               },
               "fullRange": {
-                "lineBegin": 30,
-                "columnBegin": 6,
-                "lineEnd": 30,
-                "columnEnd": 18
+                "lineBegin": 25,
+                "columnBegin": 7,
+                "lineEnd": 25,
+                "columnEnd": 19
               },
               "text": { "key": "silent" }
             }
@@ -480,16 +350,146 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 33,
-                "columnBegin": 2,
-                "lineEnd": 33,
-                "columnEnd": 8
+                "lineBegin": 27,
+                "columnBegin": 48,
+                "lineEnd": 27,
+                "columnEnd": 51
               },
               "fullRange": {
-                "lineBegin": 33,
-                "columnBegin": 2,
-                "lineEnd": 40,
-                "columnEnd": 5
+                "lineBegin": 27,
+                "columnBegin": 48,
+                "lineEnd": 27,
+                "columnEnd": 56
+              },
+              "text": { "key": "cwd" }
+            }
+          }
+        }
+      },
+      "hover": {
+        "key": { "text": { "key": "(property) cwd: string" }, "language": 49 }
+      }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 27,
+                "columnBegin": 58,
+                "lineEnd": 27,
+                "columnEnd": 64
+              },
+              "fullRange": {
+                "lineBegin": 27,
+                "columnBegin": 58,
+                "lineEnd": 27,
+                "columnEnd": 70
+              },
+              "text": { "key": "silent" }
+            }
+          }
+        }
+      },
+      "hover": {
+        "key": {
+          "text": { "key": "(property) silent: boolean" },
+          "language": 49
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 30,
+                "columnBegin": 7,
+                "lineEnd": 30,
+                "columnEnd": 10
+              },
+              "fullRange": {
+                "lineBegin": 30,
+                "columnBegin": 7,
+                "lineEnd": 30,
+                "columnEnd": 15
+              },
+              "text": { "key": "cwd" }
+            }
+          }
+        }
+      },
+      "hover": {
+        "key": { "text": { "key": "(property) cwd: string" }, "language": 49 }
+      }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 31,
+                "columnBegin": 7,
+                "lineEnd": 31,
+                "columnEnd": 13
+              },
+              "fullRange": {
+                "lineBegin": 31,
+                "columnBegin": 7,
+                "lineEnd": 31,
+                "columnEnd": 19
+              },
+              "text": { "key": "silent" }
+            }
+          }
+        }
+      },
+      "hover": {
+        "key": {
+          "text": { "key": "(property) silent: boolean" },
+          "language": 49
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 34,
+                "columnBegin": 3,
+                "lineEnd": 34,
+                "columnEnd": 9
+              },
+              "fullRange": {
+                "lineBegin": 34,
+                "columnBegin": 3,
+                "lineEnd": 41,
+                "columnEnd": 6
               },
               "text": { "key": "commit" }
             }
@@ -516,16 +516,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 33,
-                "columnBegin": 9,
-                "lineEnd": 33,
-                "columnEnd": 12
+                "lineBegin": 34,
+                "columnBegin": 10,
+                "lineEnd": 34,
+                "columnEnd": 13
               },
               "fullRange": {
-                "lineBegin": 33,
-                "columnBegin": 9,
-                "lineEnd": 33,
-                "columnEnd": 20
+                "lineBegin": 34,
+                "columnBegin": 10,
+                "lineEnd": 34,
+                "columnEnd": 21
               },
               "text": { "key": "msg" }
             }
@@ -547,16 +547,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 33,
-                "columnBegin": 22,
-                "lineEnd": 33,
-                "columnEnd": 26
+                "lineBegin": 34,
+                "columnBegin": 23,
+                "lineEnd": 34,
+                "columnEnd": 27
               },
               "fullRange": {
-                "lineBegin": 33,
-                "columnBegin": 22,
-                "lineEnd": 33,
-                "columnEnd": 34
+                "lineBegin": 34,
+                "columnBegin": 23,
+                "lineEnd": 34,
+                "columnEnd": 35
               },
               "text": { "key": "date" }
             }
@@ -578,16 +578,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 33,
-                "columnBegin": 36,
-                "lineEnd": 33,
-                "columnEnd": 42
+                "lineBegin": 34,
+                "columnBegin": 37,
+                "lineEnd": 34,
+                "columnEnd": 43
               },
               "fullRange": {
-                "lineBegin": 33,
-                "columnBegin": 36,
-                "lineEnd": 33,
-                "columnEnd": 50
+                "lineBegin": 34,
+                "columnBegin": 37,
+                "lineEnd": 34,
+                "columnEnd": 51
               },
               "text": { "key": "author" }
             }
@@ -612,16 +612,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 16
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 17
               },
               "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 73
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 74
               },
               "text": { "key": "addRes" }
             }
@@ -643,16 +643,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 44,
-                "lineEnd": 34,
-                "columnEnd": 47
+                "lineBegin": 35,
+                "columnBegin": 45,
+                "lineEnd": 35,
+                "columnEnd": 48
               },
               "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 44,
-                "lineEnd": 34,
-                "columnEnd": 57
+                "lineBegin": 35,
+                "columnBegin": 45,
+                "lineEnd": 35,
+                "columnEnd": 58
               },
               "text": { "key": "cwd" }
             }
@@ -674,16 +674,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 59,
-                "lineEnd": 34,
-                "columnEnd": 65
+                "lineBegin": 35,
+                "columnBegin": 60,
+                "lineEnd": 35,
+                "columnEnd": 66
               },
               "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 59,
-                "lineEnd": 34,
-                "columnEnd": 71
+                "lineBegin": 35,
+                "columnBegin": 60,
+                "lineEnd": 35,
+                "columnEnd": 72
               },
               "text": { "key": "silent" }
             }
@@ -708,16 +708,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 45,
-                "columnBegin": 16,
-                "lineEnd": 45,
-                "columnEnd": 30
+                "lineBegin": 46,
+                "columnBegin": 17,
+                "lineEnd": 46,
+                "columnEnd": 31
               },
               "fullRange": {
-                "lineBegin": 45,
-                "columnBegin": 0,
-                "lineEnd": 51,
-                "columnEnd": 1
+                "lineBegin": 46,
+                "columnBegin": 1,
+                "lineEnd": 52,
+                "columnEnd": 2
               },
               "text": { "key": "createTempRepo" }
             }
@@ -744,16 +744,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 45,
-                "columnBegin": 35,
-                "lineEnd": 45,
-                "columnEnd": 42
+                "lineBegin": 46,
+                "columnBegin": 36,
+                "lineEnd": 46,
+                "columnEnd": 43
               },
               "fullRange": {
-                "lineBegin": 45,
-                "columnBegin": 35,
-                "lineEnd": 45,
-                "columnEnd": 51
+                "lineBegin": 46,
+                "columnBegin": 36,
+                "lineEnd": 46,
+                "columnEnd": 52
               },
               "text": { "key": "repoDir" }
             }
@@ -778,16 +778,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 45,
-                "columnBegin": 52,
-                "lineEnd": 45,
-                "columnEnd": 55
+                "lineBegin": 46,
+                "columnBegin": 53,
+                "lineEnd": 46,
+                "columnEnd": 56
               },
               "fullRange": {
-                "lineBegin": 45,
-                "columnBegin": 52,
-                "lineEnd": 45,
-                "columnEnd": 60
+                "lineBegin": 46,
+                "columnBegin": 53,
+                "lineEnd": 46,
+                "columnEnd": 61
               },
               "text": { "key": "git" }
             }
@@ -809,16 +809,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 46,
-                "columnBegin": 8,
-                "lineEnd": 46,
-                "columnEnd": 15
+                "lineBegin": 47,
+                "columnBegin": 9,
+                "lineEnd": 47,
+                "columnEnd": 16
               },
               "fullRange": {
-                "lineBegin": 46,
-                "columnBegin": 8,
-                "lineEnd": 46,
-                "columnEnd": 73
+                "lineBegin": 47,
+                "columnBegin": 9,
+                "lineEnd": 47,
+                "columnEnd": 74
               },
               "text": { "key": "repoDir" }
             }
@@ -840,16 +840,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 48,
-                "columnBegin": 8,
-                "lineEnd": 48,
-                "columnEnd": 11
+                "lineBegin": 49,
+                "columnBegin": 9,
+                "lineEnd": 49,
+                "columnEnd": 12
               },
               "fullRange": {
-                "lineBegin": 48,
-                "columnBegin": 8,
-                "lineEnd": 48,
-                "columnEnd": 30
+                "lineBegin": 49,
+                "columnBegin": 9,
+                "lineEnd": 49,
+                "columnEnd": 31
               },
               "text": { "key": "git" }
             }
@@ -871,16 +871,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 50,
-                "columnBegin": 10,
-                "lineEnd": 50,
-                "columnEnd": 17
+                "lineBegin": 51,
+                "columnBegin": 11,
+                "lineEnd": 51,
+                "columnEnd": 18
               },
               "fullRange": {
-                "lineBegin": 50,
-                "columnBegin": 10,
-                "lineEnd": 50,
-                "columnEnd": 17
+                "lineBegin": 51,
+                "columnBegin": 11,
+                "lineEnd": 51,
+                "columnEnd": 18
               },
               "text": { "key": "repoDir" }
             }
@@ -905,16 +905,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 50,
-                "columnBegin": 19,
-                "lineEnd": 50,
-                "columnEnd": 22
+                "lineBegin": 51,
+                "columnBegin": 20,
+                "lineEnd": 51,
+                "columnEnd": 23
               },
               "fullRange": {
-                "lineBegin": 50,
-                "columnBegin": 19,
-                "lineEnd": 50,
-                "columnEnd": 22
+                "lineBegin": 51,
+                "columnBegin": 20,
+                "lineEnd": 51,
+                "columnEnd": 23
               },
               "text": { "key": "git" }
             }
@@ -936,16 +936,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 971,
-                "columnBegin": 10,
-                "lineEnd": 971,
-                "columnEnd": 15
+                "lineBegin": 972,
+                "columnBegin": 11,
+                "lineEnd": 972,
+                "columnEnd": 16
               },
               "fullRange": {
-                "lineBegin": 971,
-                "columnBegin": 0,
-                "lineEnd": 975,
-                "columnEnd": 1
+                "lineBegin": 972,
+                "columnBegin": 1,
+                "lineEnd": 976,
+                "columnEnd": 2
               },
               "text": { "key": "Error" }
             }
@@ -967,16 +967,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 983,
-                "columnBegin": 12,
-                "lineEnd": 983,
-                "columnEnd": 17
+                "lineBegin": 984,
+                "columnBegin": 13,
+                "lineEnd": 984,
+                "columnEnd": 18
               },
               "fullRange": {
-                "lineBegin": 983,
-                "columnBegin": 12,
-                "lineEnd": 983,
-                "columnEnd": 35
+                "lineBegin": 984,
+                "columnBegin": 13,
+                "lineEnd": 984,
+                "columnEnd": 36
               },
               "text": { "key": "Error" }
             }

--- a/glean/lang/typescript/tests/cases/xrefs/range.out
+++ b/glean/lang/typescript/tests/cases/xrefs/range.out
@@ -3,16 +3,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 0,
-        "columnBegin": 0,
-        "lineEnd": 0,
-        "columnEnd": 0
+        "lineBegin": 1,
+        "columnBegin": 1,
+        "lineEnd": 1,
+        "columnEnd": 1
       },
       "fullRange": {
-        "lineBegin": 0,
-        "columnBegin": 0,
-        "lineEnd": 52,
-        "columnEnd": 0
+        "lineBegin": 1,
+        "columnBegin": 1,
+        "lineEnd": 53,
+        "columnEnd": 1
       },
       "text": { "key": "" }
     }
@@ -20,16 +20,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 8,
-        "columnBegin": 7,
-        "lineEnd": 8,
-        "columnEnd": 9
+        "lineBegin": 9,
+        "columnBegin": 8,
+        "lineEnd": 9,
+        "columnEnd": 10
       },
       "fullRange": {
-        "lineBegin": 8,
-        "columnBegin": 7,
-        "lineEnd": 8,
-        "columnEnd": 9
+        "lineBegin": 9,
+        "columnBegin": 8,
+        "lineEnd": 9,
+        "columnEnd": 10
       },
       "text": { "key": "fs" }
     }
@@ -37,16 +37,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 9,
-        "columnBegin": 7,
-        "lineEnd": 9,
-        "columnEnd": 9
+        "lineBegin": 10,
+        "columnBegin": 8,
+        "lineEnd": 10,
+        "columnEnd": 10
       },
       "fullRange": {
-        "lineBegin": 9,
-        "columnBegin": 7,
-        "lineEnd": 9,
-        "columnEnd": 9
+        "lineBegin": 10,
+        "columnBegin": 8,
+        "lineEnd": 10,
+        "columnEnd": 10
       },
       "text": { "key": "os" }
     }
@@ -54,16 +54,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 10,
-        "columnBegin": 7,
-        "lineEnd": 10,
-        "columnEnd": 11
+        "lineBegin": 11,
+        "columnBegin": 8,
+        "lineEnd": 11,
+        "columnEnd": 12
       },
       "fullRange": {
-        "lineBegin": 10,
-        "columnBegin": 7,
-        "lineEnd": 10,
-        "columnEnd": 11
+        "lineBegin": 11,
+        "columnBegin": 8,
+        "lineEnd": 11,
+        "columnEnd": 12
       },
       "text": { "key": "path" }
     }
@@ -71,16 +71,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 11,
-        "columnBegin": 7,
-        "lineEnd": 11,
-        "columnEnd": 12
+        "lineBegin": 12,
+        "columnBegin": 8,
+        "lineEnd": 12,
+        "columnEnd": 13
       },
       "fullRange": {
-        "lineBegin": 11,
-        "columnBegin": 7,
-        "lineEnd": 11,
-        "columnEnd": 12
+        "lineBegin": 12,
+        "columnBegin": 8,
+        "lineEnd": 12,
+        "columnEnd": 13
       },
       "text": { "key": "shell" }
     }
@@ -88,16 +88,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 13,
-        "columnBegin": 6,
-        "lineEnd": 13,
-        "columnEnd": 9
+        "lineBegin": 14,
+        "columnBegin": 7,
+        "lineEnd": 14,
+        "columnEnd": 10
       },
       "fullRange": {
-        "lineBegin": 13,
-        "columnBegin": 0,
-        "lineEnd": 41,
-        "columnEnd": 3
+        "lineBegin": 14,
+        "columnBegin": 1,
+        "lineEnd": 42,
+        "columnEnd": 4
       },
       "text": { "key": "Git" }
     }
@@ -105,10 +105,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 14,
-        "columnBegin": 2,
-        "lineEnd": 32,
-        "columnEnd": 3
+        "lineBegin": 15,
+        "columnBegin": 3,
+        "lineEnd": 33,
+        "columnEnd": 4
       },
       "text": {
         "key": "constructor(private dir: string) {\u000a    const res = shell.exec('git init', {cwd: dir, silent: true});\u000a    if (res.code !== 0) {\u000a      throw new Error(`git init exited with code ${res.code}.\u000astderr: ${res.stderr}\u000astdout: ${res.stdout}`);\u000a    }\u000a    // Doesn't matter currently\u000a    shell.exec('git config user.email \"test@jc-verse.com\"', {\u000a      cwd: dir,\u000a      silent: true,\u000a    });\u000a    shell.exec('git config user.name \"Test\"', {cwd: dir, silent: true});\u000a\u000a    shell.exec('git commit --allow-empty -m \"First commit\"', {\u000a      cwd: dir,\u000a      silent: true,\u000a    });\u000a  }"
@@ -118,16 +118,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 14,
-        "columnBegin": 22,
-        "lineEnd": 14,
-        "columnEnd": 25
+        "lineBegin": 15,
+        "columnBegin": 23,
+        "lineEnd": 15,
+        "columnEnd": 26
       },
       "fullRange": {
-        "lineBegin": 14,
-        "columnBegin": 14,
-        "lineEnd": 14,
-        "columnEnd": 33
+        "lineBegin": 15,
+        "columnBegin": 15,
+        "lineEnd": 15,
+        "columnEnd": 34
       },
       "text": { "key": "dir" }
     }
@@ -135,16 +135,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 15,
-        "columnBegin": 10,
-        "lineEnd": 15,
-        "columnEnd": 13
+        "lineBegin": 16,
+        "columnBegin": 11,
+        "lineEnd": 16,
+        "columnEnd": 14
       },
       "fullRange": {
-        "lineBegin": 15,
-        "columnBegin": 10,
-        "lineEnd": 15,
-        "columnEnd": 64
+        "lineBegin": 16,
+        "columnBegin": 11,
+        "lineEnd": 16,
+        "columnEnd": 65
       },
       "text": { "key": "res" }
     }
@@ -152,10 +152,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 15,
-        "columnBegin": 16,
-        "lineEnd": 15,
-        "columnEnd": 21
+        "lineBegin": 16,
+        "columnBegin": 17,
+        "lineEnd": 16,
+        "columnEnd": 22
       },
       "text": { "key": "shell" }
     }
@@ -163,10 +163,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 15,
-        "columnBegin": 39,
-        "lineEnd": 15,
-        "columnEnd": 63
+        "lineBegin": 16,
+        "columnBegin": 40,
+        "lineEnd": 16,
+        "columnEnd": 64
       },
       "text": { "key": "{cwd: dir, silent: true}" }
     }
@@ -174,16 +174,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 15,
-        "columnBegin": 40,
-        "lineEnd": 15,
-        "columnEnd": 43
+        "lineBegin": 16,
+        "columnBegin": 41,
+        "lineEnd": 16,
+        "columnEnd": 44
       },
       "fullRange": {
-        "lineBegin": 15,
-        "columnBegin": 40,
-        "lineEnd": 15,
-        "columnEnd": 48
+        "lineBegin": 16,
+        "columnBegin": 41,
+        "lineEnd": 16,
+        "columnEnd": 49
       },
       "text": { "key": "cwd" }
     }
@@ -191,10 +191,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 15,
-        "columnBegin": 45,
-        "lineEnd": 15,
-        "columnEnd": 48
+        "lineBegin": 16,
+        "columnBegin": 46,
+        "lineEnd": 16,
+        "columnEnd": 49
       },
       "text": { "key": "dir" }
     }
@@ -202,16 +202,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 15,
-        "columnBegin": 50,
-        "lineEnd": 15,
-        "columnEnd": 56
+        "lineBegin": 16,
+        "columnBegin": 51,
+        "lineEnd": 16,
+        "columnEnd": 57
       },
       "fullRange": {
-        "lineBegin": 15,
-        "columnBegin": 50,
-        "lineEnd": 15,
-        "columnEnd": 62
+        "lineBegin": 16,
+        "columnBegin": 51,
+        "lineEnd": 16,
+        "columnEnd": 63
       },
       "text": { "key": "silent" }
     }
@@ -219,32 +219,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 16,
-        "columnBegin": 8,
-        "lineEnd": 16,
-        "columnEnd": 11
-      },
-      "text": { "key": "res" }
-    }
-  },
-  {
-    "key": {
-      "range": {
         "lineBegin": 17,
-        "columnBegin": 16,
+        "columnBegin": 9,
         "lineEnd": 17,
-        "columnEnd": 21
-      },
-      "text": { "key": "Error" }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 17,
-        "columnBegin": 51,
-        "lineEnd": 17,
-        "columnEnd": 54
+        "columnEnd": 12
       },
       "text": { "key": "res" }
     }
@@ -253,9 +231,20 @@
     "key": {
       "range": {
         "lineBegin": 18,
-        "columnBegin": 10,
+        "columnBegin": 17,
         "lineEnd": 18,
-        "columnEnd": 13
+        "columnEnd": 22
+      },
+      "text": { "key": "Error" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 18,
+        "columnBegin": 52,
+        "lineEnd": 18,
+        "columnEnd": 55
       },
       "text": { "key": "res" }
     }
@@ -264,9 +253,9 @@
     "key": {
       "range": {
         "lineBegin": 19,
-        "columnBegin": 10,
+        "columnBegin": 11,
         "lineEnd": 19,
-        "columnEnd": 13
+        "columnEnd": 14
       },
       "text": { "key": "res" }
     }
@@ -274,10 +263,21 @@
   {
     "key": {
       "range": {
-        "lineBegin": 22,
-        "columnBegin": 4,
-        "lineEnd": 22,
-        "columnEnd": 9
+        "lineBegin": 20,
+        "columnBegin": 11,
+        "lineEnd": 20,
+        "columnEnd": 14
+      },
+      "text": { "key": "res" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 23,
+        "columnBegin": 5,
+        "lineEnd": 23,
+        "columnEnd": 10
       },
       "text": { "key": "shell" }
     }
@@ -285,10 +285,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 22,
-        "columnBegin": 60,
-        "lineEnd": 25,
-        "columnEnd": 5
+        "lineBegin": 23,
+        "columnBegin": 61,
+        "lineEnd": 26,
+        "columnEnd": 6
       },
       "text": {
         "key": "{\u000a      cwd: dir,\u000a      silent: true,\u000a    }"
@@ -298,16 +298,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 23,
-        "columnBegin": 6,
-        "lineEnd": 23,
-        "columnEnd": 9
+        "lineBegin": 24,
+        "columnBegin": 7,
+        "lineEnd": 24,
+        "columnEnd": 10
       },
       "fullRange": {
-        "lineBegin": 23,
-        "columnBegin": 6,
-        "lineEnd": 23,
-        "columnEnd": 14
+        "lineBegin": 24,
+        "columnBegin": 7,
+        "lineEnd": 24,
+        "columnEnd": 15
       },
       "text": { "key": "cwd" }
     }
@@ -315,10 +315,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 23,
-        "columnBegin": 11,
-        "lineEnd": 23,
-        "columnEnd": 14
+        "lineBegin": 24,
+        "columnBegin": 12,
+        "lineEnd": 24,
+        "columnEnd": 15
       },
       "text": { "key": "dir" }
     }
@@ -326,16 +326,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 24,
-        "columnBegin": 6,
-        "lineEnd": 24,
-        "columnEnd": 12
+        "lineBegin": 25,
+        "columnBegin": 7,
+        "lineEnd": 25,
+        "columnEnd": 13
       },
       "fullRange": {
-        "lineBegin": 24,
-        "columnBegin": 6,
-        "lineEnd": 24,
-        "columnEnd": 18
+        "lineBegin": 25,
+        "columnBegin": 7,
+        "lineEnd": 25,
+        "columnEnd": 19
       },
       "text": { "key": "silent" }
     }
@@ -343,10 +343,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 26,
-        "columnBegin": 4,
-        "lineEnd": 26,
-        "columnEnd": 9
+        "lineBegin": 27,
+        "columnBegin": 5,
+        "lineEnd": 27,
+        "columnEnd": 10
       },
       "text": { "key": "shell" }
     }
@@ -354,10 +354,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 26,
-        "columnBegin": 46,
-        "lineEnd": 26,
-        "columnEnd": 70
+        "lineBegin": 27,
+        "columnBegin": 47,
+        "lineEnd": 27,
+        "columnEnd": 71
       },
       "text": { "key": "{cwd: dir, silent: true}" }
     }
@@ -365,16 +365,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 26,
-        "columnBegin": 47,
-        "lineEnd": 26,
-        "columnEnd": 50
+        "lineBegin": 27,
+        "columnBegin": 48,
+        "lineEnd": 27,
+        "columnEnd": 51
       },
       "fullRange": {
-        "lineBegin": 26,
-        "columnBegin": 47,
-        "lineEnd": 26,
-        "columnEnd": 55
+        "lineBegin": 27,
+        "columnBegin": 48,
+        "lineEnd": 27,
+        "columnEnd": 56
       },
       "text": { "key": "cwd" }
     }
@@ -382,10 +382,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 26,
-        "columnBegin": 52,
-        "lineEnd": 26,
-        "columnEnd": 55
+        "lineBegin": 27,
+        "columnBegin": 53,
+        "lineEnd": 27,
+        "columnEnd": 56
       },
       "text": { "key": "dir" }
     }
@@ -393,16 +393,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 26,
-        "columnBegin": 57,
-        "lineEnd": 26,
-        "columnEnd": 63
+        "lineBegin": 27,
+        "columnBegin": 58,
+        "lineEnd": 27,
+        "columnEnd": 64
       },
       "fullRange": {
-        "lineBegin": 26,
-        "columnBegin": 57,
-        "lineEnd": 26,
-        "columnEnd": 69
+        "lineBegin": 27,
+        "columnBegin": 58,
+        "lineEnd": 27,
+        "columnEnd": 70
       },
       "text": { "key": "silent" }
     }
@@ -410,10 +410,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 28,
-        "columnBegin": 4,
-        "lineEnd": 28,
-        "columnEnd": 9
+        "lineBegin": 29,
+        "columnBegin": 5,
+        "lineEnd": 29,
+        "columnEnd": 10
       },
       "text": { "key": "shell" }
     }
@@ -421,10 +421,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 28,
-        "columnBegin": 61,
-        "lineEnd": 31,
-        "columnEnd": 5
+        "lineBegin": 29,
+        "columnBegin": 62,
+        "lineEnd": 32,
+        "columnEnd": 6
       },
       "text": {
         "key": "{\u000a      cwd: dir,\u000a      silent: true,\u000a    }"
@@ -434,16 +434,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 29,
-        "columnBegin": 6,
-        "lineEnd": 29,
-        "columnEnd": 9
+        "lineBegin": 30,
+        "columnBegin": 7,
+        "lineEnd": 30,
+        "columnEnd": 10
       },
       "fullRange": {
-        "lineBegin": 29,
-        "columnBegin": 6,
-        "lineEnd": 29,
-        "columnEnd": 14
+        "lineBegin": 30,
+        "columnBegin": 7,
+        "lineEnd": 30,
+        "columnEnd": 15
       },
       "text": { "key": "cwd" }
     }
@@ -451,10 +451,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 29,
-        "columnBegin": 11,
-        "lineEnd": 29,
-        "columnEnd": 14
+        "lineBegin": 30,
+        "columnBegin": 12,
+        "lineEnd": 30,
+        "columnEnd": 15
       },
       "text": { "key": "dir" }
     }
@@ -462,16 +462,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 30,
-        "columnBegin": 6,
-        "lineEnd": 30,
-        "columnEnd": 12
+        "lineBegin": 31,
+        "columnBegin": 7,
+        "lineEnd": 31,
+        "columnEnd": 13
       },
       "fullRange": {
-        "lineBegin": 30,
-        "columnBegin": 6,
-        "lineEnd": 30,
-        "columnEnd": 18
+        "lineBegin": 31,
+        "columnBegin": 7,
+        "lineEnd": 31,
+        "columnEnd": 19
       },
       "text": { "key": "silent" }
     }
@@ -479,16 +479,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 33,
-        "columnBegin": 2,
-        "lineEnd": 33,
-        "columnEnd": 8
+        "lineBegin": 34,
+        "columnBegin": 3,
+        "lineEnd": 34,
+        "columnEnd": 9
       },
       "fullRange": {
-        "lineBegin": 33,
-        "columnBegin": 2,
-        "lineEnd": 40,
-        "columnEnd": 5
+        "lineBegin": 34,
+        "columnBegin": 3,
+        "lineEnd": 41,
+        "columnEnd": 6
       },
       "text": { "key": "commit" }
     }
@@ -496,16 +496,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 33,
-        "columnBegin": 9,
-        "lineEnd": 33,
-        "columnEnd": 12
+        "lineBegin": 34,
+        "columnBegin": 10,
+        "lineEnd": 34,
+        "columnEnd": 13
       },
       "fullRange": {
-        "lineBegin": 33,
-        "columnBegin": 9,
-        "lineEnd": 33,
-        "columnEnd": 20
+        "lineBegin": 34,
+        "columnBegin": 10,
+        "lineEnd": 34,
+        "columnEnd": 21
       },
       "text": { "key": "msg" }
     }
@@ -513,16 +513,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 33,
-        "columnBegin": 22,
-        "lineEnd": 33,
-        "columnEnd": 26
+        "lineBegin": 34,
+        "columnBegin": 23,
+        "lineEnd": 34,
+        "columnEnd": 27
       },
       "fullRange": {
-        "lineBegin": 33,
-        "columnBegin": 22,
-        "lineEnd": 33,
-        "columnEnd": 34
+        "lineBegin": 34,
+        "columnBegin": 23,
+        "lineEnd": 34,
+        "columnEnd": 35
       },
       "text": { "key": "date" }
     }
@@ -530,16 +530,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 33,
-        "columnBegin": 36,
-        "lineEnd": 33,
-        "columnEnd": 42
+        "lineBegin": 34,
+        "columnBegin": 37,
+        "lineEnd": 34,
+        "columnEnd": 43
       },
       "fullRange": {
-        "lineBegin": 33,
-        "columnBegin": 36,
-        "lineEnd": 33,
-        "columnEnd": 50
+        "lineBegin": 34,
+        "columnBegin": 37,
+        "lineEnd": 34,
+        "columnEnd": 51
       },
       "text": { "key": "author" }
     }
@@ -547,16 +547,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 34,
-        "columnBegin": 10,
-        "lineEnd": 34,
-        "columnEnd": 16
+        "lineBegin": 35,
+        "columnBegin": 11,
+        "lineEnd": 35,
+        "columnEnd": 17
       },
       "fullRange": {
-        "lineBegin": 34,
-        "columnBegin": 10,
-        "lineEnd": 34,
-        "columnEnd": 73
+        "lineBegin": 35,
+        "columnBegin": 11,
+        "lineEnd": 35,
+        "columnEnd": 74
       },
       "text": { "key": "addRes" }
     }
@@ -564,10 +564,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 34,
-        "columnBegin": 19,
-        "lineEnd": 34,
-        "columnEnd": 24
+        "lineBegin": 35,
+        "columnBegin": 20,
+        "lineEnd": 35,
+        "columnEnd": 25
       },
       "text": { "key": "shell" }
     }
@@ -575,10 +575,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 34,
-        "columnBegin": 43,
-        "lineEnd": 34,
-        "columnEnd": 72
+        "lineBegin": 35,
+        "columnBegin": 44,
+        "lineEnd": 35,
+        "columnEnd": 73
       },
       "text": { "key": "{cwd: this.dir, silent: true}" }
     }
@@ -586,16 +586,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 34,
-        "columnBegin": 44,
-        "lineEnd": 34,
-        "columnEnd": 47
+        "lineBegin": 35,
+        "columnBegin": 45,
+        "lineEnd": 35,
+        "columnEnd": 48
       },
       "fullRange": {
-        "lineBegin": 34,
-        "columnBegin": 44,
-        "lineEnd": 34,
-        "columnEnd": 57
+        "lineBegin": 35,
+        "columnBegin": 45,
+        "lineEnd": 35,
+        "columnEnd": 58
       },
       "text": { "key": "cwd" }
     }
@@ -603,10 +603,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 34,
-        "columnBegin": 54,
-        "lineEnd": 34,
-        "columnEnd": 57
+        "lineBegin": 35,
+        "columnBegin": 55,
+        "lineEnd": 35,
+        "columnEnd": 58
       },
       "text": { "key": "dir" }
     }
@@ -614,16 +614,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 34,
-        "columnBegin": 59,
-        "lineEnd": 34,
-        "columnEnd": 65
+        "lineBegin": 35,
+        "columnBegin": 60,
+        "lineEnd": 35,
+        "columnEnd": 66
       },
       "fullRange": {
-        "lineBegin": 34,
-        "columnBegin": 59,
-        "lineEnd": 34,
-        "columnEnd": 71
+        "lineBegin": 35,
+        "columnBegin": 60,
+        "lineEnd": 35,
+        "columnEnd": 72
       },
       "text": { "key": "silent" }
     }
@@ -631,32 +631,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 35,
-        "columnBegin": 8,
-        "lineEnd": 35,
-        "columnEnd": 14
-      },
-      "text": { "key": "addRes" }
-    }
-  },
-  {
-    "key": {
-      "range": {
         "lineBegin": 36,
-        "columnBegin": 16,
+        "columnBegin": 9,
         "lineEnd": 36,
-        "columnEnd": 21
-      },
-      "text": { "key": "Error" }
-    }
-  },
-  {
-    "key": {
-      "range": {
-        "lineBegin": 36,
-        "columnBegin": 50,
-        "lineEnd": 36,
-        "columnEnd": 56
+        "columnEnd": 15
       },
       "text": { "key": "addRes" }
     }
@@ -665,9 +643,20 @@
     "key": {
       "range": {
         "lineBegin": 37,
-        "columnBegin": 10,
+        "columnBegin": 17,
         "lineEnd": 37,
-        "columnEnd": 16
+        "columnEnd": 22
+      },
+      "text": { "key": "Error" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 37,
+        "columnBegin": 51,
+        "lineEnd": 37,
+        "columnEnd": 57
       },
       "text": { "key": "addRes" }
     }
@@ -676,9 +665,9 @@
     "key": {
       "range": {
         "lineBegin": 38,
-        "columnBegin": 10,
+        "columnBegin": 11,
         "lineEnd": 38,
-        "columnEnd": 16
+        "columnEnd": 17
       },
       "text": { "key": "addRes" }
     }
@@ -686,16 +675,27 @@
   {
     "key": {
       "range": {
-        "lineBegin": 45,
-        "columnBegin": 16,
-        "lineEnd": 45,
-        "columnEnd": 30
+        "lineBegin": 39,
+        "columnBegin": 11,
+        "lineEnd": 39,
+        "columnEnd": 17
+      },
+      "text": { "key": "addRes" }
+    }
+  },
+  {
+    "key": {
+      "range": {
+        "lineBegin": 46,
+        "columnBegin": 17,
+        "lineEnd": 46,
+        "columnEnd": 31
       },
       "fullRange": {
-        "lineBegin": 45,
-        "columnBegin": 0,
-        "lineEnd": 51,
-        "columnEnd": 1
+        "lineBegin": 46,
+        "columnBegin": 1,
+        "lineEnd": 52,
+        "columnEnd": 2
       },
       "text": { "key": "createTempRepo" }
     }
@@ -703,10 +703,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 45,
-        "columnBegin": 34,
-        "lineEnd": 45,
-        "columnEnd": 61
+        "lineBegin": 46,
+        "columnBegin": 35,
+        "lineEnd": 46,
+        "columnEnd": 62
       },
       "text": { "key": "{repoDir: string; git: Git}" }
     }
@@ -714,16 +714,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 45,
-        "columnBegin": 35,
-        "lineEnd": 45,
-        "columnEnd": 42
+        "lineBegin": 46,
+        "columnBegin": 36,
+        "lineEnd": 46,
+        "columnEnd": 43
       },
       "fullRange": {
-        "lineBegin": 45,
-        "columnBegin": 35,
-        "lineEnd": 45,
-        "columnEnd": 51
+        "lineBegin": 46,
+        "columnBegin": 36,
+        "lineEnd": 46,
+        "columnEnd": 52
       },
       "text": { "key": "repoDir" }
     }
@@ -731,16 +731,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 45,
-        "columnBegin": 52,
-        "lineEnd": 45,
-        "columnEnd": 55
+        "lineBegin": 46,
+        "columnBegin": 53,
+        "lineEnd": 46,
+        "columnEnd": 56
       },
       "fullRange": {
-        "lineBegin": 45,
-        "columnBegin": 52,
-        "lineEnd": 45,
-        "columnEnd": 60
+        "lineBegin": 46,
+        "columnBegin": 53,
+        "lineEnd": 46,
+        "columnEnd": 61
       },
       "text": { "key": "git" }
     }
@@ -748,10 +748,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 45,
-        "columnBegin": 57,
-        "lineEnd": 45,
-        "columnEnd": 60
+        "lineBegin": 46,
+        "columnBegin": 58,
+        "lineEnd": 46,
+        "columnEnd": 61
       },
       "text": { "key": "Git" }
     }
@@ -759,16 +759,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 46,
-        "columnBegin": 8,
-        "lineEnd": 46,
-        "columnEnd": 15
+        "lineBegin": 47,
+        "columnBegin": 9,
+        "lineEnd": 47,
+        "columnEnd": 16
       },
       "fullRange": {
-        "lineBegin": 46,
-        "columnBegin": 8,
-        "lineEnd": 46,
-        "columnEnd": 73
+        "lineBegin": 47,
+        "columnBegin": 9,
+        "lineEnd": 47,
+        "columnEnd": 74
       },
       "text": { "key": "repoDir" }
     }
@@ -776,10 +776,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 46,
-        "columnBegin": 18,
-        "lineEnd": 46,
-        "columnEnd": 20
+        "lineBegin": 47,
+        "columnBegin": 19,
+        "lineEnd": 47,
+        "columnEnd": 21
       },
       "text": { "key": "fs" }
     }
@@ -787,10 +787,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 46,
-        "columnBegin": 33,
-        "lineEnd": 46,
-        "columnEnd": 37
+        "lineBegin": 47,
+        "columnBegin": 34,
+        "lineEnd": 47,
+        "columnEnd": 38
       },
       "text": { "key": "path" }
     }
@@ -798,10 +798,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 46,
-        "columnBegin": 43,
-        "lineEnd": 46,
-        "columnEnd": 45
+        "lineBegin": 47,
+        "columnBegin": 44,
+        "lineEnd": 47,
+        "columnEnd": 46
       },
       "text": { "key": "os" }
     }
@@ -809,16 +809,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 48,
-        "columnBegin": 8,
-        "lineEnd": 48,
-        "columnEnd": 11
+        "lineBegin": 49,
+        "columnBegin": 9,
+        "lineEnd": 49,
+        "columnEnd": 12
       },
       "fullRange": {
-        "lineBegin": 48,
-        "columnBegin": 8,
-        "lineEnd": 48,
-        "columnEnd": 30
+        "lineBegin": 49,
+        "columnBegin": 9,
+        "lineEnd": 49,
+        "columnEnd": 31
       },
       "text": { "key": "git" }
     }
@@ -826,10 +826,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 48,
-        "columnBegin": 18,
-        "lineEnd": 48,
-        "columnEnd": 21
+        "lineBegin": 49,
+        "columnBegin": 19,
+        "lineEnd": 49,
+        "columnEnd": 22
       },
       "text": { "key": "Git" }
     }
@@ -837,10 +837,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 48,
-        "columnBegin": 22,
-        "lineEnd": 48,
-        "columnEnd": 29
+        "lineBegin": 49,
+        "columnBegin": 23,
+        "lineEnd": 49,
+        "columnEnd": 30
       },
       "text": { "key": "repoDir" }
     }
@@ -848,10 +848,10 @@
   {
     "key": {
       "range": {
-        "lineBegin": 50,
-        "columnBegin": 9,
-        "lineEnd": 50,
-        "columnEnd": 23
+        "lineBegin": 51,
+        "columnBegin": 10,
+        "lineEnd": 51,
+        "columnEnd": 24
       },
       "text": { "key": "{repoDir, git}" }
     }
@@ -859,16 +859,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 50,
-        "columnBegin": 10,
-        "lineEnd": 50,
-        "columnEnd": 17
+        "lineBegin": 51,
+        "columnBegin": 11,
+        "lineEnd": 51,
+        "columnEnd": 18
       },
       "fullRange": {
-        "lineBegin": 50,
-        "columnBegin": 10,
-        "lineEnd": 50,
-        "columnEnd": 17
+        "lineBegin": 51,
+        "columnBegin": 11,
+        "lineEnd": 51,
+        "columnEnd": 18
       },
       "text": { "key": "repoDir" }
     }
@@ -876,16 +876,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 50,
-        "columnBegin": 19,
-        "lineEnd": 50,
-        "columnEnd": 22
+        "lineBegin": 51,
+        "columnBegin": 20,
+        "lineEnd": 51,
+        "columnEnd": 23
       },
       "fullRange": {
-        "lineBegin": 50,
-        "columnBegin": 19,
-        "lineEnd": 50,
-        "columnEnd": 22
+        "lineBegin": 51,
+        "columnBegin": 20,
+        "lineEnd": 51,
+        "columnEnd": 23
       },
       "text": { "key": "git" }
     }
@@ -893,16 +893,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 971,
-        "columnBegin": 10,
-        "lineEnd": 971,
-        "columnEnd": 15
+        "lineBegin": 972,
+        "columnBegin": 11,
+        "lineEnd": 972,
+        "columnEnd": 16
       },
       "fullRange": {
-        "lineBegin": 971,
-        "columnBegin": 0,
-        "lineEnd": 975,
-        "columnEnd": 1
+        "lineBegin": 972,
+        "columnBegin": 1,
+        "lineEnd": 976,
+        "columnEnd": 2
       },
       "text": { "key": "Error" }
     }
@@ -910,16 +910,16 @@
   {
     "key": {
       "range": {
-        "lineBegin": 983,
-        "columnBegin": 12,
-        "lineEnd": 983,
-        "columnEnd": 17
+        "lineBegin": 984,
+        "columnBegin": 13,
+        "lineEnd": 984,
+        "columnEnd": 18
       },
       "fullRange": {
-        "lineBegin": 983,
-        "columnBegin": 12,
-        "lineEnd": 983,
-        "columnEnd": 35
+        "lineBegin": 984,
+        "columnBegin": 13,
+        "lineEnd": 984,
+        "columnEnd": 36
       },
       "text": { "key": "Error" }
     }

--- a/glean/lang/typescript/tests/cases/xrefs/references.out
+++ b/glean/lang/typescript/tests/cases/xrefs/references.out
@@ -6,10 +6,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 15,
-            "columnBegin": 16,
-            "lineEnd": 15,
-            "columnEnd": 21
+            "lineBegin": 16,
+            "columnBegin": 17,
+            "lineEnd": 16,
+            "columnEnd": 22
           },
           "text": { "key": "shell" }
         }
@@ -22,16 +22,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
               "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
               "text": { "key": "shell" }
             }
@@ -46,10 +46,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 15,
-            "columnBegin": 45,
-            "lineEnd": 15,
-            "columnEnd": 48
+            "lineBegin": 16,
+            "columnBegin": 46,
+            "lineEnd": 16,
+            "columnEnd": 49
           },
           "text": { "key": "dir" }
         }
@@ -62,16 +62,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 26
               },
               "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 34
               },
               "text": { "key": "dir" }
             }
@@ -86,10 +86,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 16,
-            "columnBegin": 8,
-            "lineEnd": 16,
-            "columnEnd": 11
+            "lineBegin": 17,
+            "columnBegin": 9,
+            "lineEnd": 17,
+            "columnEnd": 12
           },
           "text": { "key": "res" }
         }
@@ -102,136 +102,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 13
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 14
               },
               "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 64
-              },
-              "text": { "key": "res" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 17,
-            "columnBegin": 16,
-            "lineEnd": 17,
-            "columnEnd": 21
-          },
-          "text": { "key": "Error" }
-        }
-      },
-      "target": {
-        "key": {
-          "file": {
-            "key": "global/node_modules/typescript-lsif/lib/lib.es5.d.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 971,
-                "columnBegin": 10,
-                "lineEnd": 971,
-                "columnEnd": 15
-              },
-              "fullRange": {
-                "lineBegin": 971,
-                "columnBegin": 0,
-                "lineEnd": 975,
-                "columnEnd": 1
-              },
-              "text": { "key": "Error" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 17,
-            "columnBegin": 16,
-            "lineEnd": 17,
-            "columnEnd": 21
-          },
-          "text": { "key": "Error" }
-        }
-      },
-      "target": {
-        "key": {
-          "file": {
-            "key": "global/node_modules/typescript-lsif/lib/lib.es5.d.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 983,
-                "columnBegin": 12,
-                "lineEnd": 983,
-                "columnEnd": 17
-              },
-              "fullRange": {
-                "lineBegin": 983,
-                "columnBegin": 12,
-                "lineEnd": 983,
-                "columnEnd": 35
-              },
-              "text": { "key": "Error" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 17,
-            "columnBegin": 51,
-            "lineEnd": 17,
-            "columnEnd": 54
-          },
-          "text": { "key": "res" }
-        }
-      },
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 13
-              },
-              "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 64
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 65
               },
               "text": { "key": "res" }
             }
@@ -247,9 +127,89 @@
         "key": {
           "range": {
             "lineBegin": 18,
-            "columnBegin": 10,
+            "columnBegin": 17,
             "lineEnd": 18,
-            "columnEnd": 13
+            "columnEnd": 22
+          },
+          "text": { "key": "Error" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": {
+            "key": "global/node_modules/typescript-lsif/lib/lib.es5.d.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 972,
+                "columnBegin": 11,
+                "lineEnd": 972,
+                "columnEnd": 16
+              },
+              "fullRange": {
+                "lineBegin": 972,
+                "columnBegin": 1,
+                "lineEnd": 976,
+                "columnEnd": 2
+              },
+              "text": { "key": "Error" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 18,
+            "columnBegin": 17,
+            "lineEnd": 18,
+            "columnEnd": 22
+          },
+          "text": { "key": "Error" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": {
+            "key": "global/node_modules/typescript-lsif/lib/lib.es5.d.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 984,
+                "columnBegin": 13,
+                "lineEnd": 984,
+                "columnEnd": 18
+              },
+              "fullRange": {
+                "lineBegin": 984,
+                "columnBegin": 13,
+                "lineEnd": 984,
+                "columnEnd": 36
+              },
+              "text": { "key": "Error" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 18,
+            "columnBegin": 52,
+            "lineEnd": 18,
+            "columnEnd": 55
           },
           "text": { "key": "res" }
         }
@@ -262,16 +222,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 13
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 14
               },
               "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 64
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 65
               },
               "text": { "key": "res" }
             }
@@ -287,9 +247,9 @@
         "key": {
           "range": {
             "lineBegin": 19,
-            "columnBegin": 10,
+            "columnBegin": 11,
             "lineEnd": 19,
-            "columnEnd": 13
+            "columnEnd": 14
           },
           "text": { "key": "res" }
         }
@@ -302,16 +262,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 13
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 14
               },
               "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 64
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 65
               },
               "text": { "key": "res" }
             }
@@ -326,12 +286,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 22,
-            "columnBegin": 4,
-            "lineEnd": 22,
-            "columnEnd": 9
+            "lineBegin": 20,
+            "columnBegin": 11,
+            "lineEnd": 20,
+            "columnEnd": 14
           },
-          "text": { "key": "shell" }
+          "text": { "key": "res" }
         }
       },
       "target": {
@@ -342,18 +302,18 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 14
               },
               "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 65
               },
-              "text": { "key": "shell" }
+              "text": { "key": "res" }
             }
           }
         }
@@ -367,49 +327,9 @@
         "key": {
           "range": {
             "lineBegin": 23,
-            "columnBegin": 11,
+            "columnBegin": 5,
             "lineEnd": 23,
-            "columnEnd": 14
-          },
-          "text": { "key": "dir" }
-        }
-      },
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
-              },
-              "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
-              },
-              "text": { "key": "dir" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 26,
-            "columnBegin": 4,
-            "lineEnd": 26,
-            "columnEnd": 9
+            "columnEnd": 10
           },
           "text": { "key": "shell" }
         }
@@ -422,16 +342,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
               "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
               "text": { "key": "shell" }
             }
@@ -446,10 +366,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 26,
-            "columnBegin": 52,
-            "lineEnd": 26,
-            "columnEnd": 55
+            "lineBegin": 24,
+            "columnBegin": 12,
+            "lineEnd": 24,
+            "columnEnd": 15
           },
           "text": { "key": "dir" }
         }
@@ -462,16 +382,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 26
               },
               "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 34
               },
               "text": { "key": "dir" }
             }
@@ -486,10 +406,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 28,
-            "columnBegin": 4,
-            "lineEnd": 28,
-            "columnEnd": 9
+            "lineBegin": 27,
+            "columnBegin": 5,
+            "lineEnd": 27,
+            "columnEnd": 10
           },
           "text": { "key": "shell" }
         }
@@ -502,18 +422,58 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
               "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
               "text": { "key": "shell" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 27,
+            "columnBegin": 53,
+            "lineEnd": 27,
+            "columnEnd": 56
+          },
+          "text": { "key": "dir" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 26
+              },
+              "fullRange": {
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 34
+              },
+              "text": { "key": "dir" }
             }
           }
         }
@@ -527,49 +487,9 @@
         "key": {
           "range": {
             "lineBegin": 29,
-            "columnBegin": 11,
+            "columnBegin": 5,
             "lineEnd": 29,
-            "columnEnd": 14
-          },
-          "text": { "key": "dir" }
-        }
-      },
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
-              },
-              "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
-              },
-              "text": { "key": "dir" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 34,
-            "columnBegin": 19,
-            "lineEnd": 34,
-            "columnEnd": 24
+            "columnEnd": 10
           },
           "text": { "key": "shell" }
         }
@@ -582,16 +502,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
               "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
               "text": { "key": "shell" }
             }
@@ -606,10 +526,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 34,
-            "columnBegin": 54,
-            "lineEnd": 34,
-            "columnEnd": 57
+            "lineBegin": 30,
+            "columnBegin": 12,
+            "lineEnd": 30,
+            "columnEnd": 15
           },
           "text": { "key": "dir" }
         }
@@ -622,16 +542,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 26
               },
               "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 34
               },
               "text": { "key": "dir" }
             }
@@ -647,9 +567,89 @@
         "key": {
           "range": {
             "lineBegin": 35,
-            "columnBegin": 8,
+            "columnBegin": 20,
             "lineEnd": 35,
-            "columnEnd": 14
+            "columnEnd": 25
+          },
+          "text": { "key": "shell" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
+              },
+              "fullRange": {
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
+              },
+              "text": { "key": "shell" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 55,
+            "lineEnd": 35,
+            "columnEnd": 58
+          },
+          "text": { "key": "dir" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 26
+              },
+              "fullRange": {
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 34
+              },
+              "text": { "key": "dir" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 9,
+            "lineEnd": 36,
+            "columnEnd": 15
           },
           "text": { "key": "addRes" }
         }
@@ -662,136 +662,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 16
-              },
-              "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 73
-              },
-              "text": { "key": "addRes" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 36,
-            "columnBegin": 16,
-            "lineEnd": 36,
-            "columnEnd": 21
-          },
-          "text": { "key": "Error" }
-        }
-      },
-      "target": {
-        "key": {
-          "file": {
-            "key": "global/node_modules/typescript-lsif/lib/lib.es5.d.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 971,
-                "columnBegin": 10,
-                "lineEnd": 971,
-                "columnEnd": 15
-              },
-              "fullRange": {
-                "lineBegin": 971,
-                "columnBegin": 0,
-                "lineEnd": 975,
-                "columnEnd": 1
-              },
-              "text": { "key": "Error" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 36,
-            "columnBegin": 16,
-            "lineEnd": 36,
-            "columnEnd": 21
-          },
-          "text": { "key": "Error" }
-        }
-      },
-      "target": {
-        "key": {
-          "file": {
-            "key": "global/node_modules/typescript-lsif/lib/lib.es5.d.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 983,
-                "columnBegin": 12,
-                "lineEnd": 983,
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
                 "columnEnd": 17
               },
               "fullRange": {
-                "lineBegin": 983,
-                "columnBegin": 12,
-                "lineEnd": 983,
-                "columnEnd": 35
-              },
-              "text": { "key": "Error" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 36,
-            "columnBegin": 50,
-            "lineEnd": 36,
-            "columnEnd": 56
-          },
-          "text": { "key": "addRes" }
-        }
-      },
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 16
-              },
-              "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 73
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 74
               },
               "text": { "key": "addRes" }
             }
@@ -807,9 +687,89 @@
         "key": {
           "range": {
             "lineBegin": 37,
-            "columnBegin": 10,
+            "columnBegin": 17,
             "lineEnd": 37,
-            "columnEnd": 16
+            "columnEnd": 22
+          },
+          "text": { "key": "Error" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": {
+            "key": "global/node_modules/typescript-lsif/lib/lib.es5.d.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 972,
+                "columnBegin": 11,
+                "lineEnd": 972,
+                "columnEnd": 16
+              },
+              "fullRange": {
+                "lineBegin": 972,
+                "columnBegin": 1,
+                "lineEnd": 976,
+                "columnEnd": 2
+              },
+              "text": { "key": "Error" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 37,
+            "columnBegin": 17,
+            "lineEnd": 37,
+            "columnEnd": 22
+          },
+          "text": { "key": "Error" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": {
+            "key": "global/node_modules/typescript-lsif/lib/lib.es5.d.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 984,
+                "columnBegin": 13,
+                "lineEnd": 984,
+                "columnEnd": 18
+              },
+              "fullRange": {
+                "lineBegin": 984,
+                "columnBegin": 13,
+                "lineEnd": 984,
+                "columnEnd": 36
+              },
+              "text": { "key": "Error" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 37,
+            "columnBegin": 51,
+            "lineEnd": 37,
+            "columnEnd": 57
           },
           "text": { "key": "addRes" }
         }
@@ -822,16 +782,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 16
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 17
               },
               "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 73
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 74
               },
               "text": { "key": "addRes" }
             }
@@ -847,9 +807,9 @@
         "key": {
           "range": {
             "lineBegin": 38,
-            "columnBegin": 10,
+            "columnBegin": 11,
             "lineEnd": 38,
-            "columnEnd": 16
+            "columnEnd": 17
           },
           "text": { "key": "addRes" }
         }
@@ -862,16 +822,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 16
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 17
               },
               "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 73
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 74
               },
               "text": { "key": "addRes" }
             }
@@ -886,10 +846,50 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 45,
-            "columnBegin": 57,
-            "lineEnd": 45,
-            "columnEnd": 60
+            "lineBegin": 39,
+            "columnBegin": 11,
+            "lineEnd": 39,
+            "columnEnd": 17
+          },
+          "text": { "key": "addRes" }
+        }
+      },
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 17
+              },
+              "fullRange": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 74
+              },
+              "text": { "key": "addRes" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 46,
+            "columnBegin": 58,
+            "lineEnd": 46,
+            "columnEnd": 61
           },
           "text": { "key": "Git" }
         }
@@ -902,16 +902,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 13,
-                "columnBegin": 6,
-                "lineEnd": 13,
-                "columnEnd": 9
+                "lineBegin": 14,
+                "columnBegin": 7,
+                "lineEnd": 14,
+                "columnEnd": 10
               },
               "fullRange": {
-                "lineBegin": 13,
-                "columnBegin": 0,
-                "lineEnd": 41,
-                "columnEnd": 3
+                "lineBegin": 14,
+                "columnBegin": 1,
+                "lineEnd": 42,
+                "columnEnd": 4
               },
               "text": { "key": "Git" }
             }
@@ -926,10 +926,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 46,
-            "columnBegin": 18,
-            "lineEnd": 46,
-            "columnEnd": 20
+            "lineBegin": 47,
+            "columnBegin": 19,
+            "lineEnd": 47,
+            "columnEnd": 21
           },
           "text": { "key": "fs" }
         }
@@ -942,16 +942,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 8,
-                "columnBegin": 7,
-                "lineEnd": 8,
-                "columnEnd": 9
+                "lineBegin": 9,
+                "columnBegin": 8,
+                "lineEnd": 9,
+                "columnEnd": 10
               },
               "fullRange": {
-                "lineBegin": 8,
-                "columnBegin": 7,
-                "lineEnd": 8,
-                "columnEnd": 9
+                "lineBegin": 9,
+                "columnBegin": 8,
+                "lineEnd": 9,
+                "columnEnd": 10
               },
               "text": { "key": "fs" }
             }
@@ -966,10 +966,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 46,
-            "columnBegin": 33,
-            "lineEnd": 46,
-            "columnEnd": 37
+            "lineBegin": 47,
+            "columnBegin": 34,
+            "lineEnd": 47,
+            "columnEnd": 38
           },
           "text": { "key": "path" }
         }
@@ -982,16 +982,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 10,
-                "columnBegin": 7,
-                "lineEnd": 10,
-                "columnEnd": 11
+                "lineBegin": 11,
+                "columnBegin": 8,
+                "lineEnd": 11,
+                "columnEnd": 12
               },
               "fullRange": {
-                "lineBegin": 10,
-                "columnBegin": 7,
-                "lineEnd": 10,
-                "columnEnd": 11
+                "lineBegin": 11,
+                "columnBegin": 8,
+                "lineEnd": 11,
+                "columnEnd": 12
               },
               "text": { "key": "path" }
             }
@@ -1006,10 +1006,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 46,
-            "columnBegin": 43,
-            "lineEnd": 46,
-            "columnEnd": 45
+            "lineBegin": 47,
+            "columnBegin": 44,
+            "lineEnd": 47,
+            "columnEnd": 46
           },
           "text": { "key": "os" }
         }
@@ -1022,16 +1022,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 9,
-                "columnBegin": 7,
-                "lineEnd": 9,
-                "columnEnd": 9
+                "lineBegin": 10,
+                "columnBegin": 8,
+                "lineEnd": 10,
+                "columnEnd": 10
               },
               "fullRange": {
-                "lineBegin": 9,
-                "columnBegin": 7,
-                "lineEnd": 9,
-                "columnEnd": 9
+                "lineBegin": 10,
+                "columnBegin": 8,
+                "lineEnd": 10,
+                "columnEnd": 10
               },
               "text": { "key": "os" }
             }
@@ -1046,10 +1046,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 48,
-            "columnBegin": 18,
-            "lineEnd": 48,
-            "columnEnd": 21
+            "lineBegin": 49,
+            "columnBegin": 19,
+            "lineEnd": 49,
+            "columnEnd": 22
           },
           "text": { "key": "Git" }
         }
@@ -1062,16 +1062,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 13,
-                "columnBegin": 6,
-                "lineEnd": 13,
-                "columnEnd": 9
+                "lineBegin": 14,
+                "columnBegin": 7,
+                "lineEnd": 14,
+                "columnEnd": 10
               },
               "fullRange": {
-                "lineBegin": 13,
-                "columnBegin": 0,
-                "lineEnd": 41,
-                "columnEnd": 3
+                "lineBegin": 14,
+                "columnBegin": 1,
+                "lineEnd": 42,
+                "columnEnd": 4
               },
               "text": { "key": "Git" }
             }
@@ -1086,10 +1086,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 48,
-            "columnBegin": 22,
-            "lineEnd": 48,
-            "columnEnd": 29
+            "lineBegin": 49,
+            "columnBegin": 23,
+            "lineEnd": 49,
+            "columnEnd": 30
           },
           "text": { "key": "repoDir" }
         }
@@ -1102,16 +1102,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 46,
-                "columnBegin": 8,
-                "lineEnd": 46,
-                "columnEnd": 15
+                "lineBegin": 47,
+                "columnBegin": 9,
+                "lineEnd": 47,
+                "columnEnd": 16
               },
               "fullRange": {
-                "lineBegin": 46,
-                "columnBegin": 8,
-                "lineEnd": 46,
-                "columnEnd": 73
+                "lineBegin": 47,
+                "columnBegin": 9,
+                "lineEnd": 47,
+                "columnEnd": 74
               },
               "text": { "key": "repoDir" }
             }

--- a/glean/lang/typescript/tests/cases/xrefs/uses.out
+++ b/glean/lang/typescript/tests/cases/xrefs/uses.out
@@ -10,16 +10,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 8,
-                "columnBegin": 7,
-                "lineEnd": 8,
-                "columnEnd": 9
+                "lineBegin": 9,
+                "columnBegin": 8,
+                "lineEnd": 9,
+                "columnEnd": 10
               },
               "fullRange": {
-                "lineBegin": 8,
-                "columnBegin": 7,
-                "lineEnd": 8,
-                "columnEnd": 9
+                "lineBegin": 9,
+                "columnBegin": 8,
+                "lineEnd": 9,
+                "columnEnd": 10
               },
               "text": { "key": "fs" }
             }
@@ -30,10 +30,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 46,
-            "columnBegin": 18,
-            "lineEnd": 46,
-            "columnEnd": 20
+            "lineBegin": 47,
+            "columnBegin": 19,
+            "lineEnd": 47,
+            "columnEnd": 21
           },
           "text": { "key": "fs" }
         }
@@ -50,16 +50,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 9,
-                "columnBegin": 7,
-                "lineEnd": 9,
-                "columnEnd": 9
+                "lineBegin": 10,
+                "columnBegin": 8,
+                "lineEnd": 10,
+                "columnEnd": 10
               },
               "fullRange": {
-                "lineBegin": 9,
-                "columnBegin": 7,
-                "lineEnd": 9,
-                "columnEnd": 9
+                "lineBegin": 10,
+                "columnBegin": 8,
+                "lineEnd": 10,
+                "columnEnd": 10
               },
               "text": { "key": "os" }
             }
@@ -70,10 +70,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 46,
-            "columnBegin": 43,
-            "lineEnd": 46,
-            "columnEnd": 45
+            "lineBegin": 47,
+            "columnBegin": 44,
+            "lineEnd": 47,
+            "columnEnd": 46
           },
           "text": { "key": "os" }
         }
@@ -90,16 +90,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 10,
-                "columnBegin": 7,
-                "lineEnd": 10,
-                "columnEnd": 11
+                "lineBegin": 11,
+                "columnBegin": 8,
+                "lineEnd": 11,
+                "columnEnd": 12
               },
               "fullRange": {
-                "lineBegin": 10,
-                "columnBegin": 7,
-                "lineEnd": 10,
-                "columnEnd": 11
+                "lineBegin": 11,
+                "columnBegin": 8,
+                "lineEnd": 11,
+                "columnEnd": 12
               },
               "text": { "key": "path" }
             }
@@ -110,10 +110,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 46,
-            "columnBegin": 33,
-            "lineEnd": 46,
-            "columnEnd": 37
+            "lineBegin": 47,
+            "columnBegin": 34,
+            "lineEnd": 47,
+            "columnEnd": 38
           },
           "text": { "key": "path" }
         }
@@ -130,498 +130,18 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
-              },
-              "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
-              },
-              "text": { "key": "shell" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 15,
-            "columnBegin": 16,
-            "lineEnd": 15,
-            "columnEnd": 21
-          },
-          "text": { "key": "shell" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
-              },
-              "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
-              },
-              "text": { "key": "shell" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 22,
-            "columnBegin": 4,
-            "lineEnd": 22,
-            "columnEnd": 9
-          },
-          "text": { "key": "shell" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
-              },
-              "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
-              },
-              "text": { "key": "shell" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 26,
-            "columnBegin": 4,
-            "lineEnd": 26,
-            "columnEnd": 9
-          },
-          "text": { "key": "shell" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
-              },
-              "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
-              },
-              "text": { "key": "shell" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 28,
-            "columnBegin": 4,
-            "lineEnd": 28,
-            "columnEnd": 9
-          },
-          "text": { "key": "shell" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
-              },
-              "fullRange": {
-                "lineBegin": 11,
-                "columnBegin": 7,
-                "lineEnd": 11,
-                "columnEnd": 12
-              },
-              "text": { "key": "shell" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 34,
-            "columnBegin": 19,
-            "lineEnd": 34,
-            "columnEnd": 24
-          },
-          "text": { "key": "shell" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 13,
-                "columnBegin": 6,
-                "lineEnd": 13,
-                "columnEnd": 9
-              },
-              "fullRange": {
-                "lineBegin": 13,
-                "columnBegin": 0,
-                "lineEnd": 41,
-                "columnEnd": 3
-              },
-              "text": { "key": "Git" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 45,
-            "columnBegin": 57,
-            "lineEnd": 45,
-            "columnEnd": 60
-          },
-          "text": { "key": "Git" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 13,
-                "columnBegin": 6,
-                "lineEnd": 13,
-                "columnEnd": 9
-              },
-              "fullRange": {
-                "lineBegin": 13,
-                "columnBegin": 0,
-                "lineEnd": 41,
-                "columnEnd": 3
-              },
-              "text": { "key": "Git" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 48,
-            "columnBegin": 18,
-            "lineEnd": 48,
-            "columnEnd": 21
-          },
-          "text": { "key": "Git" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
-              },
-              "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
-              },
-              "text": { "key": "dir" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 15,
-            "columnBegin": 45,
-            "lineEnd": 15,
-            "columnEnd": 48
-          },
-          "text": { "key": "dir" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
-              },
-              "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
-              },
-              "text": { "key": "dir" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 23,
-            "columnBegin": 11,
-            "lineEnd": 23,
-            "columnEnd": 14
-          },
-          "text": { "key": "dir" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
-              },
-              "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
-              },
-              "text": { "key": "dir" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 26,
-            "columnBegin": 52,
-            "lineEnd": 26,
-            "columnEnd": 55
-          },
-          "text": { "key": "dir" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
-              },
-              "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
-              },
-              "text": { "key": "dir" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 29,
-            "columnBegin": 11,
-            "lineEnd": 29,
-            "columnEnd": 14
-          },
-          "text": { "key": "dir" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 14,
-                "columnBegin": 22,
-                "lineEnd": 14,
-                "columnEnd": 25
-              },
-              "fullRange": {
-                "lineBegin": 14,
-                "columnBegin": 14,
-                "lineEnd": 14,
-                "columnEnd": 33
-              },
-              "text": { "key": "dir" }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 34,
-            "columnBegin": 54,
-            "lineEnd": 34,
-            "columnEnd": 57
-          },
-          "text": { "key": "dir" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
                 "columnEnd": 13
               },
               "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 64
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
               },
-              "text": { "key": "res" }
+              "text": { "key": "shell" }
             }
           }
         }
@@ -631,11 +151,251 @@
         "key": {
           "range": {
             "lineBegin": 16,
-            "columnBegin": 8,
+            "columnBegin": 17,
             "lineEnd": 16,
-            "columnEnd": 11
+            "columnEnd": 22
           },
-          "text": { "key": "res" }
+          "text": { "key": "shell" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
+              },
+              "fullRange": {
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
+              },
+              "text": { "key": "shell" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 23,
+            "columnBegin": 5,
+            "lineEnd": 23,
+            "columnEnd": 10
+          },
+          "text": { "key": "shell" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
+              },
+              "fullRange": {
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
+              },
+              "text": { "key": "shell" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 27,
+            "columnBegin": 5,
+            "lineEnd": 27,
+            "columnEnd": 10
+          },
+          "text": { "key": "shell" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
+              },
+              "fullRange": {
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
+              },
+              "text": { "key": "shell" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 29,
+            "columnBegin": 5,
+            "lineEnd": 29,
+            "columnEnd": 10
+          },
+          "text": { "key": "shell" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
+              },
+              "fullRange": {
+                "lineBegin": 12,
+                "columnBegin": 8,
+                "lineEnd": 12,
+                "columnEnd": 13
+              },
+              "text": { "key": "shell" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 20,
+            "lineEnd": 35,
+            "columnEnd": 25
+          },
+          "text": { "key": "shell" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 14,
+                "columnBegin": 7,
+                "lineEnd": 14,
+                "columnEnd": 10
+              },
+              "fullRange": {
+                "lineBegin": 14,
+                "columnBegin": 1,
+                "lineEnd": 42,
+                "columnEnd": 4
+              },
+              "text": { "key": "Git" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 46,
+            "columnBegin": 58,
+            "lineEnd": 46,
+            "columnEnd": 61
+          },
+          "text": { "key": "Git" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 14,
+                "columnBegin": 7,
+                "lineEnd": 14,
+                "columnEnd": 10
+              },
+              "fullRange": {
+                "lineBegin": 14,
+                "columnBegin": 1,
+                "lineEnd": 42,
+                "columnEnd": 4
+              },
+              "text": { "key": "Git" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 49,
+            "columnBegin": 19,
+            "lineEnd": 49,
+            "columnEnd": 22
+          },
+          "text": { "key": "Git" }
         }
       }
     }
@@ -651,15 +411,215 @@
             "key": {
               "range": {
                 "lineBegin": 15,
-                "columnBegin": 10,
+                "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 13
+                "columnEnd": 26
               },
               "fullRange": {
                 "lineBegin": 15,
-                "columnBegin": 10,
+                "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 64
+                "columnEnd": 34
+              },
+              "text": { "key": "dir" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 16,
+            "columnBegin": 46,
+            "lineEnd": 16,
+            "columnEnd": 49
+          },
+          "text": { "key": "dir" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 26
+              },
+              "fullRange": {
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 34
+              },
+              "text": { "key": "dir" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 24,
+            "columnBegin": 12,
+            "lineEnd": 24,
+            "columnEnd": 15
+          },
+          "text": { "key": "dir" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 26
+              },
+              "fullRange": {
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 34
+              },
+              "text": { "key": "dir" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 27,
+            "columnBegin": 53,
+            "lineEnd": 27,
+            "columnEnd": 56
+          },
+          "text": { "key": "dir" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 26
+              },
+              "fullRange": {
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 34
+              },
+              "text": { "key": "dir" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 30,
+            "columnBegin": 12,
+            "lineEnd": 30,
+            "columnEnd": 15
+          },
+          "text": { "key": "dir" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 26
+              },
+              "fullRange": {
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 34
+              },
+              "text": { "key": "dir" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 55,
+            "lineEnd": 35,
+            "columnEnd": 58
+          },
+          "text": { "key": "dir" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 14
+              },
+              "fullRange": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 65
               },
               "text": { "key": "res" }
             }
@@ -671,9 +631,9 @@
         "key": {
           "range": {
             "lineBegin": 17,
-            "columnBegin": 51,
+            "columnBegin": 9,
             "lineEnd": 17,
-            "columnEnd": 54
+            "columnEnd": 12
           },
           "text": { "key": "res" }
         }
@@ -690,16 +650,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 13
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 14
               },
               "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 64
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 65
               },
               "text": { "key": "res" }
             }
@@ -711,9 +671,9 @@
         "key": {
           "range": {
             "lineBegin": 18,
-            "columnBegin": 10,
+            "columnBegin": 52,
             "lineEnd": 18,
-            "columnEnd": 13
+            "columnEnd": 55
           },
           "text": { "key": "res" }
         }
@@ -730,16 +690,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 13
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 14
               },
               "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 10,
-                "lineEnd": 15,
-                "columnEnd": 64
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 65
               },
               "text": { "key": "res" }
             }
@@ -751,9 +711,9 @@
         "key": {
           "range": {
             "lineBegin": 19,
-            "columnBegin": 10,
+            "columnBegin": 11,
             "lineEnd": 19,
-            "columnEnd": 13
+            "columnEnd": 14
           },
           "text": { "key": "res" }
         }
@@ -770,18 +730,18 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 16
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 14
               },
               "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 73
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 65
               },
-              "text": { "key": "addRes" }
+              "text": { "key": "res" }
             }
           }
         }
@@ -790,12 +750,12 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 35,
-            "columnBegin": 8,
-            "lineEnd": 35,
+            "lineBegin": 20,
+            "columnBegin": 11,
+            "lineEnd": 20,
             "columnEnd": 14
           },
-          "text": { "key": "addRes" }
+          "text": { "key": "res" }
         }
       }
     }
@@ -810,16 +770,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 16
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 17
               },
               "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 73
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 74
               },
               "text": { "key": "addRes" }
             }
@@ -831,9 +791,9 @@
         "key": {
           "range": {
             "lineBegin": 36,
-            "columnBegin": 50,
+            "columnBegin": 9,
             "lineEnd": 36,
-            "columnEnd": 56
+            "columnEnd": 15
           },
           "text": { "key": "addRes" }
         }
@@ -850,16 +810,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 16
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 17
               },
               "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 73
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 74
               },
               "text": { "key": "addRes" }
             }
@@ -871,9 +831,9 @@
         "key": {
           "range": {
             "lineBegin": 37,
-            "columnBegin": 10,
+            "columnBegin": 51,
             "lineEnd": 37,
-            "columnEnd": 16
+            "columnEnd": 57
           },
           "text": { "key": "addRes" }
         }
@@ -890,16 +850,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 16
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 17
               },
               "fullRange": {
-                "lineBegin": 34,
-                "columnBegin": 10,
-                "lineEnd": 34,
-                "columnEnd": 73
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 74
               },
               "text": { "key": "addRes" }
             }
@@ -911,9 +871,9 @@
         "key": {
           "range": {
             "lineBegin": 38,
-            "columnBegin": 10,
+            "columnBegin": 11,
             "lineEnd": 38,
-            "columnEnd": 16
+            "columnEnd": 17
           },
           "text": { "key": "addRes" }
         }
@@ -930,16 +890,56 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 46,
-                "columnBegin": 8,
-                "lineEnd": 46,
-                "columnEnd": 15
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 17
               },
               "fullRange": {
-                "lineBegin": 46,
-                "columnBegin": 8,
-                "lineEnd": 46,
-                "columnEnd": 73
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 74
+              },
+              "text": { "key": "addRes" }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/typescript/tests/cases/xrefs/example.ts" },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 11,
+            "lineEnd": 39,
+            "columnEnd": 17
+          },
+          "text": { "key": "addRes" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 47,
+                "columnBegin": 9,
+                "lineEnd": 47,
+                "columnEnd": 16
+              },
+              "fullRange": {
+                "lineBegin": 47,
+                "columnBegin": 9,
+                "lineEnd": 47,
+                "columnEnd": 74
               },
               "text": { "key": "repoDir" }
             }
@@ -950,10 +950,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 48,
-            "columnBegin": 22,
-            "lineEnd": 48,
-            "columnEnd": 29
+            "lineBegin": 49,
+            "columnBegin": 23,
+            "lineEnd": 49,
+            "columnEnd": 30
           },
           "text": { "key": "repoDir" }
         }
@@ -970,16 +970,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 971,
-                "columnBegin": 10,
-                "lineEnd": 971,
-                "columnEnd": 15
+                "lineBegin": 972,
+                "columnBegin": 11,
+                "lineEnd": 972,
+                "columnEnd": 16
               },
               "fullRange": {
-                "lineBegin": 971,
-                "columnBegin": 0,
-                "lineEnd": 975,
-                "columnEnd": 1
+                "lineBegin": 972,
+                "columnBegin": 1,
+                "lineEnd": 976,
+                "columnEnd": 2
               },
               "text": { "key": "Error" }
             }
@@ -990,10 +990,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 17,
-            "columnBegin": 16,
-            "lineEnd": 17,
-            "columnEnd": 21
+            "lineBegin": 18,
+            "columnBegin": 17,
+            "lineEnd": 18,
+            "columnEnd": 22
           },
           "text": { "key": "Error" }
         }
@@ -1010,16 +1010,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 971,
-                "columnBegin": 10,
-                "lineEnd": 971,
-                "columnEnd": 15
+                "lineBegin": 972,
+                "columnBegin": 11,
+                "lineEnd": 972,
+                "columnEnd": 16
               },
               "fullRange": {
-                "lineBegin": 971,
-                "columnBegin": 0,
-                "lineEnd": 975,
-                "columnEnd": 1
+                "lineBegin": 972,
+                "columnBegin": 1,
+                "lineEnd": 976,
+                "columnEnd": 2
               },
               "text": { "key": "Error" }
             }
@@ -1030,10 +1030,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 36,
-            "columnBegin": 16,
-            "lineEnd": 36,
-            "columnEnd": 21
+            "lineBegin": 37,
+            "columnBegin": 17,
+            "lineEnd": 37,
+            "columnEnd": 22
           },
           "text": { "key": "Error" }
         }
@@ -1050,16 +1050,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 983,
-                "columnBegin": 12,
-                "lineEnd": 983,
-                "columnEnd": 17
+                "lineBegin": 984,
+                "columnBegin": 13,
+                "lineEnd": 984,
+                "columnEnd": 18
               },
               "fullRange": {
-                "lineBegin": 983,
-                "columnBegin": 12,
-                "lineEnd": 983,
-                "columnEnd": 35
+                "lineBegin": 984,
+                "columnBegin": 13,
+                "lineEnd": 984,
+                "columnEnd": 36
               },
               "text": { "key": "Error" }
             }
@@ -1070,10 +1070,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 17,
-            "columnBegin": 16,
-            "lineEnd": 17,
-            "columnEnd": 21
+            "lineBegin": 18,
+            "columnBegin": 17,
+            "lineEnd": 18,
+            "columnEnd": 22
           },
           "text": { "key": "Error" }
         }
@@ -1090,16 +1090,16 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 983,
-                "columnBegin": 12,
-                "lineEnd": 983,
-                "columnEnd": 17
+                "lineBegin": 984,
+                "columnBegin": 13,
+                "lineEnd": 984,
+                "columnEnd": 18
               },
               "fullRange": {
-                "lineBegin": 983,
-                "columnBegin": 12,
-                "lineEnd": 983,
-                "columnEnd": 35
+                "lineBegin": 984,
+                "columnBegin": 13,
+                "lineEnd": 984,
+                "columnEnd": 36
               },
               "text": { "key": "Error" }
             }
@@ -1110,10 +1110,10 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 36,
-            "columnBegin": 16,
-            "lineEnd": 36,
-            "columnEnd": 21
+            "lineBegin": 37,
+            "columnBegin": 17,
+            "lineEnd": 37,
+            "columnEnd": 22
           },
           "text": { "key": "Error" }
         }

--- a/glean/schema/source/lsif.angle
+++ b/glean/schema/source/lsif.angle
@@ -89,9 +89,10 @@ predicate ProjectDocument:
     project: lsif.Project,
   }
 
-# Note, in LSIF range spans are not keyed by file
-# having this as a type compresses better than as a predicate
-# Note: These are 0-based, unlike src.Range.
+# In LSIF range spans are not keyed by file, we index them separately.
+# Having this as a type compresses better than as a predicate
+# Note: these are 1-indexed, like src.Range, while LSIF native is 0-indexed.
+# The conversion happens in the indexer.
 type RangeSpan =
   {
     lineBegin : nat,


### PR DESCRIPTION
Makes identifier names non-optional (tbd if this is sensible);
Switches to 1-indexed ranges, so we don't need to do math in the DB.
Update regression tests.