### PR TITLE
Migrate from existing .bzl logic to Indexer for regression tests

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -854,6 +854,7 @@ library lib
         Glean.Util.Declarations
         Glean.Util.URI
         Glean.Util.Range
+        Glean.Util.ToAngle
         Glean.Util.XRefs
         Glean.Util.Same
         Glean.Util.SchemaRepos
@@ -944,6 +945,28 @@ library shell-lib
         prettyprinter-ansi-terminal,
         split
 
+library indexers
+    import: fb-haskell, fb-cpp, deps
+    hs-source-dirs:
+        glean/lang/flow
+        glean/lang/hack
+        glean/index
+    exposed-modules:
+        Glean.Indexer
+        Glean.Indexer.External
+        Glean.Indexer.Flow
+        Glean.Indexer.Hack
+    build-depends:
+        glean:client-hs,
+        glean:client-hs-local,
+        glean:db,
+        glean:handler,
+        glean:lib,
+        glean:lsif,
+        glean:stubs,
+        glean:util,
+        thrift-server
+
 library cli-types
     import: fb-haskell, fb-cpp, deps
     hs-source-dirs: glean/tools/gleancli/plugin
@@ -962,6 +985,7 @@ executable glean
         GleanCLI.Complete
         GleanCLI.Derive
         GleanCLI.Finish
+        GleanCLI.Index
         GleanCLI.Query
         GleanCLI.Restore
         GleanCLI.Write
@@ -973,6 +997,7 @@ executable glean
         glean:client-hs-local,
         glean:db,
         glean:if-glean-hs,
+        glean:indexers,
         glean:shell-lib,
         glean:stubs,
         glean:config,
@@ -1320,14 +1345,7 @@ library regression-test-lib
     visibility: private
     hs-source-dirs:
         glean/test/regression
-        glean/lang/flow
-        glean/lang/hack
-        glean/index
     exposed-modules:
-        Glean.Indexer
-        Glean.Indexer.External
-        Glean.Indexer.Flow
-        Glean.Indexer.Hack
         Glean.Regression.Config
         Glean.Regression.Driver.External
         Glean.Regression.Indexer
@@ -1340,17 +1358,14 @@ library regression-test-lib
         Glean.Regression.Test
     build-depends:
         glean:client-hs,
-        glean:client-hs-local,
         glean:db,
-        glean:handler,
+        glean:indexers,
         glean:if-glean-hs,
         glean:lib,
-        glean:lsif,
         glean:stubs,
         glean:test-lib,
         glean:util,
         split,
-        thrift-server,
         yaml
 
 -- library clang-derive-test
@@ -1749,7 +1764,9 @@ test-suite glean-snapshot-flow
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/Flow/Main.hs
     ghc-options: -main-is Glean.Regression.Flow.Main
-    build-depends: glean:regression-test-lib
+    build-depends:
+        glean:regression-test-lib,
+        glean:indexers
 
 test-suite glean-snapshot-hack
     import: fb-haskell, deps
@@ -1757,7 +1774,9 @@ test-suite glean-snapshot-hack
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/Hack/Main.hs
     ghc-options: -main-is Glean.Regression.Hack.Main
-    build-depends: glean:regression-test-lib
+    build-depends:
+        glean:regression-test-lib,
+        glean:indexers
     -- no regular hhvm builds for arm64
     if !flag(hack-tests)
         buildable: False
@@ -1844,6 +1863,7 @@ test-suite glass-regression-flow
     other-modules: Glean.Glass.Regression.Flow
     build-depends:
         glean:client-hs,
+        glean:indexers,
         glean:util
 
 test-suite glass-regression-hack
@@ -1854,6 +1874,7 @@ test-suite glass-regression-hack
     other-modules: Glean.Glass.Regression.Hack
     build-depends:
         glean:client-hs,
+        glean:indexers,
         glean:util,
     if !flag(hack-tests)
         buildable: False

--- a/glean.cabal
+++ b/glean.cabal
@@ -951,11 +951,13 @@ library indexers
         glean/lang/flow
         glean/lang/hack
         glean/index
+        glean/index/list
     exposed-modules:
         Glean.Indexer
         Glean.Indexer.External
         Glean.Indexer.Flow
         Glean.Indexer.Hack
+        Glean.Indexer.List
     build-depends:
         glean:client-hs,
         glean:client-hs-local,

--- a/glean/glass/test/regression/Glean/Glass/Regression/Python.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/Python.hs
@@ -13,6 +13,7 @@ import Data.Text (Text)
 import Test.HUnit
 
 import Glean
+import Glean.Indexer.Python as Python
 import Glean.Regression.Test
 import Glean.Util.Some
 
@@ -20,7 +21,7 @@ import Glean.Glass.Types
 import Glean.Glass.Regression.Tests
 
 main :: IO ()
-main = mainTestIndexExternal "glass-regression-python" $ \get -> TestList
+main = mainTestIndex "glass-regression-python" Python.indexer $ \get -> TestList
   [ testDocumentSymbolListX (Path "all.py") get
   , testSymbolIdLookup get
   , testPythonFindReferences get

--- a/glean/index/Glean/Indexer.hs
+++ b/glean/index/Glean/Indexer.hs
@@ -28,7 +28,9 @@ import Glean.Util.Some
 -- backend.
 --
 data Indexer opts = Indexer
-  { indexerOptParser :: Parser opts
+  { indexerShortName :: String
+  , indexerDescription :: String
+  , indexerOptParser :: Parser opts
   , indexerRun :: opts -> RunIndexer
   }
 
@@ -60,14 +62,16 @@ data IndexerParams = IndexerParams
 -- generalise this, but this more restricted form was found to be more
 -- convenient when used with 'Driver'.
 indexerThen :: Indexer a -> RunIndexer -> Indexer a
-indexerThen (Indexer parseOpts run1) run2 = Indexer
-  { indexerOptParser = parseOpts
-  , indexerRun = \opts backend repo params ->
-      run1 opts backend repo params >> run2 backend repo params
+indexerThen indexer run2 = indexer
+  { indexerRun = \opts backend repo params -> do
+      indexerRun indexer opts backend repo params
+      run2 backend repo params
   }
 
-indexerWithNoOptions :: RunIndexer -> Indexer ()
-indexerWithNoOptions run = Indexer
-  { indexerOptParser = pure ()
+indexerWithNoOptions :: String -> RunIndexer -> Indexer ()
+indexerWithNoOptions name run = Indexer
+  { indexerShortName = name
+  , indexerDescription = name
+  , indexerOptParser = pure ()
   , indexerRun = const run
   }

--- a/glean/index/Glean/Indexer/External.hs
+++ b/glean/index/Glean/Indexer/External.hs
@@ -51,7 +51,9 @@ import Glean.Util.Service
 
 externalIndexer :: Indexer Ext
 externalIndexer = Indexer
-  { indexerOptParser = extOptions
+  { indexerShortName = "external"
+  , indexerDescription = "A generic indexer that runs an external binary"
+  , indexerOptParser = extOptions
   , indexerRun = execExternal
   }
 

--- a/glean/index/list/Glean/Indexer/List.hs
+++ b/glean/index/list/Glean/Indexer/List.hs
@@ -6,6 +6,7 @@
   LICENSE file in the root directory of this source tree.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ApplicativeDo #-}
 module Glean.Indexer.List (
     SomeIndexer(..),
@@ -22,6 +23,9 @@ import Glean.Indexer
 import qualified Glean.Indexer.External as External
 import qualified Glean.Indexer.Flow as Flow
 import qualified Glean.Indexer.Hack as Hack
+#ifdef FACEBOOK
+import qualified Glean.Indexer.Python as Python
+#endif
 
 data SomeIndexer = forall opts . SomeIndexer (Indexer opts)
 
@@ -30,6 +34,9 @@ indexers =
   [ SomeIndexer External.externalIndexer
   , SomeIndexer Flow.indexer
   , SomeIndexer Hack.indexer
+#ifdef FACEBOOK
+  , SomeIndexer Python.indexer
+#endif
   ]
 
 cmdLineParser :: Parser RunIndexer

--- a/glean/index/list/Glean/Indexer/List.hs
+++ b/glean/index/list/Glean/Indexer/List.hs
@@ -1,0 +1,32 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Glean.Indexer.List (
+    SomeIndexer(..),
+    indexers,
+  ) where
+
+import Glean.Indexer
+import qualified Glean.Indexer.External as External
+import qualified Glean.Indexer.Flow as Flow
+import qualified Glean.Indexer.Hack as Hack
+
+data SomeIndexer = forall opts . SomeIndexer (Indexer opts)
+
+indexers :: [(String, String, SomeIndexer)]
+indexers =
+  [ ("external",
+      "Use a generic external indexer",
+      SomeIndexer External.externalIndexer)
+  , ("flow",
+      "Index JS/Flow code",
+      SomeIndexer Flow.indexer)
+  , ("hack",
+      "Index Hack code",
+      SomeIndexer Hack.indexer)
+  ]

--- a/glean/lang/codemarkup/tests/flow/Glean/Regression/Flow/Main.hs
+++ b/glean/lang/codemarkup/tests/flow/Glean/Regression/Flow/Main.hs
@@ -10,10 +10,12 @@ module Glean.Regression.Flow.Main ( main ) where
 
 import System.Environment ( withArgs )
 
-import qualified Glean.Regression.Driver.External as Driver ( main )
-import qualified Glean.Regression.Driver.Args.Flow as Flow
+import Glean.Indexer.Flow as Flow
+import Glean.Regression.Snapshot
+import Glean.Regression.Snapshot.Driver
 
 main :: IO ()
-main = withArgs (Flow.args path) Driver.main
+main = withArgs ["--root", path] $ testMain driver
   where
+      driver = driverFromIndexer Flow.indexer
       path = "glean/lang/codemarkup/tests/flow/cases"

--- a/glean/lang/codemarkup/tests/hack/Glean/Regression/Hack/Main.hs
+++ b/glean/lang/codemarkup/tests/hack/Glean/Regression/Hack/Main.hs
@@ -10,10 +10,12 @@ module Glean.Regression.Hack.Main ( main ) where
 
 import System.Environment ( withArgs )
 
-import qualified Glean.Regression.Driver.External as Driver ( main )
-import qualified Glean.Regression.Driver.Args.Hack as Hack
+import Glean.Indexer.Hack as Hack
+import Glean.Regression.Snapshot
+import Glean.Regression.Snapshot.Driver
 
 main :: IO ()
-main = withArgs (Hack.args path) Driver.main
+main = withArgs ["--root", path] $ testMain driver
   where
-    path = "glean/lang/codemarkup/tests/hack/cases"
+      driver = driverFromIndexer Hack.indexer
+      path = "glean/lang/codemarkup/tests/hack/cases"

--- a/glean/lang/flow/Glean/Indexer/Flow.hs
+++ b/glean/lang/flow/Glean/Indexer/Flow.hs
@@ -30,6 +30,8 @@ options = do
 
 indexer :: Indexer Flow
 indexer = Indexer {
+  indexerShortName = "flow",
+  indexerDescription = "Index JS/Flow code",
   indexerOptParser = options,
   indexerRun = \Flow{..} -> do
     let ext = Ext {

--- a/glean/lang/hack/Glean/Indexer/Hack.hs
+++ b/glean/lang/hack/Glean/Indexer/Hack.hs
@@ -33,6 +33,8 @@ options = do
 
 indexer :: Indexer Hack
 indexer = Indexer {
+  indexerShortName = "hack",
+  indexerDescription = "Index Hack code",
   indexerOptParser = options,
   indexerRun = \Hack{..} -> do
     let ext = Ext {

--- a/glean/lang/hack/Glean/Indexer/Hack.hs
+++ b/glean/lang/hack/Glean/Indexer/Hack.hs
@@ -7,7 +7,7 @@
 -}
 
 {-# LANGUAGE ApplicativeDo #-}
-module Glean.Indexer.Hack ( indexer ) where
+module Glean.Indexer.Hack ( indexer, Hack(..) ) where
 
 import Options.Applicative
 
@@ -17,6 +17,7 @@ import Glean.Indexer.External
 data Hack = Hack
   { hackBinary :: FilePath
   , hackWriteRoot :: String
+  , hackOnly :: Maybe String
   }
 
 options :: Parser Hack
@@ -29,6 +30,9 @@ options = do
     long "symbol-write-root-path" <>
     value "www" <>
     help "prefix to add to source file paths in the DB"
+  hackOnly <- optional $ strOption $
+    long "only-index" <>
+    help "comma-separated list of files to index (otherwise all)"
   return Hack{..}
 
 indexer :: Indexer Hack
@@ -58,7 +62,7 @@ indexer = Indexer {
             ]
         }
 
-        hhConfig = concat $ map (\x -> ["--config", x])
+        hhConfig = concat $ map (\x -> ["--config", x]) $
           [ "symbol_write_include_hhi=false"
           , "symbol_write_root_path=" <> hackWriteRoot
           , "symbolindex_search_provider=NoIndex"
@@ -68,7 +72,10 @@ indexer = Indexer {
           , "lazy_init2=true"
           , "enable_enum_classes=true"
           , "enable_enum_supertyping=true"
-          ]
+          ] <>
+          (case hackOnly of
+            Nothing -> []
+            Just paths -> ["symbol_write_index_paths=" <> paths])
 
     indexerRun externalIndexer ext
   }

--- a/glean/lang/hack/tests/Driver.hs
+++ b/glean/lang/hack/tests/Driver.hs
@@ -14,15 +14,15 @@ import Derive.Env (withEnv)
 import Derive.HackDeclarationTarget (deriveHackDeclarationTarget)
 import qualified Derive.Types as DT
 import Glean.Indexer
-import Glean.Indexer.External
+import qualified Glean.Indexer.Hack as Hack
 import Glean.Regression.Snapshot (testMain)
 import Glean.Regression.Snapshot.Driver
 
-indexer :: Indexer Ext
+indexer :: Indexer Hack.Hack
 indexer =
-  externalIndexer `indexerThen` \env repo _params ->
+  Hack.indexer `indexerThen` \env repo _params ->
     withEnv (DT.defaultConfig repo) env
       deriveHackDeclarationTarget
 
 main :: IO ()
-main = testMain (externalDriver { driverIndexer = indexer })
+main = testMain (driverFromIndexer indexer)

--- a/glean/test/regression/Glean/Regression/Driver/External.hs
+++ b/glean/test/regression/Glean/Regression/Driver/External.hs
@@ -10,8 +10,29 @@
 
 module Glean.Regression.Driver.External (main) where
 
-import Glean.Regression.Snapshot
+import System.Environment
+
+import Util.Log
+
+import Glean.Indexer
+import Glean.Indexer.List (cmdLineParser)
+
+import Glean.Regression.Snapshot (testMain)
 import Glean.Regression.Snapshot.Driver
 
+snapshotDriver :: Driver RunIndexer
+snapshotDriver = driverFromIndexer
+  Indexer {
+    indexerShortName = "multiple",
+    indexerDescription = "Choose an indexer to run",
+    indexerOptParser = cmdLineParser,
+    indexerRun = id
+  }
+
 main :: IO ()
-main = testMain externalDriver
+main = do
+  args <- getArgs
+  logInfo $ "args: " <> show args
+    -- useful for debugging issues in surrounding scripts that pass
+    -- arguments in.
+  testMain snapshotDriver

--- a/glean/test/regression/Glean/Regression/Snapshot/Driver.hs
+++ b/glean/test/regression/Glean/Regression/Snapshot/Driver.hs
@@ -8,7 +8,6 @@
 
 module Glean.Regression.Snapshot.Driver
   ( Driver(..)
-  , emptyDriver
   , driverFromIndexer
   , externalDriver
   ) where
@@ -32,17 +31,11 @@ data Driver opts = Driver
 
 type Group = String
 
-emptyDriver :: Driver ()
-emptyDriver = Driver
-  { driverIndexer = Indexer (pure ()) (\_ _ _ _ -> return ())
-  , driverGroups = const []
-  , driverTransforms = mempty
-  }
-
 driverFromIndexer :: Indexer opts -> Driver opts
-driverFromIndexer indexer = emptyDriver
+driverFromIndexer indexer = Driver
   { driverIndexer = indexer
   , driverGroups = const []
+  , driverTransforms = mempty
   }
 
 -- | A 'Driver' using an external 'Indexer'. See
@@ -51,7 +44,4 @@ driverFromIndexer indexer = emptyDriver
 -- This driver doesn't support multiple groups; that could be added if
 -- necessary.
 externalDriver :: Driver Ext
-externalDriver = emptyDriver
-  { driverIndexer = externalIndexer
-  , driverGroups = const []
-  }
+externalDriver = driverFromIndexer externalIndexer

--- a/glean/tools/gleancli/GleanCLI/Index.hs
+++ b/glean/tools/gleancli/GleanCLI/Index.hs
@@ -19,9 +19,7 @@ import Util.OptParse
 
 import Glean hiding (options)
 import Glean.Indexer
-import qualified Glean.Indexer.External as External
-import qualified Glean.Indexer.Flow as Flow
-import qualified Glean.Indexer.Hack as Hack
+import Glean.Indexer.List
 import Glean.Util.Some
 
 import GleanCLI.Common
@@ -33,21 +31,6 @@ data IndexCommand
       , indexCmdRoot :: FilePath
       , indexCmdRun :: RunIndexer
       }
-
-data SomeIndexer = forall opts . SomeIndexer (Indexer opts)
-
-indexers :: [(String, String, SomeIndexer)]
-indexers =
-  [ ("external",
-      "Use a generic external indexer",
-      SomeIndexer External.externalIndexer)
-  , ("flow",
-      "Index JS/Flow code",
-      SomeIndexer Flow.indexer)
-  , ("hack",
-      "Index Hack code",
-      SomeIndexer Hack.indexer)
-  ]
 
 instance Plugin IndexCommand where
   parseCommand =

--- a/glean/tools/gleancli/GleanCLI/Index.hs
+++ b/glean/tools/gleancli/GleanCLI/Index.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 module GleanCLI.Index (IndexCommand) where
 
-import Data.Foldable
 import Options.Applicative
 import System.Directory
 import System.IO.Temp
@@ -36,14 +35,9 @@ instance Plugin IndexCommand where
   parseCommand =
     commandParser "index" (progDesc "Index some source code") $ do
       indexCmdRepo <- repoOpts
-      indexCmdRun <- asum langs
+      indexCmdRun <- cmdLineParser
       indexCmdRoot <- strArgument (metavar "ROOT")
       return Index{..}
-   where
-     langs = flip map indexers $ \(cmd, desc, SomeIndexer indexer) ->
-       commandParser cmd (progDesc desc) $ do
-         opts <- indexerOptParser indexer
-         return (indexerRun indexer opts)
 
   runCommand _evb _cfg backend Index{..} = do
     projectRoot <- getCurrentDirectory


### PR DESCRIPTION
Summary:
Finally, removing the duplication by using the new Indexer abstraction
instead of the .bzl logic. This makes the indexers usable in the open
source build without having to duplicate the logic there.

Reviewed By: pepeiborra

Differential Revision: D35814034

