### PR TITLE
Refactoring: move indexer abstraction outside the test framework

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -1322,13 +1322,14 @@ library regression-test-lib
         glean/test/regression
         glean/lang/flow
         glean/lang/hack
+        glean/index
     exposed-modules:
+        Glean.Indexer
+        Glean.Indexer.External
         Glean.Regression.Config
         Glean.Regression.Driver.Args.Flow
         Glean.Regression.Driver.Args.Hack
         Glean.Regression.Driver.External
-        Glean.Regression.Indexer
-        Glean.Regression.Indexer.External
         Glean.Regression.Snapshot
         Glean.Regression.Snapshot.Driver
         Glean.Regression.Snapshot.Options

--- a/glean/index/Glean/Indexer.hs
+++ b/glean/index/Glean/Indexer.hs
@@ -1,0 +1,73 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Glean.Indexer
+  ( Indexer(..)
+  , IndexerParams(..)
+  , RunIndexer
+  , indexerWithNoOptions
+  , indexerThen
+  ) where
+
+import Options.Applicative
+
+import Glean
+import Glean.LocalOrRemote
+import Glean.Util.Some
+
+
+-- | An 'Indexer' knows how to index some source code.
+--
+-- Indexers have command-line options, and a function to index the
+-- code specified by the 'TestConfig' using a given 'Env' as a
+-- backend.
+--
+data Indexer opts = Indexer
+  { indexerOptParser :: Parser opts
+  , indexerRun :: opts -> RunIndexer
+  }
+
+type RunIndexer = Some LocalOrRemote -> Repo -> IndexerParams -> IO ()
+
+data IndexerParams = IndexerParams
+  { indexerRoot :: FilePath
+    -- ^ path containing source files to index
+  , indexerProjectRoot :: FilePath
+    -- ^ path to the root of the repository
+  , indexerOutput :: FilePath
+    -- ^ Where to put temporary files. The caller will choose whether
+    -- to create a temporary directory, or to use one specified by the
+    -- user in case they want to keep the temporary files for
+    -- debugging purposes.
+  , indexerGroup :: String
+    -- ^ which "group" to use. This is for when we run a set of tests
+    -- in multiple different ways. The interpretation of "group" is up
+    -- to the indexing backend; indexers that don't need to support
+    -- groups can ignore this.
+  }
+
+-- | An indexer composed of two separate indexing tasks. The left
+-- indexer is run before the right indexer.  This is useful when we
+-- have a base indexer and we want to add a deriving pass, for
+-- example.
+--
+-- The right indexer doesn't have any options. It's possible to
+-- generalise this, but this more restricted form was found to be more
+-- convenient when used with 'Driver'.
+indexerThen :: Indexer a -> RunIndexer -> Indexer a
+indexerThen (Indexer parseOpts run1) run2 = Indexer
+  { indexerOptParser = parseOpts
+  , indexerRun = \opts backend repo params ->
+      run1 opts backend repo params >> run2 backend repo params
+  }
+
+indexerWithNoOptions :: RunIndexer -> Indexer ()
+indexerWithNoOptions run = Indexer
+  { indexerOptParser = pure ()
+  , indexerRun = const run
+  }

--- a/glean/index/Glean/Indexer/External.hs
+++ b/glean/index/Glean/Indexer/External.hs
@@ -13,7 +13,7 @@
 -- generate JSON files and then writing them to the repo using the
 -- 'glean' CLI tool, or it might involve running a server.
 --
-module Glean.Regression.Indexer.External
+module Glean.Indexer.External
   ( externalIndexer
   , Ext(..)
   ) where
@@ -43,8 +43,7 @@ import qualified Glean
 import Glean.Backend (BackendKind(..), LocalOrRemote(..), ThriftBackend(..))
 import Glean.Derive
 import qualified Glean.Handler as GleanHandler
-import Glean.Regression.Indexer
-import Glean.Types
+import Glean.Indexer
 import Glean.Write
 import qualified Glean.LSIF.Driver as LSIF
 import Glean.Util.Service
@@ -102,8 +101,8 @@ execExternal Ext{..} env repo IndexerParams{..} = do index; derive
     derivePredicate env repo Nothing Nothing
       (parseRef pred) Nothing
 
-  repoName = Text.unpack (repo_name repo)
-  repoHash = Text.unpack (repo_hash repo)
+  repoName = Text.unpack (Glean.repo_name repo)
+  repoHash = Text.unpack (Glean.repo_hash repo)
 
   vars = HashMap.fromList
     [ ("TEST_REPO", Glean.showRepo repo)

--- a/glean/lang/clang/tests/Glean/Clang/Test/DerivePass.hs
+++ b/glean/lang/clang/tests/Glean/Clang/Test/DerivePass.hs
@@ -12,7 +12,7 @@ module Glean.Clang.Test.DerivePass (testDeriver, driver) where
 import Control.Monad
 
 import qualified Glean.Clang.Test as Clang
-import Glean.Regression.Indexer
+import Glean.Indexer
 import Glean.Regression.Snapshot.Driver
 import Glean.Regression.Snapshot
 

--- a/glean/lang/clang/tests/Glean/Regression/Driver/DocBlock.hs
+++ b/glean/lang/clang/tests/Glean/Regression/Driver/DocBlock.hs
@@ -12,7 +12,7 @@ import Control.Monad
 
 import qualified Glean.Clang.Test as Clang
 import qualified Glean.DocBlock.Test as DocBlock (runIndexer)
-import Glean.Regression.Indexer
+import Glean.Indexer
 import Glean.Regression.Snapshot.Driver
 import Glean.Regression.Snapshot
 import Glean.Derive (derivePredicate)

--- a/glean/lang/hack/tests/Driver.hs
+++ b/glean/lang/hack/tests/Driver.hs
@@ -13,8 +13,8 @@ module Driver
 import Derive.Env (withEnv)
 import Derive.HackDeclarationTarget (deriveHackDeclarationTarget)
 import qualified Derive.Types as DT
-import Glean.Regression.Indexer
-import Glean.Regression.Indexer.External
+import Glean.Indexer
+import Glean.Indexer.External
 import Glean.Regression.Snapshot (testMain)
 import Glean.Regression.Snapshot.Driver
 

--- a/glean/test/regression/Glean/Regression/Indexer.hs
+++ b/glean/test/regression/Glean/Regression/Indexer.hs
@@ -7,76 +7,17 @@
 -}
 
 module Glean.Regression.Indexer
-  ( Indexer(..)
-  , IndexerParams(..)
-  , RunIndexer
-  , indexerWithNoOptions
-  , indexerThen
-  , withTestDatabase
+  ( withTestDatabase
   ) where
 
-import Options.Applicative
 import System.Exit
 import System.FilePath
 
-import Glean (fillDatabase)
-import Glean.Backend (Backend, LocalOrRemote)
+import Glean
 import Glean.Database.Test
+import Glean.Indexer
 import Glean.Regression.Config
-import Glean.Types
 import Glean.Util.Some
-
-
--- | An 'Indexer' knows how to index some source code.
---
--- Indexers have command-line options, and a function to index the
--- code specified by the 'TestConfig' using a given 'Env' as a
--- backend.
---
-data Indexer opts = Indexer
-  { indexerOptParser :: Parser opts
-  , indexerRun :: opts -> RunIndexer
-  }
-
-type RunIndexer = Some LocalOrRemote -> Repo -> IndexerParams -> IO ()
-
-data IndexerParams = IndexerParams
-  { indexerRoot :: FilePath
-    -- ^ path containing source files to index
-  , indexerProjectRoot :: FilePath
-    -- ^ path to the root of the repository
-  , indexerOutput :: FilePath
-    -- ^ Where to put temporary files. The caller will choose whether
-    -- to create a temporary directory, or to use one specified by the
-    -- user in case they want to keep the temporary files for
-    -- debugging purposes.
-  , indexerGroup :: String
-    -- ^ which "group" to use. This is for when we run a set of tests
-    -- in multiple different ways. The interpretation of "group" is up
-    -- to the indexing backend; indexers that don't need to support
-    -- groups can ignore this.
-  }
-
--- | An indexer composed of two separate indexing tasks. The left
--- indexer is run before the right indexer.  This is useful when we
--- have a base indexer and we want to add a deriving pass, for
--- example.
---
--- The right indexer doesn't have any options. It's possible to
--- generalise this, but this more restricted form was found to be more
--- convenient when used with 'Driver'.
-indexerThen :: Indexer a -> RunIndexer -> Indexer a
-indexerThen (Indexer parseOpts run1) run2 = Indexer
-  { indexerOptParser = parseOpts
-  , indexerRun = \opts backend repo params ->
-      run1 opts backend repo params >> run2 backend repo params
-  }
-
-indexerWithNoOptions :: RunIndexer -> Indexer ()
-indexerWithNoOptions run = Indexer
-  { indexerOptParser = pure ()
-  , indexerRun = const run
-  }
 
 -- | Run the supplied Indexer to populate a temporary DB
 withTestDatabase

--- a/glean/test/regression/Glean/Regression/Snapshot.hs
+++ b/glean/test/regression/Glean/Regression/Snapshot.hs
@@ -34,6 +34,7 @@ import qualified Test.HUnit as HUnit
 import TestRunner
 import Util.JSON.Pretty ()
 
+import Glean.Indexer
 import Glean.Init (withUnitTestOptions)
 import Glean.Regression.Config
 import Glean.Regression.Indexer

--- a/glean/test/regression/Glean/Regression/Snapshot/Driver.hs
+++ b/glean/test/regression/Glean/Regression/Snapshot/Driver.hs
@@ -13,8 +13,8 @@ module Glean.Regression.Snapshot.Driver
   , externalDriver
   ) where
 
-import Glean.Regression.Indexer
-import Glean.Regression.Indexer.External
+import Glean.Indexer
+import Glean.Indexer.External
 import Glean.Regression.Snapshot.Transform
 
 -- | A test driver describes how to run a set of tests. It is passed to
@@ -46,7 +46,7 @@ driverFromIndexer indexer = emptyDriver
   }
 
 -- | A 'Driver' using an external 'Indexer'. See
--- "Glean.Regression.Indexer.External".
+-- "Glean.Indexer.External".
 --
 -- This driver doesn't support multiple groups; that could be added if
 -- necessary.

--- a/glean/test/regression/Glean/Regression/Test.hs
+++ b/glean/test/regression/Glean/Regression/Test.hs
@@ -28,6 +28,7 @@ import TestRunner
 import Util.IO
 
 import Glean
+import Glean.Indexer
 import Glean.Init (withUnitTestOptions)
 import Glean.Regression.Config
 import Glean.Regression.Indexer

--- a/glean/tools/gleancli/GleanCLI/Index.hs
+++ b/glean/tools/gleancli/GleanCLI/Index.hs
@@ -17,8 +17,8 @@ import Util.IO
 import Util.OptParse
 
 import Glean hiding (options)
-import Glean.Regression.Indexer
-import Glean.Regression.Indexer.External
+import Glean.Indexer
+import Glean.Indexer.External
 import Glean.Util.Some
 
 import GleanCLI.Common


### PR DESCRIPTION
Summary: Mainly just moving files around, but this makes a separate indexer abstraction that we will use from the regression framework, from the `glean index` CLI and from the `:index` shell command.

Reviewed By: nhawkes

Differential Revision: D35612700

