### PR TITLE
Added symbolId tests for Flow

### DIFF
--- a/glean/glass/test/regression/Glean/Glass/Regression/Flow.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/Flow.hs
@@ -9,13 +9,40 @@
 module Glean.Glass.Regression.Flow (main) where
 
 import Test.HUnit
+import Data.Text (Text)
 
 import Glean.Regression.Test
 
+import Glean
+import Glean.Util.Some
 import Glean.Glass.Types
 import Glean.Glass.Regression.Tests
 
 main :: IO ()
 main = mainTestIndexExternal "glass-regression-flow" $ \get -> TestList
   [ testDocumentSymbolListX (Path "test/imports.js") get
+  , testSymbolIdLookup get
   ]
+
+testSymbolIdLookup :: IO (Some Backend, Repo) -> Test
+testSymbolIdLookup get = TestLabel "describeSymbol" $ TestList [
+  "test/js/test/es_exports.js.flow/foo" --> "test/es_exports.js.flow",
+  "test/js/test/es_exports.js.flow/bor" --> "test/es_exports.js.flow",
+  "test/js/test/es_exports.js.flow/d" --> "test/es_exports.js.flow",
+  "test/js/test/es_exports.js.flow/C" --> "test/es_exports.js.flow",
+  "test/js/test/es_exports.js.flow/num" --> "test/es_exports.js.flow",
+  "test/js/test/cjs_exports.js/plus" --> "test/cjs_exports.js",
+  "test/js/test/imports.js/a" --> "test/imports.js",
+  "test/js/test/imports.js/caz" --> "test/imports.js",
+  "test/js/test/imports.js/s" --> "test/imports.js",
+  "test/js/test/imports.js/qux" --> "test/imports.js",
+  "test/js/test/imports.js/str" --> "test/imports.js",
+  "test/js/test/imports.js/fn" --> "test/imports.js"
+  ]
+  where
+    (-->) :: Text -> Text -> Test
+    sym --> expected =
+      testDescribeSymbolMatchesPath
+        (SymbolId sym)
+        (Path expected)
+        get


### PR DESCRIPTION
Summary: Diff contains testcases to resolve SymbolIds for Flow/Javascript symbols to the correct file. The sample Flow code to refer symbols is found in /fbsource/fbcode/glean/lang/codemarkup/tests/flow/cases/xrefs

Reviewed By: simonmar

Differential Revision: D35642932

