### PR TITLE
Basic working interface for C++ indexer

### DIFF
--- a/glean/lang/clang/exe/Glean/CMake.hs
+++ b/glean/lang/clang/exe/Glean/CMake.hs
@@ -1,0 +1,87 @@
+module Glean.CMake where
+
+import Control.Monad.Except
+import Control.Monad.IO.Class
+import System.Directory
+import System.Exit
+import System.FilePath
+import System.IO.Temp
+import System.Process
+
+data CppIndexerOpts = CppIndexerOpts
+  { cfgCppSrcDir   :: FilePath     -- ^ directory with the root CMakeLists.txt
+  , cfgDumpFile    :: FilePath     -- ^ where to dump indexed data (thrift compact format)
+  , cfgInventory   :: FilePath     -- ^ path to inventory file for the glean schema to be used
+  , cfgCMakeTarget :: String       -- ^ cmake target to focus on ('Nothing' corresponds to 'all')
+  , cfgClangArgs   :: String       -- ^ extra clang arguments
+  }
+
+
+data IndexError
+  = CMakeError Int String String -- ^ cmake exit code, stdout, stderr
+  | CMakeCommandsFileMissing FilePath -- ^ @compile_commands.json@ missing
+  | IndexerError Int String String -- ^ indexer exit code, stdout, stderr
+  deriving Show
+
+type IndexM = ExceptT IndexError IO
+
+-- | Generate @compile_commands.json@ file for a CMake project
+generateBuildCommands
+  :: CppIndexerOpts
+  -> FilePath        -- ^ path to (temporary) cmake build dir
+  -> IndexM FilePath -- ^ path to @compile_commands.jsonà file, when successful
+generateBuildCommands indexOpts buildDir = do
+  (ex, out, err) <- liftIO (readProcessWithExitCode "cmake" args "")
+  case ex of
+    ExitSuccess   -> return (buildDir </> "compile_commands.json")
+    ExitFailure i -> throwError $ CMakeError i out err
+
+  where args = words (cfgClangArgs indexOpts)
+            ++ [ "-DCMAKE_EXPORT_COMPILE_COMMANDS=1"
+               , "-S", cfgCppSrcDir indexOpts
+               , "-B", buildDir
+               ]
+
+runIndexer
+  :: CppIndexerOpts
+  -> FilePath     -- ^ path to (temporary) cmake build dir
+  -> IndexM ()
+runIndexer indexOpts buildDir = do
+  liftIO . putStrLn $
+    "calling:\t " ++ unwords ("glean-clang-index":args)
+  (ex, out, err) <- liftIO $ readProcessWithExitCode "glean-clang-index" args ""
+  -- Uncomment to see C++ indexer output. TODO: hide behind a --verbose flag?
+  -- liftIO $ do
+  --   print ex
+  --   putStrLn "---"
+  --   putStrLn out
+  --   putStrLn "---"
+  --   putStrLn err
+  --   putStrLn "---"
+  case ex of
+    ExitSuccess   -> return ()
+    ExitFailure i -> throwError $ IndexerError i out err
+
+  where args = [ "-cdb_dir", buildDir
+               , "-cdb_target", cfgCMakeTarget indexOpts
+               , "-root", cfgCppSrcDir indexOpts
+               , "-dump", cfgDumpFile indexOpts
+               , "--inventory", cfgInventory indexOpts
+               ]
+
+indexCMake :: CppIndexerOpts -> IndexM ()
+indexCMake indexOpts =
+  withSystemTempDirectory "glean-cmake" $ \tmpDir -> do
+    compileCommandsPath <- generateBuildCommands indexOpts tmpDir
+    -- Uncomment the 5 lines below to see what happens if we additionally try to
+    -- build the project.
+    -- (ex, out, err) <- liftIO $
+    --   readProcessWithExitCode "cmake" ["--build", tmpDir] ""
+    -- liftIO $ do
+    --   putStrLn ("stdout:\n" ++ out ++ "\n---")
+    --   putStrLn ("stderr:\n" ++ err ++ "\n---")
+
+    exists <- liftIO (doesFileExist compileCommandsPath)
+    when (not exists) $
+      throwError (CMakeCommandsFileMissing compileCommandsPath)
+    runIndexer indexOpts tmpDir

--- a/glean/lang/clang/exe/Glean/Clang.hs
+++ b/glean/lang/clang/exe/Glean/Clang.hs
@@ -1,0 +1,55 @@
+module Glean.Clang where
+
+import Control.Monad.Except
+import Options.Applicative
+import System.Environment
+
+import Glean.CMake
+
+-- TODO: when the Derive business is integrated,
+--       turn this CLI interface into several
+--       commands? (index, derive, do both in one shot)
+options :: ParserInfo CppIndexerOpts
+options = info (helper <*> parser) fullDesc
+  where
+    parser :: Parser CppIndexerOpts
+    parser = CppIndexerOpts
+      <$> strOption
+            ( long "srcdir"
+           <> help "C++ sources directory, containing the root CMakeLists.txt"
+           <> metavar "DIR"
+            )
+      <*> strOption
+            ( long "output"
+           <> short 'o'
+           <> help "Path to the file where the indexed data should be dumped"
+           <> metavar "FILE"
+            )
+      <*> strOption
+            ( long "inventory"
+           <> short 'i'
+           <> help "Path to the schema inventory file"
+           <> metavar "FILE"
+            )
+      <*> strOption
+            ( long "target"
+           <> short 't'
+           <> help "CMake target to index from the project given by --srcdir"
+           <> value "all"
+           <> showDefault
+            )
+      <*> strOption
+            ( long "clang-args"
+           <> help "Extra arguments to pass to clang (in addition to the ones dictated by CMake)"
+           <> value ""
+           <> showDefault
+            )
+
+main :: IO ()
+main = execParser options >>= go
+
+  where go opts = do
+          r <- runExceptT (indexCMake opts)
+          case r of
+            Left e  -> error $ "Indexing error: " ++ show e
+            Right _ -> putStrLn "Indexing OK."

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -131,7 +131,7 @@ common fb-cpp
      cxx-options: -O3
 
 library
-    import: fb-haskell, fb-cpp, deps, exe
+    import: fb-haskell, fb-cpp, deps
     exposed-modules:
         Derive
         Derive.Common
@@ -198,3 +198,13 @@ executable glean-clang-index
       cxx-options: -DGLEAN_X86_64 -march=haswell
     if flag(opt)
       cxx-options: -O3
+
+executable glean-clang
+    import: fb-haskell, fb-cpp, deps, exe
+    main-is: Glean/Clang.hs
+    hs-source-dirs: exe
+    other-modules: Glean.CMake
+    ghc-options: -main-is Glean.Clang
+    build-depends:
+        glean-clang,
+        mtl


### PR DESCRIPTION
This is a fairly thin wrapper at the moment, with a basic CLI interface, not doing much work for the user. I was split between making the wrapper do more, or something along the lines of this patch.

Things that could (and should?) be done on behalf of the user: generating the inventory file, writing the data dumped by the indexer to a glean DB.

It's also not entirely clear on what the final interface would be once the functionality implemented by `Derive.hs` is integrated. This would at the very least require the "write data dumped by the indexer to glean DB" step to be handled by the wrapper, ideally, since I don't think there's any way for the deriving mechanism to operate on a binary data dump.

But in the interest of not having to potentially undo a lot of work, I decided to present something minimal and get feedback on what the ideal CLI would be.

---

I tested this patch with the following process

``` sh
# create gleandb directory
mkdir -p /gleandb

# initialize gleandb with repo/hash = foo/0
glean --db-root /gleandb \
      --db-schema dir:/Glean/glean/schema/source \
      create --repo foo/0

# generate inventory file for schema, required by C++ indexer
glean --db-root /gleandb \
      --db-schema dir:/Glean/glean/schema/source \
      write-serialized-inventory --repo foo/0 \
      ./inventory.data

# at this point, we're ready to run the wrapper. assuming a test C++/CMake project living at /some/dir:
glean-clang --srcdir /some/dir -o ./indexer.data -i ./inventory.data

# we finally write the dumped data to the glean DB we created earlier
glean --db-root /gleandb --db-schema dir:/Glean/glean/schema/source write --repo foo/0 ./indexer.data --file-format binary

# launching a glean shell to inspect the foo/0 repo in the /gleandb DB should reveal a bunch of facts about the C++ project
```

For completeness, this is the minimal C++ project I used for my tests.

CMakeLists.txt:

```
project(HelloWorld)
cmake_minimum_required(VERSION 3.0)

add_executable(hello_world main.cpp)
```

main.cpp:

``` cpp
#include <iostream>

class F {
  public:
  F() {
    std::cout << "F constructed" << std::endl;
  }
  void hello() {
    std::cout << "F says hello" << std::endl;
  }
};

int main(int _argc, char** _argv) {
  F f;
  f.hello();
  return 0;
}
```
