### PR TITLE
Move the list of indexers out to a separate library

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -390,6 +390,7 @@ library util
         Glean.Util.ThriftSource
         Glean.Util.Throttle
         Glean.Util.Time
+        Glean.Util.ToAngle
         Glean.Util.Trace
         Glean.Util.ValueBuffer
         Glean.Util.Warden
@@ -944,6 +945,28 @@ library shell-lib
         prettyprinter-ansi-terminal,
         split
 
+library indexers
+    import: fb-haskell, fb-cpp, deps
+    hs-source-dirs:
+        glean/lang/flow
+        glean/lang/hack
+        glean/index
+    exposed-modules:
+        Glean.Indexer
+        Glean.Indexer.External
+        Glean.Indexer.Flow
+        Glean.Indexer.Hack
+    build-depends:
+        glean:client-hs,
+        glean:client-hs-local,
+        glean:db,
+        glean:handler,
+        glean:lib,
+        glean:lsif,
+        glean:stubs,
+        glean:util,
+        thrift-server
+
 library cli-types
     import: fb-haskell, fb-cpp, deps
     hs-source-dirs: glean/tools/gleancli/plugin
@@ -962,6 +985,7 @@ executable glean
         GleanCLI.Complete
         GleanCLI.Derive
         GleanCLI.Finish
+        GleanCLI.Index
         GleanCLI.Query
         GleanCLI.Restore
         GleanCLI.Write
@@ -973,6 +997,7 @@ executable glean
         glean:client-hs-local,
         glean:db,
         glean:if-glean-hs,
+        glean:indexers,
         glean:shell-lib,
         glean:stubs,
         glean:config,
@@ -1320,14 +1345,7 @@ library regression-test-lib
     visibility: private
     hs-source-dirs:
         glean/test/regression
-        glean/lang/flow
-        glean/lang/hack
-        glean/index
     exposed-modules:
-        Glean.Indexer
-        Glean.Indexer.External
-        Glean.Indexer.Flow
-        Glean.Indexer.Hack
         Glean.Regression.Config
         Glean.Regression.Driver.External
         Glean.Regression.Indexer
@@ -1340,17 +1358,14 @@ library regression-test-lib
         Glean.Regression.Test
     build-depends:
         glean:client-hs,
-        glean:client-hs-local,
         glean:db,
-        glean:handler,
+        glean:indexers,
         glean:if-glean-hs,
         glean:lib,
-        glean:lsif,
         glean:stubs,
         glean:test-lib,
         glean:util,
         split,
-        thrift-server,
         yaml
 
 -- library clang-derive-test
@@ -1749,7 +1764,9 @@ test-suite glean-snapshot-flow
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/Flow/Main.hs
     ghc-options: -main-is Glean.Regression.Flow.Main
-    build-depends: glean:regression-test-lib
+    build-depends:
+        glean:regression-test-lib,
+        glean:indexers
 
 test-suite glean-snapshot-hack
     import: fb-haskell, deps
@@ -1757,7 +1774,9 @@ test-suite glean-snapshot-hack
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/Hack/Main.hs
     ghc-options: -main-is Glean.Regression.Hack.Main
-    build-depends: glean:regression-test-lib
+    build-depends:
+        glean:regression-test-lib,
+        glean:indexers
     -- no regular hhvm builds for arm64
     if !flag(hack-tests)
         buildable: False
@@ -1844,6 +1863,7 @@ test-suite glass-regression-flow
     other-modules: Glean.Glass.Regression.Flow
     build-depends:
         glean:client-hs,
+        glean:indexers,
         glean:util
 
 test-suite glass-regression-hack
@@ -1854,6 +1874,7 @@ test-suite glass-regression-hack
     other-modules: Glean.Glass.Regression.Hack
     build-depends:
         glean:client-hs,
+        glean:indexers,
         glean:util,
     if !flag(hack-tests)
         buildable: False

--- a/glean.cabal
+++ b/glean.cabal
@@ -951,11 +951,13 @@ library indexers
         glean/lang/flow
         glean/lang/hack
         glean/index
+        glean/index/list
     exposed-modules:
         Glean.Indexer
         Glean.Indexer.External
         Glean.Indexer.Flow
         Glean.Indexer.Hack
+        Glean.Indexer.List
     build-depends:
         glean:client-hs,
         glean:client-hs-local,

--- a/glean/index/list/Glean/Indexer/List.hs
+++ b/glean/index/list/Glean/Indexer/List.hs
@@ -1,0 +1,32 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Glean.Indexer.List (
+    SomeIndexer(..),
+    indexers,
+  ) where
+
+import Glean.Indexer
+import qualified Glean.Indexer.External as External
+import qualified Glean.Indexer.Flow as Flow
+import qualified Glean.Indexer.Hack as Hack
+
+data SomeIndexer = forall opts . SomeIndexer (Indexer opts)
+
+indexers :: [(String, String, SomeIndexer)]
+indexers =
+  [ ("external",
+      "Use a generic external indexer",
+      SomeIndexer External.externalIndexer)
+  , ("flow",
+      "Index JS/Flow code",
+      SomeIndexer Flow.indexer)
+  , ("hack",
+      "Index Hack code",
+      SomeIndexer Hack.indexer)
+  ]

--- a/glean/lang/codemarkup/tests/flow/Glean/Regression/Flow/Main.hs
+++ b/glean/lang/codemarkup/tests/flow/Glean/Regression/Flow/Main.hs
@@ -10,10 +10,12 @@ module Glean.Regression.Flow.Main ( main ) where
 
 import System.Environment ( withArgs )
 
-import qualified Glean.Regression.Driver.External as Driver ( main )
-import qualified Glean.Regression.Driver.Args.Flow as Flow
+import Glean.Indexer.Flow as Flow
+import Glean.Regression.Snapshot
+import Glean.Regression.Snapshot.Driver
 
 main :: IO ()
-main = withArgs (Flow.args path) Driver.main
+main = withArgs ["--root", path] $ testMain driver
   where
+      driver = driverFromIndexer Flow.indexer
       path = "glean/lang/codemarkup/tests/flow/cases"

--- a/glean/lang/codemarkup/tests/hack/Glean/Regression/Hack/Main.hs
+++ b/glean/lang/codemarkup/tests/hack/Glean/Regression/Hack/Main.hs
@@ -10,10 +10,12 @@ module Glean.Regression.Hack.Main ( main ) where
 
 import System.Environment ( withArgs )
 
-import qualified Glean.Regression.Driver.External as Driver ( main )
-import qualified Glean.Regression.Driver.Args.Hack as Hack
+import Glean.Indexer.Hack as Hack
+import Glean.Regression.Snapshot
+import Glean.Regression.Snapshot.Driver
 
 main :: IO ()
-main = withArgs (Hack.args path) Driver.main
+main = withArgs ["--root", path] $ testMain driver
   where
-    path = "glean/lang/codemarkup/tests/hack/cases"
+      driver = driverFromIndexer Hack.indexer
+      path = "glean/lang/codemarkup/tests/hack/cases"

--- a/glean/tools/gleancli/GleanCLI/Index.hs
+++ b/glean/tools/gleancli/GleanCLI/Index.hs
@@ -19,9 +19,7 @@ import Util.OptParse
 
 import Glean hiding (options)
 import Glean.Indexer
-import qualified Glean.Indexer.External as External
-import qualified Glean.Indexer.Flow as Flow
-import qualified Glean.Indexer.Hack as Hack
+import Glean.Indexer.List
 import Glean.Util.Some
 
 import GleanCLI.Common
@@ -33,21 +31,6 @@ data IndexCommand
       , indexCmdRoot :: FilePath
       , indexCmdRun :: RunIndexer
       }
-
-data SomeIndexer = forall opts . SomeIndexer (Indexer opts)
-
-indexers :: [(String, String, SomeIndexer)]
-indexers =
-  [ ("external",
-      "Use a generic external indexer",
-      SomeIndexer External.externalIndexer)
-  , ("flow",
-      "Index JS/Flow code",
-      SomeIndexer Flow.indexer)
-  , ("hack",
-      "Index Hack code",
-      SomeIndexer Hack.indexer)
-  ]
 
 instance Plugin IndexCommand where
   parseCommand =


### PR DESCRIPTION
Summary: This will be used by regression tests and the shell too.

Reviewed By: pepeiborra

Differential Revision: D35777858

