### PR TITLE
Add an HLint config yaml for Glean

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,64 @@
+# Don't recommend LambdaCase
+- ignore: {name: Use lambda-case}
+
+# Allow identifiers like @c_frobnicateTheBlerch@.
+- ignore: {name: Use camelCase}
+
+# Discourage point-free style.
+- ignore: {name: Eta reduce}
+
+# Allow one-statement do blocks.
+- ignore: {name: Redundant do}
+
+# > (`f` "something")        # NO
+# > (\x -> f x "something")  # YES
+- ignore: {name: Avoid lambda}
+
+# Allow @Set.union x y@ instead of @x `Set.union` y@.
+- ignore: {name: Use infix}
+
+# Allow explicit export of multiple modules without the
+# import/export shortcut.
+- ignore: {name: Use import/export shortcut}
+
+# Let the branches of @if@ have some redundancy:
+
+# > if pred x then return x else return y
+# > return (if pred x then x else y)
+- ignore: {name: Too strict if}
+
+# join is a bit obscure
+- ignore: {name: Use join}
+
+# "when (not x)" is just as clear as "unless x"
+- ignore: {name: Use unless}
+
+# uncurry doesn't increase readability
+- ignore: {name: Use uncurry}
+
+# Arrows are too obscure to recommend
+- ignore: {name: Use &&&}
+
+# tuple sections don't increase readability
+- ignore: {name: Use tuple-section}
+
+# foldl' is almost always what you want
+- warn: {
+  lhs: foldl,
+  rhs: foldl',
+  note: "Use foldl', which is strict, to avoid space leaks. https://fburl.com/fo\
+ldl"
+}
+- warn: {
+  lhs: fromJust,
+  rhs: "fromMaybe (error \"your descriptive error message\")",
+  note: "Avoid usage of partial functions. https://fburl.com/partial-functions"
+}
+
+# Discourage point-free style:
+- warn: {
+  lhs: f . g $ x,
+  rhs: f $ g $ x,
+  name: Point-free style,
+  note: "Don't overuse the point-free style: https://fburl.com/wiki/hdhaxhbm"
+}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ We have added experimental support for [LSIF](https://lsif.dev) indexers, starti
 * [Go](https://glean.software/docs/indexer/lsif-go)
 * [Rust](https://glean.software/docs/indexer/lsif-rust)
 
-
 ## License
 
 Glean is licensed under a [BSD LICENSE](LICENSE).
@@ -66,6 +65,10 @@ requests](https://github.com/facebookincubator/Glean/pulls) on github,
 and note that we need contributors to sign the [Contributor license
 agreement](https://code.facebook.com/cla) before we can accept your
 pull request.
+
+Style guide: for Haskell code, we use `hlint` to check for style issues. Lines
+wrap at 80 columns. Code should be -Wall clean. For C++, code should compile
+with Clang or GCC.
 
 ## Building
 

--- a/glean/glass/Glean/Glass/SymbolId/Flow.hs
+++ b/glean/glass/Glean/Glass/SymbolId/Flow.hs
@@ -172,7 +172,7 @@ instance ToQName Flow.Module_key where
     sym <- toSymbol m
     return $ case reverse sym of
       [] -> Left "QName not supported for this symbol"
-      (h:t) -> Right $ (Name h, Name $ intercalate "." $ reverse t)
+      (h:t) -> Right (Name h, Name (intercalate "." (reverse t)))
 
 pairToQName
   :: (Symbol name, Symbol container)

--- a/glean/tools/gleancli/GleanCLI.hs
+++ b/glean/tools/gleancli/GleanCLI.hs
@@ -274,7 +274,7 @@ instance Plugin DumpCommand where
   runCommand _ _ backend Dump{..} =
     Glean.dumpJsonToFile backend dumpRepo dumpFile
 
-data DeleteCommand
+newtype DeleteCommand
   = Delete
       { deleteRepo :: Repo
       }
@@ -324,7 +324,7 @@ instance Plugin ValidateCommand where
     Glean.BackendEnv env -> Glean.validate env validateRepo validate
     _ -> die 2 "Can't validate a remote database"
 
-data ValidateSchemaCommand
+newtype ValidateSchemaCommand
   = ValidateSchema
       { file :: FilePath
       }
@@ -404,7 +404,7 @@ instance Plugin StatsCommand where
           predicateRef_name == sourceRefName &&
           maybe True (== predicateRef_version) sourceRefVersion
 
-data OwnershipCommand
+newtype OwnershipCommand
   = Ownership
       { ownershipRepo :: Repo
       }

--- a/glean/tools/gleancli/GleanCLI/Complete.hs
+++ b/glean/tools/gleancli/GleanCLI/Complete.hs
@@ -33,7 +33,7 @@ instance Plugin CompleteCommand where
       (progDesc "Notify server that some predicates are complete.") $ do
       completeRepo <- repoOpts
       completePredicates <-
-        many $ fmap parseRef $ strArgument (metavar "PREDICATE")
+        many $ parseRef <$> strArgument (metavar "PREDICATE")
       return Complete{..}
 
   runCommand _ _ backend Complete{..} = do

--- a/glean/tools/gleancli/GleanCLI/Write.hs
+++ b/glean/tools/gleancli/GleanCLI/Write.hs
@@ -90,7 +90,7 @@ instance Plugin WriteCommand where
           )
         writeFiles <- fileArgs
         finish <- finishOpt
-        scribe <- Just <$> scribeOptions <|> pure Nothing
+        scribe <- optional scribeOptions
         dependencies <- optional (stackedOptions <|> updateOptions)
         properties <- many $ option readProperty
           (  long "property"
@@ -162,8 +162,8 @@ instance Plugin WriteCommand where
     writeScribeOpts :: Parser (Text, Maybe PickScribeBucket, Bool)
     writeScribeOpts = do
       cat <- textOption (long "scribe-category" <> metavar "NAME")
-      bucket <- optional $ fmap PickScribeBucket_bucket $
-        option auto (long "scribe-bucket" <> metavar "BUCKET")
+      bucket <- optional (PickScribeBucket_bucket <$>
+        option auto (long "scribe-bucket" <> metavar "BUCKET"))
       compress <- switch (long "compress")
       return (cat, bucket, compress)
 


### PR DESCRIPTION
Can use this to keep style in sync with Meta internal linters.

- Add style advice to README.
- Fix a few superficial lints to get going.