### PR TITLE
LSIF ranges are indexed inclusive-of-end column

### DIFF
--- a/glean/lang/go/tests/cases/xrefs/entitylocation.out
+++ b/glean/lang/go/tests/cases/xrefs/entitylocation.out
@@ -23,7 +23,7 @@
                           "lineBegin": 11,
                           "columnBegin": 9,
                           "lineEnd": 11,
-                          "columnEnd": 17
+                          "columnEnd": 16
                         },
                         "text": { "key": "" }
                       }
@@ -51,7 +51,7 @@
             "lineBegin": 11,
             "columnBegin": 9,
             "lineEnd": 11,
-            "columnEnd": 17
+            "columnEnd": 16
           }
         }
       }
@@ -80,7 +80,7 @@
                           "lineBegin": 24,
                           "columnBegin": 6,
                           "lineEnd": 24,
-                          "columnEnd": 13
+                          "columnEnd": 12
                         },
                         "text": { "key": "" }
                       }
@@ -108,7 +108,7 @@
             "lineBegin": 24,
             "columnBegin": 6,
             "lineEnd": 24,
-            "columnEnd": 13
+            "columnEnd": 12
           }
         }
       }
@@ -137,7 +137,7 @@
                           "lineBegin": 24,
                           "columnBegin": 14,
                           "lineEnd": 24,
-                          "columnEnd": 18
+                          "columnEnd": 17
                         },
                         "text": { "key": "" }
                       }
@@ -158,7 +158,7 @@
             "lineBegin": 24,
             "columnBegin": 14,
             "lineEnd": 24,
-            "columnEnd": 18
+            "columnEnd": 17
           }
         }
       }
@@ -187,7 +187,7 @@
                           "lineBegin": 25,
                           "columnBegin": 2,
                           "lineEnd": 25,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -208,7 +208,7 @@
             "lineBegin": 25,
             "columnBegin": 2,
             "lineEnd": 25,
-            "columnEnd": 7
+            "columnEnd": 6
           }
         }
       }
@@ -237,7 +237,7 @@
                           "lineBegin": 27,
                           "columnBegin": 6,
                           "lineEnd": 27,
-                          "columnEnd": 14
+                          "columnEnd": 13
                         },
                         "text": { "key": "" }
                       }
@@ -258,7 +258,7 @@
             "lineBegin": 27,
             "columnBegin": 6,
             "lineEnd": 27,
-            "columnEnd": 14
+            "columnEnd": 13
           }
         }
       }
@@ -287,7 +287,7 @@
                           "lineBegin": 28,
                           "columnBegin": 2,
                           "lineEnd": 28,
-                          "columnEnd": 14
+                          "columnEnd": 13
                         },
                         "text": { "key": "" }
                       }
@@ -308,7 +308,7 @@
             "lineBegin": 28,
             "columnBegin": 2,
             "lineEnd": 28,
-            "columnEnd": 14
+            "columnEnd": 13
           }
         }
       }
@@ -337,7 +337,7 @@
                           "lineBegin": 28,
                           "columnBegin": 23,
                           "lineEnd": 28,
-                          "columnEnd": 24
+                          "columnEnd": 23
                         },
                         "text": { "key": "" }
                       }
@@ -358,7 +358,7 @@
             "lineBegin": 28,
             "columnBegin": 23,
             "lineEnd": 28,
-            "columnEnd": 24
+            "columnEnd": 23
           }
         }
       }
@@ -387,7 +387,7 @@
                           "lineBegin": 35,
                           "columnBegin": 6,
                           "lineEnd": 35,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -408,7 +408,7 @@
             "lineBegin": 35,
             "columnBegin": 6,
             "lineEnd": 35,
-            "columnEnd": 7
+            "columnEnd": 6
           }
         }
       }
@@ -437,7 +437,7 @@
                           "lineBegin": 44,
                           "columnBegin": 4,
                           "lineEnd": 44,
-                          "columnEnd": 8
+                          "columnEnd": 7
                         },
                         "text": { "key": "" }
                       }
@@ -458,7 +458,7 @@
             "lineBegin": 44,
             "columnBegin": 4,
             "lineEnd": 44,
-            "columnEnd": 8
+            "columnEnd": 7
           }
         }
       }
@@ -487,7 +487,7 @@
                           "lineBegin": 46,
                           "columnBegin": 4,
                           "lineEnd": 46,
-                          "columnEnd": 14
+                          "columnEnd": 13
                         },
                         "text": { "key": "" }
                       }
@@ -508,7 +508,7 @@
             "lineBegin": 46,
             "columnBegin": 4,
             "lineEnd": 46,
-            "columnEnd": 14
+            "columnEnd": 13
           }
         }
       }
@@ -537,7 +537,7 @@
                           "lineBegin": 56,
                           "columnBegin": 2,
                           "lineEnd": 56,
-                          "columnEnd": 6
+                          "columnEnd": 5
                         },
                         "text": { "key": "" }
                       }
@@ -558,7 +558,7 @@
             "lineBegin": 56,
             "columnBegin": 2,
             "lineEnd": 56,
-            "columnEnd": 6
+            "columnEnd": 5
           }
         }
       }
@@ -587,7 +587,7 @@
                           "lineBegin": 58,
                           "columnBegin": 6,
                           "lineEnd": 58,
-                          "columnEnd": 17
+                          "columnEnd": 16
                         },
                         "text": { "key": "" }
                       }
@@ -608,7 +608,7 @@
             "lineBegin": 58,
             "columnBegin": 6,
             "lineEnd": 58,
-            "columnEnd": 17
+            "columnEnd": 16
           }
         }
       }
@@ -637,7 +637,7 @@
                           "lineBegin": 60,
                           "columnBegin": 6,
                           "lineEnd": 60,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -658,7 +658,7 @@
             "lineBegin": 60,
             "columnBegin": 6,
             "lineEnd": 60,
-            "columnEnd": 7
+            "columnEnd": 6
           }
         }
       }

--- a/glean/lang/go/tests/cases/xrefs/entityreferences.out
+++ b/glean/lang/go/tests/cases/xrefs/entityreferences.out
@@ -23,7 +23,7 @@
                           "lineBegin": 24,
                           "columnBegin": 14,
                           "lineEnd": 24,
-                          "columnEnd": 18
+                          "columnEnd": 17
                         },
                         "text": { "key": "" }
                       }
@@ -42,7 +42,7 @@
           "lineBegin": 25,
           "columnBegin": 32,
           "lineEnd": 25,
-          "columnEnd": 36
+          "columnEnd": 35
         }
       }
     }
@@ -70,7 +70,7 @@
                           "lineBegin": 25,
                           "columnBegin": 2,
                           "lineEnd": 25,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -89,7 +89,7 @@
           "lineBegin": 35,
           "columnBegin": 22,
           "lineEnd": 35,
-          "columnEnd": 27
+          "columnEnd": 26
         }
       }
     }
@@ -117,7 +117,7 @@
                           "lineBegin": 25,
                           "columnBegin": 2,
                           "lineEnd": 25,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -136,7 +136,7 @@
           "lineBegin": 36,
           "columnBegin": 24,
           "lineEnd": 36,
-          "columnEnd": 29
+          "columnEnd": 28
         }
       }
     }
@@ -164,7 +164,7 @@
                           "lineBegin": 25,
                           "columnBegin": 2,
                           "lineEnd": 25,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -183,7 +183,7 @@
           "lineBegin": 36,
           "columnBegin": 61,
           "lineEnd": 36,
-          "columnEnd": 66
+          "columnEnd": 65
         }
       }
     }
@@ -211,7 +211,7 @@
                           "lineBegin": 25,
                           "columnBegin": 2,
                           "lineEnd": 25,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -230,1087 +230,6 @@
           "lineBegin": 39,
           "columnBegin": 42,
           "lineEnd": 39,
-          "columnEnd": 47
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 25,
-                          "columnBegin": 2,
-                          "lineEnd": 25,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 39,
-          "columnBegin": 57,
-          "lineEnd": 39,
-          "columnEnd": 62
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 25,
-                          "columnBegin": 2,
-                          "lineEnd": 25,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 40,
-          "columnBegin": 31,
-          "lineEnd": 40,
-          "columnEnd": 36
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 25,
-                          "columnBegin": 2,
-                          "lineEnd": 25,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 44,
-          "columnBegin": 12,
-          "lineEnd": 44,
-          "columnEnd": 17
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 27,
-                          "columnBegin": 6,
-                          "lineEnd": 27,
-                          "columnEnd": 14
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 39,
-          "columnBegin": 4,
-          "lineEnd": 39,
-          "columnEnd": 12
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 27,
-                          "columnBegin": 6,
-                          "lineEnd": 27,
-                          "columnEnd": 14
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 51,
-          "columnBegin": 4,
-          "lineEnd": 51,
-          "columnEnd": 12
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 27,
-                          "columnBegin": 6,
-                          "lineEnd": 27,
-                          "columnEnd": 14
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 56,
-          "columnBegin": 44,
-          "lineEnd": 56,
-          "columnEnd": 52
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 28,
-                          "columnBegin": 2,
-                          "lineEnd": 28,
-                          "columnEnd": 14
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 39,
-          "columnBegin": 28,
-          "lineEnd": 39,
-          "columnEnd": 40
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 28,
-                          "columnBegin": 2,
-                          "lineEnd": 28,
-                          "columnEnd": 14
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 51,
-          "columnBegin": 28,
-          "lineEnd": 51,
-          "columnEnd": 40
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 28,
-                          "columnBegin": 23,
-                          "lineEnd": 28,
-                          "columnEnd": 24
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 29,
-          "columnBegin": 6,
-          "lineEnd": 29,
-          "columnEnd": 7
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 28,
-                          "columnBegin": 23,
-                          "lineEnd": 28,
-                          "columnEnd": 24
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 29,
-          "columnBegin": 18,
-          "lineEnd": 29,
-          "columnEnd": 19
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 28,
-                          "columnBegin": 23,
-                          "lineEnd": 28,
-                          "columnEnd": 24
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 32,
-          "columnBegin": 10,
-          "lineEnd": 32,
-          "columnEnd": 11
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 35,
-          "columnBegin": 14,
-          "lineEnd": 35,
-          "columnEnd": 15
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 35,
-          "columnBegin": 30,
-          "lineEnd": 35,
-          "columnEnd": 31
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 36,
-          "columnBegin": 30,
-          "lineEnd": 36,
-          "columnEnd": 31
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 36,
-          "columnBegin": 67,
-          "lineEnd": 36,
-          "columnEnd": 68
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 39,
-          "columnBegin": 48,
-          "lineEnd": 39,
-          "columnEnd": 49
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 39,
-          "columnBegin": 63,
-          "lineEnd": 39,
-          "columnEnd": 64
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 40,
-          "columnBegin": 37,
-          "lineEnd": 40,
-          "columnEnd": 38
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 44,
-          "columnBegin": 18,
-          "lineEnd": 44,
-          "columnEnd": 19
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 44,
-                          "columnBegin": 4,
-                          "lineEnd": 44,
-                          "columnEnd": 8
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 46,
-          "columnBegin": 32,
-          "lineEnd": 46,
-          "columnEnd": 36
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 44,
-                          "columnBegin": 4,
-                          "lineEnd": 44,
-                          "columnEnd": 8
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 48,
-          "columnBegin": 5,
-          "lineEnd": 48,
-          "columnEnd": 9
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 44,
-                          "columnBegin": 4,
-                          "lineEnd": 44,
-                          "columnEnd": 8
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 48,
-          "columnBegin": 12,
-          "lineEnd": 48,
-          "columnEnd": 16
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 44,
-                          "columnBegin": 4,
-                          "lineEnd": 44,
-                          "columnEnd": 8
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 51,
-          "columnBegin": 42,
-          "lineEnd": 51,
           "columnEnd": 46
         }
       }
@@ -1336,10 +255,10 @@
                     "range": {
                       "key": {
                         "range": {
-                          "lineBegin": 46,
-                          "columnBegin": 4,
-                          "lineEnd": 46,
-                          "columnEnd": 14
+                          "lineBegin": 25,
+                          "columnBegin": 2,
+                          "lineEnd": 25,
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -1355,10 +274,1044 @@
       "range": {
         "range": {
           "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 47,
-          "columnBegin": 7,
-          "lineEnd": 47,
-          "columnEnd": 17
+          "lineBegin": 39,
+          "columnBegin": 57,
+          "lineEnd": 39,
+          "columnEnd": 61
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 25,
+                          "columnBegin": 2,
+                          "lineEnd": 25,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 40,
+          "columnBegin": 31,
+          "lineEnd": 40,
+          "columnEnd": 35
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 25,
+                          "columnBegin": 2,
+                          "lineEnd": 25,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 44,
+          "columnBegin": 12,
+          "lineEnd": 44,
+          "columnEnd": 16
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 27,
+                          "columnBegin": 6,
+                          "lineEnd": 27,
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 39,
+          "columnBegin": 4,
+          "lineEnd": 39,
+          "columnEnd": 11
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 27,
+                          "columnBegin": 6,
+                          "lineEnd": 27,
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 51,
+          "columnBegin": 4,
+          "lineEnd": 51,
+          "columnEnd": 11
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 27,
+                          "columnBegin": 6,
+                          "lineEnd": 27,
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 56,
+          "columnBegin": 44,
+          "lineEnd": 56,
+          "columnEnd": 51
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 28,
+                          "columnBegin": 2,
+                          "lineEnd": 28,
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 39,
+          "columnBegin": 28,
+          "lineEnd": 39,
+          "columnEnd": 39
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 28,
+                          "columnBegin": 2,
+                          "lineEnd": 28,
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 51,
+          "columnBegin": 28,
+          "lineEnd": 51,
+          "columnEnd": 39
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 28,
+                          "columnBegin": 23,
+                          "lineEnd": 28,
+                          "columnEnd": 23
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 29,
+          "columnBegin": 6,
+          "lineEnd": 29,
+          "columnEnd": 6
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 28,
+                          "columnBegin": 23,
+                          "lineEnd": 28,
+                          "columnEnd": 23
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 29,
+          "columnBegin": 18,
+          "lineEnd": 29,
+          "columnEnd": 18
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 28,
+                          "columnBegin": 23,
+                          "lineEnd": 28,
+                          "columnEnd": 23
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 32,
+          "columnBegin": 10,
+          "lineEnd": 32,
+          "columnEnd": 10
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 35,
+          "columnBegin": 14,
+          "lineEnd": 35,
+          "columnEnd": 14
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 35,
+          "columnBegin": 30,
+          "lineEnd": 35,
+          "columnEnd": 30
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 36,
+          "columnBegin": 30,
+          "lineEnd": 36,
+          "columnEnd": 30
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 36,
+          "columnBegin": 67,
+          "lineEnd": 36,
+          "columnEnd": 67
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 39,
+          "columnBegin": 48,
+          "lineEnd": 39,
+          "columnEnd": 48
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 39,
+          "columnBegin": 63,
+          "lineEnd": 39,
+          "columnEnd": 63
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 40,
+          "columnBegin": 37,
+          "lineEnd": 40,
+          "columnEnd": 37
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 44,
+          "columnBegin": 18,
+          "lineEnd": 44,
+          "columnEnd": 18
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 44,
+                          "columnBegin": 4,
+                          "lineEnd": 44,
+                          "columnEnd": 7
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 46,
+          "columnBegin": 32,
+          "lineEnd": 46,
+          "columnEnd": 35
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 44,
+                          "columnBegin": 4,
+                          "lineEnd": 44,
+                          "columnEnd": 7
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 48,
+          "columnBegin": 5,
+          "lineEnd": 48,
+          "columnEnd": 8
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 44,
+                          "columnBegin": 4,
+                          "lineEnd": 44,
+                          "columnEnd": 7
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 48,
+          "columnBegin": 12,
+          "lineEnd": 48,
+          "columnEnd": 15
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 44,
+                          "columnBegin": 4,
+                          "lineEnd": 44,
+                          "columnEnd": 7
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 51,
+          "columnBegin": 42,
+          "lineEnd": 51,
+          "columnEnd": 45
         }
       }
     }
@@ -1386,7 +1339,54 @@
                           "lineBegin": 46,
                           "columnBegin": 4,
                           "lineEnd": 46,
-                          "columnEnd": 14
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 47,
+          "columnBegin": 7,
+          "lineEnd": 47,
+          "columnEnd": 16
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 46,
+                          "columnBegin": 4,
+                          "lineEnd": 46,
+                          "columnEnd": 13
                         },
                         "text": { "key": "" }
                       }
@@ -1405,7 +1405,7 @@
           "lineBegin": 48,
           "columnBegin": 21,
           "lineEnd": 48,
-          "columnEnd": 31
+          "columnEnd": 30
         }
       }
     }
@@ -1433,7 +1433,7 @@
                           "lineBegin": 56,
                           "columnBegin": 2,
                           "lineEnd": 56,
-                          "columnEnd": 6
+                          "columnEnd": 5
                         },
                         "text": { "key": "" }
                       }
@@ -1452,7 +1452,7 @@
           "lineBegin": 64,
           "columnBegin": 18,
           "lineEnd": 64,
-          "columnEnd": 22
+          "columnEnd": 21
         }
       }
     }
@@ -1480,7 +1480,7 @@
                           "lineBegin": 58,
                           "columnBegin": 6,
                           "lineEnd": 58,
-                          "columnEnd": 17
+                          "columnEnd": 16
                         },
                         "text": { "key": "" }
                       }
@@ -1499,7 +1499,7 @@
           "lineBegin": 61,
           "columnBegin": 6,
           "lineEnd": 61,
-          "columnEnd": 17
+          "columnEnd": 16
         }
       }
     }
@@ -1527,7 +1527,7 @@
                           "lineBegin": 58,
                           "columnBegin": 6,
                           "lineEnd": 58,
-                          "columnEnd": 17
+                          "columnEnd": 16
                         },
                         "text": { "key": "" }
                       }
@@ -1546,53 +1546,6 @@
           "lineBegin": 62,
           "columnBegin": 4,
           "lineEnd": 62,
-          "columnEnd": 15
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 58,
-                          "columnBegin": 6,
-                          "lineEnd": 58,
-                          "columnEnd": 17
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "range": {
-        "range": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "lineBegin": 64,
-          "columnBegin": 3,
-          "lineEnd": 64,
           "columnEnd": 14
         }
       }
@@ -1621,7 +1574,54 @@
                           "lineBegin": 58,
                           "columnBegin": 6,
                           "lineEnd": 58,
-                          "columnEnd": 17
+                          "columnEnd": 16
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "range": {
+        "range": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "lineBegin": 64,
+          "columnBegin": 3,
+          "lineEnd": 64,
+          "columnEnd": 13
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 58,
+                          "columnBegin": 6,
+                          "lineEnd": 58,
+                          "columnEnd": 16
                         },
                         "text": { "key": "" }
                       }
@@ -1640,7 +1640,7 @@
           "lineBegin": 67,
           "columnBegin": 9,
           "lineEnd": 67,
-          "columnEnd": 20
+          "columnEnd": 19
         }
       }
     }
@@ -1668,7 +1668,7 @@
                           "lineBegin": 60,
                           "columnBegin": 6,
                           "lineEnd": 60,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -1687,7 +1687,7 @@
           "lineBegin": 60,
           "columnBegin": 14,
           "lineEnd": 60,
-          "columnEnd": 15
+          "columnEnd": 14
         }
       }
     }
@@ -1715,7 +1715,7 @@
                           "lineBegin": 60,
                           "columnBegin": 6,
                           "lineEnd": 60,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -1734,7 +1734,7 @@
           "lineBegin": 60,
           "columnBegin": 21,
           "lineEnd": 60,
-          "columnEnd": 22
+          "columnEnd": 21
         }
       }
     }
@@ -1762,7 +1762,7 @@
                           "lineBegin": 60,
                           "columnBegin": 6,
                           "lineEnd": 60,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -1781,7 +1781,7 @@
           "lineBegin": 64,
           "columnBegin": 23,
           "lineEnd": 64,
-          "columnEnd": 24
+          "columnEnd": 23
         }
       }
     }
@@ -1809,7 +1809,7 @@
                           "lineBegin": 60,
                           "columnBegin": 6,
                           "lineEnd": 60,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -1828,7 +1828,7 @@
           "lineBegin": 64,
           "columnBegin": 30,
           "lineEnd": 64,
-          "columnEnd": 31
+          "columnEnd": 30
         }
       }
     }

--- a/glean/lang/go/tests/cases/xrefs/filedefinitions.out
+++ b/glean/lang/go/tests/cases/xrefs/filedefinitions.out
@@ -14,7 +14,7 @@
             "lineBegin": 11,
             "columnBegin": 9,
             "lineEnd": 11,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "" }
         }
@@ -35,7 +35,7 @@
             "lineBegin": 24,
             "columnBegin": 6,
             "lineEnd": 24,
-            "columnEnd": 13
+            "columnEnd": 12
           },
           "text": { "key": "" }
         }
@@ -56,7 +56,7 @@
             "lineBegin": 24,
             "columnBegin": 14,
             "lineEnd": 24,
-            "columnEnd": 18
+            "columnEnd": 17
           },
           "text": { "key": "" }
         }
@@ -77,7 +77,7 @@
             "lineBegin": 25,
             "columnBegin": 2,
             "lineEnd": 25,
-            "columnEnd": 7
+            "columnEnd": 6
           },
           "text": { "key": "" }
         }
@@ -98,7 +98,7 @@
             "lineBegin": 27,
             "columnBegin": 6,
             "lineEnd": 27,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "" }
         }
@@ -119,7 +119,7 @@
             "lineBegin": 28,
             "columnBegin": 2,
             "lineEnd": 28,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "" }
         }
@@ -140,7 +140,7 @@
             "lineBegin": 28,
             "columnBegin": 23,
             "lineEnd": 28,
-            "columnEnd": 24
+            "columnEnd": 23
           },
           "text": { "key": "" }
         }
@@ -161,7 +161,7 @@
             "lineBegin": 35,
             "columnBegin": 6,
             "lineEnd": 35,
-            "columnEnd": 7
+            "columnEnd": 6
           },
           "text": { "key": "" }
         }
@@ -182,7 +182,7 @@
             "lineBegin": 44,
             "columnBegin": 4,
             "lineEnd": 44,
-            "columnEnd": 8
+            "columnEnd": 7
           },
           "text": { "key": "" }
         }
@@ -203,7 +203,7 @@
             "lineBegin": 46,
             "columnBegin": 4,
             "lineEnd": 46,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "" }
         }
@@ -224,7 +224,7 @@
             "lineBegin": 56,
             "columnBegin": 2,
             "lineEnd": 56,
-            "columnEnd": 6
+            "columnEnd": 5
           },
           "text": { "key": "" }
         }
@@ -245,7 +245,7 @@
             "lineBegin": 58,
             "columnBegin": 6,
             "lineEnd": 58,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "" }
         }
@@ -266,7 +266,7 @@
             "lineBegin": 60,
             "columnBegin": 6,
             "lineEnd": 60,
-            "columnEnd": 7
+            "columnEnd": 6
           },
           "text": { "key": "" }
         }

--- a/glean/lang/go/tests/cases/xrefs/fileentitylocations.out
+++ b/glean/lang/go/tests/cases/xrefs/fileentitylocations.out
@@ -12,7 +12,7 @@
             "lineBegin": 11,
             "columnBegin": 9,
             "lineEnd": 11,
-            "columnEnd": 17
+            "columnEnd": 16
           }
         }
       },
@@ -37,7 +37,7 @@
                           "lineBegin": 11,
                           "columnBegin": 9,
                           "lineEnd": 11,
-                          "columnEnd": 17
+                          "columnEnd": 16
                         },
                         "text": { "key": "" }
                       }
@@ -70,7 +70,7 @@
             "lineBegin": 24,
             "columnBegin": 6,
             "lineEnd": 24,
-            "columnEnd": 13
+            "columnEnd": 12
           }
         }
       },
@@ -95,7 +95,7 @@
                           "lineBegin": 24,
                           "columnBegin": 6,
                           "lineEnd": 24,
-                          "columnEnd": 13
+                          "columnEnd": 12
                         },
                         "text": { "key": "" }
                       }
@@ -128,7 +128,7 @@
             "lineBegin": 24,
             "columnBegin": 14,
             "lineEnd": 24,
-            "columnEnd": 18
+            "columnEnd": 17
           }
         }
       },
@@ -153,7 +153,7 @@
                           "lineBegin": 24,
                           "columnBegin": 14,
                           "lineEnd": 24,
-                          "columnEnd": 18
+                          "columnEnd": 17
                         },
                         "text": { "key": "" }
                       }
@@ -179,7 +179,7 @@
             "lineBegin": 25,
             "columnBegin": 2,
             "lineEnd": 25,
-            "columnEnd": 7
+            "columnEnd": 6
           }
         }
       },
@@ -204,7 +204,7 @@
                           "lineBegin": 25,
                           "columnBegin": 2,
                           "lineEnd": 25,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -230,7 +230,7 @@
             "lineBegin": 27,
             "columnBegin": 6,
             "lineEnd": 27,
-            "columnEnd": 14
+            "columnEnd": 13
           }
         }
       },
@@ -255,7 +255,7 @@
                           "lineBegin": 27,
                           "columnBegin": 6,
                           "lineEnd": 27,
-                          "columnEnd": 14
+                          "columnEnd": 13
                         },
                         "text": { "key": "" }
                       }
@@ -281,7 +281,7 @@
             "lineBegin": 28,
             "columnBegin": 2,
             "lineEnd": 28,
-            "columnEnd": 14
+            "columnEnd": 13
           }
         }
       },
@@ -306,7 +306,7 @@
                           "lineBegin": 28,
                           "columnBegin": 2,
                           "lineEnd": 28,
-                          "columnEnd": 14
+                          "columnEnd": 13
                         },
                         "text": { "key": "" }
                       }
@@ -332,7 +332,7 @@
             "lineBegin": 28,
             "columnBegin": 23,
             "lineEnd": 28,
-            "columnEnd": 24
+            "columnEnd": 23
           }
         }
       },
@@ -357,7 +357,7 @@
                           "lineBegin": 28,
                           "columnBegin": 23,
                           "lineEnd": 28,
-                          "columnEnd": 24
+                          "columnEnd": 23
                         },
                         "text": { "key": "" }
                       }
@@ -383,7 +383,7 @@
             "lineBegin": 35,
             "columnBegin": 6,
             "lineEnd": 35,
-            "columnEnd": 7
+            "columnEnd": 6
           }
         }
       },
@@ -408,7 +408,7 @@
                           "lineBegin": 35,
                           "columnBegin": 6,
                           "lineEnd": 35,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -434,7 +434,7 @@
             "lineBegin": 44,
             "columnBegin": 4,
             "lineEnd": 44,
-            "columnEnd": 8
+            "columnEnd": 7
           }
         }
       },
@@ -459,7 +459,7 @@
                           "lineBegin": 44,
                           "columnBegin": 4,
                           "lineEnd": 44,
-                          "columnEnd": 8
+                          "columnEnd": 7
                         },
                         "text": { "key": "" }
                       }
@@ -485,7 +485,7 @@
             "lineBegin": 46,
             "columnBegin": 4,
             "lineEnd": 46,
-            "columnEnd": 14
+            "columnEnd": 13
           }
         }
       },
@@ -510,7 +510,7 @@
                           "lineBegin": 46,
                           "columnBegin": 4,
                           "lineEnd": 46,
-                          "columnEnd": 14
+                          "columnEnd": 13
                         },
                         "text": { "key": "" }
                       }
@@ -536,7 +536,7 @@
             "lineBegin": 56,
             "columnBegin": 2,
             "lineEnd": 56,
-            "columnEnd": 6
+            "columnEnd": 5
           }
         }
       },
@@ -561,7 +561,7 @@
                           "lineBegin": 56,
                           "columnBegin": 2,
                           "lineEnd": 56,
-                          "columnEnd": 6
+                          "columnEnd": 5
                         },
                         "text": { "key": "" }
                       }
@@ -587,7 +587,7 @@
             "lineBegin": 58,
             "columnBegin": 6,
             "lineEnd": 58,
-            "columnEnd": 17
+            "columnEnd": 16
           }
         }
       },
@@ -612,7 +612,7 @@
                           "lineBegin": 58,
                           "columnBegin": 6,
                           "lineEnd": 58,
-                          "columnEnd": 17
+                          "columnEnd": 16
                         },
                         "text": { "key": "" }
                       }
@@ -638,7 +638,7 @@
             "lineBegin": 60,
             "columnBegin": 6,
             "lineEnd": 60,
-            "columnEnd": 7
+            "columnEnd": 6
           }
         }
       },
@@ -663,7 +663,7 @@
                           "lineBegin": 60,
                           "columnBegin": 6,
                           "lineEnd": 60,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }

--- a/glean/lang/go/tests/cases/xrefs/fileentityxreflocations.out
+++ b/glean/lang/go/tests/cases/xrefs/fileentityxreflocations.out
@@ -13,7 +13,7 @@
               "lineBegin": 24,
               "columnBegin": 14,
               "lineEnd": 24,
-              "columnEnd": 18
+              "columnEnd": 17
             }
           }
         },
@@ -23,7 +23,7 @@
             "lineBegin": 25,
             "columnBegin": 32,
             "lineEnd": 25,
-            "columnEnd": 36
+            "columnEnd": 35
           }
         }
       },
@@ -48,7 +48,7 @@
                           "lineBegin": 24,
                           "columnBegin": 14,
                           "lineEnd": 24,
-                          "columnEnd": 18
+                          "columnEnd": 17
                         },
                         "text": { "key": "" }
                       }
@@ -75,7 +75,7 @@
               "lineBegin": 25,
               "columnBegin": 2,
               "lineEnd": 25,
-              "columnEnd": 7
+              "columnEnd": 6
             }
           }
         },
@@ -85,7 +85,7 @@
             "lineBegin": 35,
             "columnBegin": 22,
             "lineEnd": 35,
-            "columnEnd": 27
+            "columnEnd": 26
           }
         }
       },
@@ -110,7 +110,7 @@
                           "lineBegin": 25,
                           "columnBegin": 2,
                           "lineEnd": 25,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -137,7 +137,7 @@
               "lineBegin": 25,
               "columnBegin": 2,
               "lineEnd": 25,
-              "columnEnd": 7
+              "columnEnd": 6
             }
           }
         },
@@ -147,7 +147,7 @@
             "lineBegin": 36,
             "columnBegin": 24,
             "lineEnd": 36,
-            "columnEnd": 29
+            "columnEnd": 28
           }
         }
       },
@@ -172,7 +172,7 @@
                           "lineBegin": 25,
                           "columnBegin": 2,
                           "lineEnd": 25,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -199,7 +199,7 @@
               "lineBegin": 25,
               "columnBegin": 2,
               "lineEnd": 25,
-              "columnEnd": 7
+              "columnEnd": 6
             }
           }
         },
@@ -209,7 +209,7 @@
             "lineBegin": 36,
             "columnBegin": 61,
             "lineEnd": 36,
-            "columnEnd": 66
+            "columnEnd": 65
           }
         }
       },
@@ -234,7 +234,7 @@
                           "lineBegin": 25,
                           "columnBegin": 2,
                           "lineEnd": 25,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -261,7 +261,7 @@
               "lineBegin": 25,
               "columnBegin": 2,
               "lineEnd": 25,
-              "columnEnd": 7
+              "columnEnd": 6
             }
           }
         },
@@ -271,1432 +271,6 @@
             "lineBegin": 39,
             "columnBegin": 42,
             "lineEnd": 39,
-            "columnEnd": 47
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 25,
-                          "columnBegin": 2,
-                          "lineEnd": 25,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 25,
-              "columnBegin": 2,
-              "lineEnd": 25,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 39,
-            "columnBegin": 57,
-            "lineEnd": 39,
-            "columnEnd": 62
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 25,
-                          "columnBegin": 2,
-                          "lineEnd": 25,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 25,
-              "columnBegin": 2,
-              "lineEnd": 25,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 40,
-            "columnBegin": 31,
-            "lineEnd": 40,
-            "columnEnd": 36
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 25,
-                          "columnBegin": 2,
-                          "lineEnd": 25,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 25,
-              "columnBegin": 2,
-              "lineEnd": 25,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 44,
-            "columnBegin": 12,
-            "lineEnd": 44,
-            "columnEnd": 17
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 25,
-                          "columnBegin": 2,
-                          "lineEnd": 25,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 27,
-              "columnBegin": 6,
-              "lineEnd": 27,
-              "columnEnd": 14
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 39,
-            "columnBegin": 4,
-            "lineEnd": 39,
-            "columnEnd": 12
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 27,
-                          "columnBegin": 6,
-                          "lineEnd": 27,
-                          "columnEnd": 14
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 27,
-              "columnBegin": 6,
-              "lineEnd": 27,
-              "columnEnd": 14
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 51,
-            "columnBegin": 4,
-            "lineEnd": 51,
-            "columnEnd": 12
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 27,
-                          "columnBegin": 6,
-                          "lineEnd": 27,
-                          "columnEnd": 14
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 27,
-              "columnBegin": 6,
-              "lineEnd": 27,
-              "columnEnd": 14
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 56,
-            "columnBegin": 44,
-            "lineEnd": 56,
-            "columnEnd": 52
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 27,
-                          "columnBegin": 6,
-                          "lineEnd": 27,
-                          "columnEnd": 14
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 28,
-              "columnBegin": 2,
-              "lineEnd": 28,
-              "columnEnd": 14
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 39,
-            "columnBegin": 28,
-            "lineEnd": 39,
-            "columnEnd": 40
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 28,
-                          "columnBegin": 2,
-                          "lineEnd": 28,
-                          "columnEnd": 14
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 28,
-              "columnBegin": 2,
-              "lineEnd": 28,
-              "columnEnd": 14
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 51,
-            "columnBegin": 28,
-            "lineEnd": 51,
-            "columnEnd": 40
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 28,
-                          "columnBegin": 2,
-                          "lineEnd": 28,
-                          "columnEnd": 14
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 28,
-              "columnBegin": 23,
-              "lineEnd": 28,
-              "columnEnd": 24
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 29,
-            "columnBegin": 6,
-            "lineEnd": 29,
-            "columnEnd": 7
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 28,
-                          "columnBegin": 23,
-                          "lineEnd": 28,
-                          "columnEnd": 24
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 28,
-              "columnBegin": 23,
-              "lineEnd": 28,
-              "columnEnd": 24
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 29,
-            "columnBegin": 18,
-            "lineEnd": 29,
-            "columnEnd": 19
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 28,
-                          "columnBegin": 23,
-                          "lineEnd": 28,
-                          "columnEnd": 24
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 28,
-              "columnBegin": 23,
-              "lineEnd": 28,
-              "columnEnd": 24
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 32,
-            "columnBegin": 10,
-            "lineEnd": 32,
-            "columnEnd": 11
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 28,
-                          "columnBegin": 23,
-                          "lineEnd": 28,
-                          "columnEnd": 24
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 35,
-              "columnBegin": 6,
-              "lineEnd": 35,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 35,
-            "columnBegin": 14,
-            "lineEnd": 35,
-            "columnEnd": 15
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 35,
-              "columnBegin": 6,
-              "lineEnd": 35,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 35,
-            "columnBegin": 30,
-            "lineEnd": 35,
-            "columnEnd": 31
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 35,
-              "columnBegin": 6,
-              "lineEnd": 35,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 36,
-            "columnBegin": 30,
-            "lineEnd": 36,
-            "columnEnd": 31
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 35,
-              "columnBegin": 6,
-              "lineEnd": 35,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 36,
-            "columnBegin": 67,
-            "lineEnd": 36,
-            "columnEnd": 68
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 35,
-              "columnBegin": 6,
-              "lineEnd": 35,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 39,
-            "columnBegin": 48,
-            "lineEnd": 39,
-            "columnEnd": 49
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 35,
-              "columnBegin": 6,
-              "lineEnd": 35,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 39,
-            "columnBegin": 63,
-            "lineEnd": 39,
-            "columnEnd": 64
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 35,
-              "columnBegin": 6,
-              "lineEnd": 35,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 40,
-            "columnBegin": 37,
-            "lineEnd": 40,
-            "columnEnd": 38
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 35,
-              "columnBegin": 6,
-              "lineEnd": 35,
-              "columnEnd": 7
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 44,
-            "columnBegin": 18,
-            "lineEnd": 44,
-            "columnEnd": 19
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 35,
-                          "columnBegin": 6,
-                          "lineEnd": 35,
-                          "columnEnd": 7
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 44,
-              "columnBegin": 4,
-              "lineEnd": 44,
-              "columnEnd": 8
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 46,
-            "columnBegin": 32,
-            "lineEnd": 46,
-            "columnEnd": 36
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 44,
-                          "columnBegin": 4,
-                          "lineEnd": 44,
-                          "columnEnd": 8
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 44,
-              "columnBegin": 4,
-              "lineEnd": 44,
-              "columnEnd": 8
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 48,
-            "columnBegin": 5,
-            "lineEnd": 48,
-            "columnEnd": 9
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 44,
-                          "columnBegin": 4,
-                          "lineEnd": 44,
-                          "columnEnd": 8
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 44,
-              "columnBegin": 4,
-              "lineEnd": 44,
-              "columnEnd": 8
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 48,
-            "columnBegin": 12,
-            "lineEnd": 48,
-            "columnEnd": 16
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 44,
-                          "columnBegin": 4,
-                          "lineEnd": 44,
-                          "columnEnd": 8
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 44,
-              "columnBegin": 4,
-              "lineEnd": 44,
-              "columnEnd": 8
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 51,
-            "columnBegin": 42,
-            "lineEnd": 51,
             "columnEnd": 46
           }
         }
@@ -1719,10 +293,1436 @@
                     "range": {
                       "key": {
                         "range": {
+                          "lineBegin": 25,
+                          "columnBegin": 2,
+                          "lineEnd": 25,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 25,
+              "columnBegin": 2,
+              "lineEnd": 25,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 39,
+            "columnBegin": 57,
+            "lineEnd": 39,
+            "columnEnd": 61
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 25,
+                          "columnBegin": 2,
+                          "lineEnd": 25,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 25,
+              "columnBegin": 2,
+              "lineEnd": 25,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 40,
+            "columnBegin": 31,
+            "lineEnd": 40,
+            "columnEnd": 35
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 25,
+                          "columnBegin": 2,
+                          "lineEnd": 25,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 25,
+              "columnBegin": 2,
+              "lineEnd": 25,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 44,
+            "columnBegin": 12,
+            "lineEnd": 44,
+            "columnEnd": 16
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 25,
+                          "columnBegin": 2,
+                          "lineEnd": 25,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 27,
+              "columnBegin": 6,
+              "lineEnd": 27,
+              "columnEnd": 13
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 39,
+            "columnBegin": 4,
+            "lineEnd": 39,
+            "columnEnd": 11
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 27,
+                          "columnBegin": 6,
+                          "lineEnd": 27,
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 27,
+              "columnBegin": 6,
+              "lineEnd": 27,
+              "columnEnd": 13
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 51,
+            "columnBegin": 4,
+            "lineEnd": 51,
+            "columnEnd": 11
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 27,
+                          "columnBegin": 6,
+                          "lineEnd": 27,
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 27,
+              "columnBegin": 6,
+              "lineEnd": 27,
+              "columnEnd": 13
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 56,
+            "columnBegin": 44,
+            "lineEnd": 56,
+            "columnEnd": 51
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 27,
+                          "columnBegin": 6,
+                          "lineEnd": 27,
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 28,
+              "columnBegin": 2,
+              "lineEnd": 28,
+              "columnEnd": 13
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 39,
+            "columnBegin": 28,
+            "lineEnd": 39,
+            "columnEnd": 39
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 28,
+                          "columnBegin": 2,
+                          "lineEnd": 28,
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 28,
+              "columnBegin": 2,
+              "lineEnd": 28,
+              "columnEnd": 13
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 51,
+            "columnBegin": 28,
+            "lineEnd": 51,
+            "columnEnd": 39
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 28,
+                          "columnBegin": 2,
+                          "lineEnd": 28,
+                          "columnEnd": 13
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 28,
+              "columnBegin": 23,
+              "lineEnd": 28,
+              "columnEnd": 23
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 29,
+            "columnBegin": 6,
+            "lineEnd": 29,
+            "columnEnd": 6
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 28,
+                          "columnBegin": 23,
+                          "lineEnd": 28,
+                          "columnEnd": 23
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 28,
+              "columnBegin": 23,
+              "lineEnd": 28,
+              "columnEnd": 23
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 29,
+            "columnBegin": 18,
+            "lineEnd": 29,
+            "columnEnd": 18
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 28,
+                          "columnBegin": 23,
+                          "lineEnd": 28,
+                          "columnEnd": 23
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 28,
+              "columnBegin": 23,
+              "lineEnd": 28,
+              "columnEnd": 23
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 32,
+            "columnBegin": 10,
+            "lineEnd": 32,
+            "columnEnd": 10
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 28,
+                          "columnBegin": 23,
+                          "lineEnd": 28,
+                          "columnEnd": 23
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 35,
+              "columnBegin": 6,
+              "lineEnd": 35,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 35,
+            "columnBegin": 14,
+            "lineEnd": 35,
+            "columnEnd": 14
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 35,
+              "columnBegin": 6,
+              "lineEnd": 35,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 35,
+            "columnBegin": 30,
+            "lineEnd": 35,
+            "columnEnd": 30
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 35,
+              "columnBegin": 6,
+              "lineEnd": 35,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 36,
+            "columnBegin": 30,
+            "lineEnd": 36,
+            "columnEnd": 30
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 35,
+              "columnBegin": 6,
+              "lineEnd": 35,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 36,
+            "columnBegin": 67,
+            "lineEnd": 36,
+            "columnEnd": 67
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 35,
+              "columnBegin": 6,
+              "lineEnd": 35,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 39,
+            "columnBegin": 48,
+            "lineEnd": 39,
+            "columnEnd": 48
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 35,
+              "columnBegin": 6,
+              "lineEnd": 35,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 39,
+            "columnBegin": 63,
+            "lineEnd": 39,
+            "columnEnd": 63
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 35,
+              "columnBegin": 6,
+              "lineEnd": 35,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 40,
+            "columnBegin": 37,
+            "lineEnd": 40,
+            "columnEnd": 37
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 35,
+              "columnBegin": 6,
+              "lineEnd": 35,
+              "columnEnd": 6
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 44,
+            "columnBegin": 18,
+            "lineEnd": 44,
+            "columnEnd": 18
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 35,
+                          "columnBegin": 6,
+                          "lineEnd": 35,
+                          "columnEnd": 6
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 44,
+              "columnBegin": 4,
+              "lineEnd": 44,
+              "columnEnd": 7
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 46,
+            "columnBegin": 32,
+            "lineEnd": 46,
+            "columnEnd": 35
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
                           "lineBegin": 44,
                           "columnBegin": 4,
                           "lineEnd": 44,
-                          "columnEnd": 8
+                          "columnEnd": 7
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 44,
+              "columnBegin": 4,
+              "lineEnd": 44,
+              "columnEnd": 7
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 48,
+            "columnBegin": 5,
+            "lineEnd": 48,
+            "columnEnd": 8
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 44,
+                          "columnBegin": 4,
+                          "lineEnd": 44,
+                          "columnEnd": 7
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 44,
+              "columnBegin": 4,
+              "lineEnd": 44,
+              "columnEnd": 7
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 48,
+            "columnBegin": 12,
+            "lineEnd": 48,
+            "columnEnd": 15
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 44,
+                          "columnBegin": 4,
+                          "lineEnd": 44,
+                          "columnEnd": 7
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 44,
+              "columnBegin": 4,
+              "lineEnd": 44,
+              "columnEnd": 7
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 51,
+            "columnBegin": 42,
+            "lineEnd": 51,
+            "columnEnd": 45
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 44,
+                          "columnBegin": 4,
+                          "lineEnd": 44,
+                          "columnEnd": 7
                         },
                         "text": { "key": "" }
                       }
@@ -1749,7 +1749,7 @@
               "lineBegin": 46,
               "columnBegin": 4,
               "lineEnd": 46,
-              "columnEnd": 14
+              "columnEnd": 13
             }
           }
         },
@@ -1759,7 +1759,7 @@
             "lineBegin": 47,
             "columnBegin": 7,
             "lineEnd": 47,
-            "columnEnd": 17
+            "columnEnd": 16
           }
         }
       },
@@ -1784,7 +1784,7 @@
                           "lineBegin": 46,
                           "columnBegin": 4,
                           "lineEnd": 46,
-                          "columnEnd": 14
+                          "columnEnd": 13
                         },
                         "text": { "key": "" }
                       }
@@ -1811,7 +1811,7 @@
               "lineBegin": 46,
               "columnBegin": 4,
               "lineEnd": 46,
-              "columnEnd": 14
+              "columnEnd": 13
             }
           }
         },
@@ -1821,7 +1821,7 @@
             "lineBegin": 48,
             "columnBegin": 21,
             "lineEnd": 48,
-            "columnEnd": 31
+            "columnEnd": 30
           }
         }
       },
@@ -1846,7 +1846,7 @@
                           "lineBegin": 46,
                           "columnBegin": 4,
                           "lineEnd": 46,
-                          "columnEnd": 14
+                          "columnEnd": 13
                         },
                         "text": { "key": "" }
                       }
@@ -1873,7 +1873,7 @@
               "lineBegin": 56,
               "columnBegin": 2,
               "lineEnd": 56,
-              "columnEnd": 6
+              "columnEnd": 5
             }
           }
         },
@@ -1883,7 +1883,7 @@
             "lineBegin": 64,
             "columnBegin": 18,
             "lineEnd": 64,
-            "columnEnd": 22
+            "columnEnd": 21
           }
         }
       },
@@ -1908,7 +1908,7 @@
                           "lineBegin": 56,
                           "columnBegin": 2,
                           "lineEnd": 56,
-                          "columnEnd": 6
+                          "columnEnd": 5
                         },
                         "text": { "key": "" }
                       }
@@ -1935,7 +1935,7 @@
               "lineBegin": 58,
               "columnBegin": 6,
               "lineEnd": 58,
-              "columnEnd": 17
+              "columnEnd": 16
             }
           }
         },
@@ -1945,7 +1945,7 @@
             "lineBegin": 61,
             "columnBegin": 6,
             "lineEnd": 61,
-            "columnEnd": 17
+            "columnEnd": 16
           }
         }
       },
@@ -1970,7 +1970,7 @@
                           "lineBegin": 58,
                           "columnBegin": 6,
                           "lineEnd": 58,
-                          "columnEnd": 17
+                          "columnEnd": 16
                         },
                         "text": { "key": "" }
                       }
@@ -1997,7 +1997,7 @@
               "lineBegin": 58,
               "columnBegin": 6,
               "lineEnd": 58,
-              "columnEnd": 17
+              "columnEnd": 16
             }
           }
         },
@@ -2007,68 +2007,6 @@
             "lineBegin": 62,
             "columnBegin": 4,
             "lineEnd": 62,
-            "columnEnd": 15
-          }
-        }
-      },
-      "entity": {
-        "lsif": {
-          "go": {
-            "defn": {
-              "key": {
-                "defn": {
-                  "key": {
-                    "file": {
-                      "key": {
-                        "file": {
-                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
-                        },
-                        "language": 16
-                      }
-                    },
-                    "range": {
-                      "key": {
-                        "range": {
-                          "lineBegin": 58,
-                          "columnBegin": 6,
-                          "lineEnd": 58,
-                          "columnEnd": 17
-                        },
-                        "text": { "key": "" }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-      "xref": {
-        "target": {
-          "name": "",
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "location": {
-            "range": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "lineBegin": 58,
-              "columnBegin": 6,
-              "lineEnd": 58,
-              "columnEnd": 17
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 64,
-            "columnBegin": 3,
-            "lineEnd": 64,
             "columnEnd": 14
           }
         }
@@ -2094,7 +2032,7 @@
                           "lineBegin": 58,
                           "columnBegin": 6,
                           "lineEnd": 58,
-                          "columnEnd": 17
+                          "columnEnd": 16
                         },
                         "text": { "key": "" }
                       }
@@ -2121,17 +2059,17 @@
               "lineBegin": 58,
               "columnBegin": 6,
               "lineEnd": 58,
-              "columnEnd": 17
+              "columnEnd": 16
             }
           }
         },
         "source": {
           "range": {
             "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-            "lineBegin": 67,
-            "columnBegin": 9,
-            "lineEnd": 67,
-            "columnEnd": 20
+            "lineBegin": 64,
+            "columnBegin": 3,
+            "lineEnd": 64,
+            "columnEnd": 13
           }
         }
       },
@@ -2156,7 +2094,69 @@
                           "lineBegin": 58,
                           "columnBegin": 6,
                           "lineEnd": 58,
-                          "columnEnd": 17
+                          "columnEnd": 16
+                        },
+                        "text": { "key": "" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+      "xref": {
+        "target": {
+          "name": "",
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "location": {
+            "range": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "lineBegin": 58,
+              "columnBegin": 6,
+              "lineEnd": 58,
+              "columnEnd": 16
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+            "lineBegin": 67,
+            "columnBegin": 9,
+            "lineEnd": 67,
+            "columnEnd": 19
+          }
+        }
+      },
+      "entity": {
+        "lsif": {
+          "go": {
+            "defn": {
+              "key": {
+                "defn": {
+                  "key": {
+                    "file": {
+                      "key": {
+                        "file": {
+                          "key": "glean/lang/go/tests/cases/xrefs/leaphash.go"
+                        },
+                        "language": 16
+                      }
+                    },
+                    "range": {
+                      "key": {
+                        "range": {
+                          "lineBegin": 58,
+                          "columnBegin": 6,
+                          "lineEnd": 58,
+                          "columnEnd": 16
                         },
                         "text": { "key": "" }
                       }
@@ -2183,7 +2183,7 @@
               "lineBegin": 60,
               "columnBegin": 6,
               "lineEnd": 60,
-              "columnEnd": 7
+              "columnEnd": 6
             }
           }
         },
@@ -2193,7 +2193,7 @@
             "lineBegin": 60,
             "columnBegin": 14,
             "lineEnd": 60,
-            "columnEnd": 15
+            "columnEnd": 14
           }
         }
       },
@@ -2218,7 +2218,7 @@
                           "lineBegin": 60,
                           "columnBegin": 6,
                           "lineEnd": 60,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -2245,7 +2245,7 @@
               "lineBegin": 60,
               "columnBegin": 6,
               "lineEnd": 60,
-              "columnEnd": 7
+              "columnEnd": 6
             }
           }
         },
@@ -2255,7 +2255,7 @@
             "lineBegin": 60,
             "columnBegin": 21,
             "lineEnd": 60,
-            "columnEnd": 22
+            "columnEnd": 21
           }
         }
       },
@@ -2280,7 +2280,7 @@
                           "lineBegin": 60,
                           "columnBegin": 6,
                           "lineEnd": 60,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -2307,7 +2307,7 @@
               "lineBegin": 60,
               "columnBegin": 6,
               "lineEnd": 60,
-              "columnEnd": 7
+              "columnEnd": 6
             }
           }
         },
@@ -2317,7 +2317,7 @@
             "lineBegin": 64,
             "columnBegin": 23,
             "lineEnd": 64,
-            "columnEnd": 24
+            "columnEnd": 23
           }
         }
       },
@@ -2342,7 +2342,7 @@
                           "lineBegin": 60,
                           "columnBegin": 6,
                           "lineEnd": 60,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }
@@ -2369,7 +2369,7 @@
               "lineBegin": 60,
               "columnBegin": 6,
               "lineEnd": 60,
-              "columnEnd": 7
+              "columnEnd": 6
             }
           }
         },
@@ -2379,7 +2379,7 @@
             "lineBegin": 64,
             "columnBegin": 30,
             "lineEnd": 64,
-            "columnEnd": 31
+            "columnEnd": 30
           }
         }
       },
@@ -2404,7 +2404,7 @@
                           "lineBegin": 60,
                           "columnBegin": 6,
                           "lineEnd": 60,
-                          "columnEnd": 7
+                          "columnEnd": 6
                         },
                         "text": { "key": "" }
                       }

--- a/glean/lang/go/tests/cases/xrefs/filereferences.out
+++ b/glean/lang/go/tests/cases/xrefs/filereferences.out
@@ -14,7 +14,7 @@
             "lineBegin": 25,
             "columnBegin": 32,
             "lineEnd": 25,
-            "columnEnd": 36
+            "columnEnd": 35
           },
           "text": { "key": "" }
         }
@@ -33,7 +33,7 @@
                 "lineBegin": 24,
                 "columnBegin": 14,
                 "lineEnd": 24,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "text": { "key": "" }
             }
@@ -56,7 +56,7 @@
             "lineBegin": 29,
             "columnBegin": 6,
             "lineEnd": 29,
-            "columnEnd": 7
+            "columnEnd": 6
           },
           "text": { "key": "" }
         }
@@ -75,7 +75,7 @@
                 "lineBegin": 28,
                 "columnBegin": 23,
                 "lineEnd": 28,
-                "columnEnd": 24
+                "columnEnd": 23
               },
               "text": { "key": "" }
             }
@@ -98,7 +98,7 @@
             "lineBegin": 29,
             "columnBegin": 18,
             "lineEnd": 29,
-            "columnEnd": 19
+            "columnEnd": 18
           },
           "text": { "key": "" }
         }
@@ -117,7 +117,7 @@
                 "lineBegin": 28,
                 "columnBegin": 23,
                 "lineEnd": 28,
-                "columnEnd": 24
+                "columnEnd": 23
               },
               "text": { "key": "" }
             }
@@ -140,7 +140,7 @@
             "lineBegin": 32,
             "columnBegin": 10,
             "lineEnd": 32,
-            "columnEnd": 11
+            "columnEnd": 10
           },
           "text": { "key": "" }
         }
@@ -159,7 +159,7 @@
                 "lineBegin": 28,
                 "columnBegin": 23,
                 "lineEnd": 28,
-                "columnEnd": 24
+                "columnEnd": 23
               },
               "text": { "key": "" }
             }
@@ -182,7 +182,7 @@
             "lineBegin": 35,
             "columnBegin": 14,
             "lineEnd": 35,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "" }
         }
@@ -201,7 +201,7 @@
                 "lineBegin": 35,
                 "columnBegin": 6,
                 "lineEnd": 35,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -224,7 +224,7 @@
             "lineBegin": 35,
             "columnBegin": 22,
             "lineEnd": 35,
-            "columnEnd": 27
+            "columnEnd": 26
           },
           "text": { "key": "" }
         }
@@ -243,7 +243,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -266,7 +266,7 @@
             "lineBegin": 35,
             "columnBegin": 30,
             "lineEnd": 35,
-            "columnEnd": 31
+            "columnEnd": 30
           },
           "text": { "key": "" }
         }
@@ -285,7 +285,7 @@
                 "lineBegin": 35,
                 "columnBegin": 6,
                 "lineEnd": 35,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -308,7 +308,7 @@
             "lineBegin": 36,
             "columnBegin": 24,
             "lineEnd": 36,
-            "columnEnd": 29
+            "columnEnd": 28
           },
           "text": { "key": "" }
         }
@@ -327,7 +327,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -350,7 +350,7 @@
             "lineBegin": 36,
             "columnBegin": 30,
             "lineEnd": 36,
-            "columnEnd": 31
+            "columnEnd": 30
           },
           "text": { "key": "" }
         }
@@ -369,7 +369,7 @@
                 "lineBegin": 35,
                 "columnBegin": 6,
                 "lineEnd": 35,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -392,7 +392,7 @@
             "lineBegin": 36,
             "columnBegin": 61,
             "lineEnd": 36,
-            "columnEnd": 66
+            "columnEnd": 65
           },
           "text": { "key": "" }
         }
@@ -411,7 +411,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -434,7 +434,7 @@
             "lineBegin": 36,
             "columnBegin": 67,
             "lineEnd": 36,
-            "columnEnd": 68
+            "columnEnd": 67
           },
           "text": { "key": "" }
         }
@@ -453,7 +453,7 @@
                 "lineBegin": 35,
                 "columnBegin": 6,
                 "lineEnd": 35,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -476,7 +476,7 @@
             "lineBegin": 39,
             "columnBegin": 4,
             "lineEnd": 39,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "text": { "key": "" }
         }
@@ -495,7 +495,7 @@
                 "lineBegin": 27,
                 "columnBegin": 6,
                 "lineEnd": 27,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -518,7 +518,7 @@
             "lineBegin": 39,
             "columnBegin": 28,
             "lineEnd": 39,
-            "columnEnd": 40
+            "columnEnd": 39
           },
           "text": { "key": "" }
         }
@@ -537,7 +537,7 @@
                 "lineBegin": 28,
                 "columnBegin": 2,
                 "lineEnd": 28,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -560,7 +560,7 @@
             "lineBegin": 39,
             "columnBegin": 42,
             "lineEnd": 39,
-            "columnEnd": 47
+            "columnEnd": 46
           },
           "text": { "key": "" }
         }
@@ -579,7 +579,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -602,7 +602,7 @@
             "lineBegin": 39,
             "columnBegin": 48,
             "lineEnd": 39,
-            "columnEnd": 49
+            "columnEnd": 48
           },
           "text": { "key": "" }
         }
@@ -621,7 +621,7 @@
                 "lineBegin": 35,
                 "columnBegin": 6,
                 "lineEnd": 35,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -644,7 +644,7 @@
             "lineBegin": 39,
             "columnBegin": 57,
             "lineEnd": 39,
-            "columnEnd": 62
+            "columnEnd": 61
           },
           "text": { "key": "" }
         }
@@ -663,7 +663,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -686,7 +686,7 @@
             "lineBegin": 39,
             "columnBegin": 63,
             "lineEnd": 39,
-            "columnEnd": 64
+            "columnEnd": 63
           },
           "text": { "key": "" }
         }
@@ -705,7 +705,7 @@
                 "lineBegin": 35,
                 "columnBegin": 6,
                 "lineEnd": 35,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -728,7 +728,7 @@
             "lineBegin": 40,
             "columnBegin": 31,
             "lineEnd": 40,
-            "columnEnd": 36
+            "columnEnd": 35
           },
           "text": { "key": "" }
         }
@@ -747,7 +747,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -770,7 +770,7 @@
             "lineBegin": 40,
             "columnBegin": 37,
             "lineEnd": 40,
-            "columnEnd": 38
+            "columnEnd": 37
           },
           "text": { "key": "" }
         }
@@ -789,7 +789,7 @@
                 "lineBegin": 35,
                 "columnBegin": 6,
                 "lineEnd": 35,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -812,7 +812,7 @@
             "lineBegin": 44,
             "columnBegin": 12,
             "lineEnd": 44,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "" }
         }
@@ -831,7 +831,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -854,7 +854,7 @@
             "lineBegin": 44,
             "columnBegin": 18,
             "lineEnd": 44,
-            "columnEnd": 19
+            "columnEnd": 18
           },
           "text": { "key": "" }
         }
@@ -873,7 +873,7 @@
                 "lineBegin": 35,
                 "columnBegin": 6,
                 "lineEnd": 35,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -896,7 +896,7 @@
             "lineBegin": 46,
             "columnBegin": 32,
             "lineEnd": 46,
-            "columnEnd": 36
+            "columnEnd": 35
           },
           "text": { "key": "" }
         }
@@ -915,7 +915,7 @@
                 "lineBegin": 44,
                 "columnBegin": 4,
                 "lineEnd": 44,
-                "columnEnd": 8
+                "columnEnd": 7
               },
               "text": { "key": "" }
             }
@@ -938,7 +938,7 @@
             "lineBegin": 47,
             "columnBegin": 7,
             "lineEnd": 47,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "" }
         }
@@ -957,7 +957,7 @@
                 "lineBegin": 46,
                 "columnBegin": 4,
                 "lineEnd": 46,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -980,7 +980,7 @@
             "lineBegin": 48,
             "columnBegin": 5,
             "lineEnd": 48,
-            "columnEnd": 9
+            "columnEnd": 8
           },
           "text": { "key": "" }
         }
@@ -999,7 +999,7 @@
                 "lineBegin": 44,
                 "columnBegin": 4,
                 "lineEnd": 44,
-                "columnEnd": 8
+                "columnEnd": 7
               },
               "text": { "key": "" }
             }
@@ -1022,7 +1022,7 @@
             "lineBegin": 48,
             "columnBegin": 12,
             "lineEnd": 48,
-            "columnEnd": 16
+            "columnEnd": 15
           },
           "text": { "key": "" }
         }
@@ -1041,7 +1041,7 @@
                 "lineBegin": 44,
                 "columnBegin": 4,
                 "lineEnd": 44,
-                "columnEnd": 8
+                "columnEnd": 7
               },
               "text": { "key": "" }
             }
@@ -1064,7 +1064,7 @@
             "lineBegin": 48,
             "columnBegin": 21,
             "lineEnd": 48,
-            "columnEnd": 31
+            "columnEnd": 30
           },
           "text": { "key": "" }
         }
@@ -1083,7 +1083,7 @@
                 "lineBegin": 46,
                 "columnBegin": 4,
                 "lineEnd": 46,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -1106,7 +1106,7 @@
             "lineBegin": 51,
             "columnBegin": 4,
             "lineEnd": 51,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "text": { "key": "" }
         }
@@ -1125,7 +1125,7 @@
                 "lineBegin": 27,
                 "columnBegin": 6,
                 "lineEnd": 27,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -1148,7 +1148,7 @@
             "lineBegin": 51,
             "columnBegin": 28,
             "lineEnd": 51,
-            "columnEnd": 40
+            "columnEnd": 39
           },
           "text": { "key": "" }
         }
@@ -1167,7 +1167,7 @@
                 "lineBegin": 28,
                 "columnBegin": 2,
                 "lineEnd": 28,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -1190,7 +1190,7 @@
             "lineBegin": 51,
             "columnBegin": 42,
             "lineEnd": 51,
-            "columnEnd": 46
+            "columnEnd": 45
           },
           "text": { "key": "" }
         }
@@ -1209,7 +1209,7 @@
                 "lineBegin": 44,
                 "columnBegin": 4,
                 "lineEnd": 44,
-                "columnEnd": 8
+                "columnEnd": 7
               },
               "text": { "key": "" }
             }
@@ -1232,7 +1232,7 @@
             "lineBegin": 56,
             "columnBegin": 44,
             "lineEnd": 56,
-            "columnEnd": 52
+            "columnEnd": 51
           },
           "text": { "key": "" }
         }
@@ -1251,7 +1251,7 @@
                 "lineBegin": 27,
                 "columnBegin": 6,
                 "lineEnd": 27,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -1274,7 +1274,7 @@
             "lineBegin": 60,
             "columnBegin": 14,
             "lineEnd": 60,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "" }
         }
@@ -1293,7 +1293,7 @@
                 "lineBegin": 60,
                 "columnBegin": 6,
                 "lineEnd": 60,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -1316,7 +1316,7 @@
             "lineBegin": 60,
             "columnBegin": 21,
             "lineEnd": 60,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "" }
         }
@@ -1335,7 +1335,7 @@
                 "lineBegin": 60,
                 "columnBegin": 6,
                 "lineEnd": 60,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -1358,7 +1358,7 @@
             "lineBegin": 61,
             "columnBegin": 6,
             "lineEnd": 61,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "" }
         }
@@ -1377,7 +1377,7 @@
                 "lineBegin": 58,
                 "columnBegin": 6,
                 "lineEnd": 58,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "text": { "key": "" }
             }
@@ -1400,7 +1400,7 @@
             "lineBegin": 62,
             "columnBegin": 4,
             "lineEnd": 62,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "" }
         }
@@ -1419,7 +1419,7 @@
                 "lineBegin": 58,
                 "columnBegin": 6,
                 "lineEnd": 58,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "text": { "key": "" }
             }
@@ -1442,7 +1442,7 @@
             "lineBegin": 64,
             "columnBegin": 3,
             "lineEnd": 64,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "" }
         }
@@ -1461,7 +1461,7 @@
                 "lineBegin": 58,
                 "columnBegin": 6,
                 "lineEnd": 58,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "text": { "key": "" }
             }
@@ -1484,7 +1484,7 @@
             "lineBegin": 64,
             "columnBegin": 18,
             "lineEnd": 64,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "" }
         }
@@ -1503,7 +1503,7 @@
                 "lineBegin": 56,
                 "columnBegin": 2,
                 "lineEnd": 56,
-                "columnEnd": 6
+                "columnEnd": 5
               },
               "text": { "key": "" }
             }
@@ -1526,7 +1526,7 @@
             "lineBegin": 64,
             "columnBegin": 23,
             "lineEnd": 64,
-            "columnEnd": 24
+            "columnEnd": 23
           },
           "text": { "key": "" }
         }
@@ -1545,7 +1545,7 @@
                 "lineBegin": 60,
                 "columnBegin": 6,
                 "lineEnd": 60,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -1568,7 +1568,7 @@
             "lineBegin": 64,
             "columnBegin": 30,
             "lineEnd": 64,
-            "columnEnd": 31
+            "columnEnd": 30
           },
           "text": { "key": "" }
         }
@@ -1587,7 +1587,7 @@
                 "lineBegin": 60,
                 "columnBegin": 6,
                 "lineEnd": 60,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -1610,7 +1610,7 @@
             "lineBegin": 67,
             "columnBegin": 9,
             "lineEnd": 67,
-            "columnEnd": 20
+            "columnEnd": 19
           },
           "text": { "key": "" }
         }
@@ -1629,7 +1629,7 @@
                 "lineBegin": 58,
                 "columnBegin": 6,
                 "lineEnd": 58,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "text": { "key": "" }
             }

--- a/glean/lang/go/tests/cases/xrefs/hovercontent.out
+++ b/glean/lang/go/tests/cases/xrefs/hovercontent.out
@@ -16,7 +16,7 @@
                 "lineBegin": 11,
                 "columnBegin": 9,
                 "lineEnd": 11,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "text": { "key": "" }
             }
@@ -47,7 +47,7 @@
                 "lineBegin": 24,
                 "columnBegin": 6,
                 "lineEnd": 24,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "" }
             }
@@ -80,7 +80,7 @@
                 "lineBegin": 24,
                 "columnBegin": 14,
                 "lineEnd": 24,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "text": { "key": "" }
             }
@@ -111,7 +111,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -142,7 +142,7 @@
                 "lineBegin": 27,
                 "columnBegin": 6,
                 "lineEnd": 27,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -173,7 +173,7 @@
                 "lineBegin": 28,
                 "columnBegin": 2,
                 "lineEnd": 28,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -206,7 +206,7 @@
                 "lineBegin": 28,
                 "columnBegin": 23,
                 "lineEnd": 28,
-                "columnEnd": 24
+                "columnEnd": 23
               },
               "text": { "key": "" }
             }
@@ -237,7 +237,7 @@
                 "lineBegin": 35,
                 "columnBegin": 6,
                 "lineEnd": 35,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -268,7 +268,7 @@
                 "lineBegin": 44,
                 "columnBegin": 4,
                 "lineEnd": 44,
-                "columnEnd": 8
+                "columnEnd": 7
               },
               "text": { "key": "" }
             }
@@ -299,7 +299,7 @@
                 "lineBegin": 46,
                 "columnBegin": 4,
                 "lineEnd": 46,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -330,7 +330,7 @@
                 "lineBegin": 56,
                 "columnBegin": 2,
                 "lineEnd": 56,
-                "columnEnd": 6
+                "columnEnd": 5
               },
               "text": { "key": "" }
             }
@@ -361,7 +361,7 @@
                 "lineBegin": 58,
                 "columnBegin": 6,
                 "lineEnd": 58,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "text": { "key": "" }
             }
@@ -392,7 +392,7 @@
                 "lineBegin": 60,
                 "columnBegin": 6,
                 "lineEnd": 60,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }

--- a/glean/lang/go/tests/cases/xrefs/range.out
+++ b/glean/lang/go/tests/cases/xrefs/range.out
@@ -6,7 +6,7 @@
         "lineBegin": 11,
         "columnBegin": 9,
         "lineEnd": 11,
-        "columnEnd": 17
+        "columnEnd": 16
       },
       "text": { "key": "" }
     }
@@ -17,7 +17,7 @@
         "lineBegin": 14,
         "columnBegin": 3,
         "lineEnd": 14,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "" }
     }
@@ -28,7 +28,7 @@
         "lineBegin": 15,
         "columnBegin": 3,
         "lineEnd": 15,
-        "columnEnd": 6
+        "columnEnd": 5
       },
       "text": { "key": "" }
     }
@@ -39,7 +39,7 @@
         "lineBegin": 16,
         "columnBegin": 3,
         "lineEnd": 16,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "text": { "key": "" }
     }
@@ -50,7 +50,7 @@
         "lineBegin": 24,
         "columnBegin": 6,
         "lineEnd": 24,
-        "columnEnd": 13
+        "columnEnd": 12
       },
       "text": { "key": "" }
     }
@@ -61,7 +61,7 @@
         "lineBegin": 24,
         "columnBegin": 14,
         "lineEnd": 24,
-        "columnEnd": 18
+        "columnEnd": 17
       },
       "text": { "key": "" }
     }
@@ -72,7 +72,7 @@
         "lineBegin": 25,
         "columnBegin": 2,
         "lineEnd": 25,
-        "columnEnd": 7
+        "columnEnd": 6
       },
       "text": { "key": "" }
     }
@@ -83,7 +83,7 @@
         "lineBegin": 25,
         "columnBegin": 11,
         "lineEnd": 25,
-        "columnEnd": 18
+        "columnEnd": 17
       },
       "text": { "key": "" }
     }
@@ -94,7 +94,7 @@
         "lineBegin": 25,
         "columnBegin": 19,
         "lineEnd": 25,
-        "columnEnd": 24
+        "columnEnd": 23
       },
       "text": { "key": "" }
     }
@@ -105,7 +105,7 @@
         "lineBegin": 25,
         "columnBegin": 32,
         "lineEnd": 25,
-        "columnEnd": 36
+        "columnEnd": 35
       },
       "text": { "key": "" }
     }
@@ -116,7 +116,7 @@
         "lineBegin": 27,
         "columnBegin": 6,
         "lineEnd": 27,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "" }
     }
@@ -127,7 +127,7 @@
         "lineBegin": 28,
         "columnBegin": 2,
         "lineEnd": 28,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "" }
     }
@@ -138,7 +138,7 @@
         "lineBegin": 28,
         "columnBegin": 23,
         "lineEnd": 28,
-        "columnEnd": 24
+        "columnEnd": 23
       },
       "text": { "key": "" }
     }
@@ -149,7 +149,7 @@
         "lineBegin": 29,
         "columnBegin": 6,
         "lineEnd": 29,
-        "columnEnd": 7
+        "columnEnd": 6
       },
       "text": { "key": "" }
     }
@@ -160,7 +160,7 @@
         "lineBegin": 29,
         "columnBegin": 18,
         "lineEnd": 29,
-        "columnEnd": 19
+        "columnEnd": 18
       },
       "text": { "key": "" }
     }
@@ -171,7 +171,7 @@
         "lineBegin": 32,
         "columnBegin": 10,
         "lineEnd": 32,
-        "columnEnd": 11
+        "columnEnd": 10
       },
       "text": { "key": "" }
     }
@@ -182,7 +182,7 @@
         "lineBegin": 35,
         "columnBegin": 6,
         "lineEnd": 35,
-        "columnEnd": 7
+        "columnEnd": 6
       },
       "text": { "key": "" }
     }
@@ -193,7 +193,7 @@
         "lineBegin": 35,
         "columnBegin": 14,
         "lineEnd": 35,
-        "columnEnd": 15
+        "columnEnd": 14
       },
       "text": { "key": "" }
     }
@@ -204,7 +204,7 @@
         "lineBegin": 35,
         "columnBegin": 22,
         "lineEnd": 35,
-        "columnEnd": 27
+        "columnEnd": 26
       },
       "text": { "key": "" }
     }
@@ -215,7 +215,7 @@
         "lineBegin": 35,
         "columnBegin": 30,
         "lineEnd": 35,
-        "columnEnd": 31
+        "columnEnd": 30
       },
       "text": { "key": "" }
     }
@@ -226,7 +226,7 @@
         "lineBegin": 36,
         "columnBegin": 6,
         "lineEnd": 36,
-        "columnEnd": 13
+        "columnEnd": 12
       },
       "text": { "key": "" }
     }
@@ -237,7 +237,7 @@
         "lineBegin": 36,
         "columnBegin": 14,
         "lineEnd": 36,
-        "columnEnd": 23
+        "columnEnd": 22
       },
       "text": { "key": "" }
     }
@@ -248,7 +248,7 @@
         "lineBegin": 36,
         "columnBegin": 24,
         "lineEnd": 36,
-        "columnEnd": 29
+        "columnEnd": 28
       },
       "text": { "key": "" }
     }
@@ -259,7 +259,7 @@
         "lineBegin": 36,
         "columnBegin": 30,
         "lineEnd": 36,
-        "columnEnd": 31
+        "columnEnd": 30
       },
       "text": { "key": "" }
     }
@@ -270,7 +270,7 @@
         "lineBegin": 36,
         "columnBegin": 43,
         "lineEnd": 36,
-        "columnEnd": 50
+        "columnEnd": 49
       },
       "text": { "key": "" }
     }
@@ -281,7 +281,7 @@
         "lineBegin": 36,
         "columnBegin": 51,
         "lineEnd": 36,
-        "columnEnd": 60
+        "columnEnd": 59
       },
       "text": { "key": "" }
     }
@@ -292,7 +292,7 @@
         "lineBegin": 36,
         "columnBegin": 61,
         "lineEnd": 36,
-        "columnEnd": 66
+        "columnEnd": 65
       },
       "text": { "key": "" }
     }
@@ -303,7 +303,7 @@
         "lineBegin": 36,
         "columnBegin": 67,
         "lineEnd": 36,
-        "columnEnd": 68
+        "columnEnd": 67
       },
       "text": { "key": "" }
     }
@@ -314,7 +314,7 @@
         "lineBegin": 39,
         "columnBegin": 4,
         "lineEnd": 39,
-        "columnEnd": 12
+        "columnEnd": 11
       },
       "text": { "key": "" }
     }
@@ -325,7 +325,7 @@
         "lineBegin": 39,
         "columnBegin": 16,
         "lineEnd": 39,
-        "columnEnd": 23
+        "columnEnd": 22
       },
       "text": { "key": "" }
     }
@@ -336,7 +336,7 @@
         "lineBegin": 39,
         "columnBegin": 24,
         "lineEnd": 39,
-        "columnEnd": 27
+        "columnEnd": 26
       },
       "text": { "key": "" }
     }
@@ -347,7 +347,7 @@
         "lineBegin": 39,
         "columnBegin": 28,
         "lineEnd": 39,
-        "columnEnd": 40
+        "columnEnd": 39
       },
       "text": { "key": "" }
     }
@@ -358,7 +358,7 @@
         "lineBegin": 39,
         "columnBegin": 42,
         "lineEnd": 39,
-        "columnEnd": 47
+        "columnEnd": 46
       },
       "text": { "key": "" }
     }
@@ -369,7 +369,7 @@
         "lineBegin": 39,
         "columnBegin": 48,
         "lineEnd": 39,
-        "columnEnd": 49
+        "columnEnd": 48
       },
       "text": { "key": "" }
     }
@@ -380,7 +380,7 @@
         "lineBegin": 39,
         "columnBegin": 57,
         "lineEnd": 39,
-        "columnEnd": 62
+        "columnEnd": 61
       },
       "text": { "key": "" }
     }
@@ -391,7 +391,7 @@
         "lineBegin": 39,
         "columnBegin": 63,
         "lineEnd": 39,
-        "columnEnd": 64
+        "columnEnd": 63
       },
       "text": { "key": "" }
     }
@@ -402,7 +402,7 @@
         "lineBegin": 40,
         "columnBegin": 13,
         "lineEnd": 40,
-        "columnEnd": 20
+        "columnEnd": 19
       },
       "text": { "key": "" }
     }
@@ -413,7 +413,7 @@
         "lineBegin": 40,
         "columnBegin": 21,
         "lineEnd": 40,
-        "columnEnd": 30
+        "columnEnd": 29
       },
       "text": { "key": "" }
     }
@@ -424,7 +424,7 @@
         "lineBegin": 40,
         "columnBegin": 31,
         "lineEnd": 40,
-        "columnEnd": 36
+        "columnEnd": 35
       },
       "text": { "key": "" }
     }
@@ -435,7 +435,7 @@
         "lineBegin": 40,
         "columnBegin": 37,
         "lineEnd": 40,
-        "columnEnd": 38
+        "columnEnd": 37
       },
       "text": { "key": "" }
     }
@@ -446,7 +446,7 @@
         "lineBegin": 44,
         "columnBegin": 4,
         "lineEnd": 44,
-        "columnEnd": 8
+        "columnEnd": 7
       },
       "text": { "key": "" }
     }
@@ -457,7 +457,7 @@
         "lineBegin": 44,
         "columnBegin": 12,
         "lineEnd": 44,
-        "columnEnd": 17
+        "columnEnd": 16
       },
       "text": { "key": "" }
     }
@@ -468,7 +468,7 @@
         "lineBegin": 44,
         "columnBegin": 18,
         "lineEnd": 44,
-        "columnEnd": 19
+        "columnEnd": 18
       },
       "text": { "key": "" }
     }
@@ -479,7 +479,7 @@
         "lineBegin": 46,
         "columnBegin": 4,
         "lineEnd": 46,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "" }
     }
@@ -490,7 +490,7 @@
         "lineBegin": 46,
         "columnBegin": 18,
         "lineEnd": 46,
-        "columnEnd": 25
+        "columnEnd": 24
       },
       "text": { "key": "" }
     }
@@ -501,7 +501,7 @@
         "lineBegin": 46,
         "columnBegin": 26,
         "lineEnd": 46,
-        "columnEnd": 31
+        "columnEnd": 30
       },
       "text": { "key": "" }
     }
@@ -512,7 +512,7 @@
         "lineBegin": 46,
         "columnBegin": 32,
         "lineEnd": 46,
-        "columnEnd": 36
+        "columnEnd": 35
       },
       "text": { "key": "" }
     }
@@ -523,7 +523,7 @@
         "lineBegin": 47,
         "columnBegin": 7,
         "lineEnd": 47,
-        "columnEnd": 17
+        "columnEnd": 16
       },
       "text": { "key": "" }
     }
@@ -534,7 +534,7 @@
         "lineBegin": 48,
         "columnBegin": 5,
         "lineEnd": 48,
-        "columnEnd": 9
+        "columnEnd": 8
       },
       "text": { "key": "" }
     }
@@ -545,7 +545,7 @@
         "lineBegin": 48,
         "columnBegin": 12,
         "lineEnd": 48,
-        "columnEnd": 16
+        "columnEnd": 15
       },
       "text": { "key": "" }
     }
@@ -556,7 +556,7 @@
         "lineBegin": 48,
         "columnBegin": 21,
         "lineEnd": 48,
-        "columnEnd": 31
+        "columnEnd": 30
       },
       "text": { "key": "" }
     }
@@ -567,7 +567,7 @@
         "lineBegin": 51,
         "columnBegin": 4,
         "lineEnd": 51,
-        "columnEnd": 12
+        "columnEnd": 11
       },
       "text": { "key": "" }
     }
@@ -578,7 +578,7 @@
         "lineBegin": 51,
         "columnBegin": 16,
         "lineEnd": 51,
-        "columnEnd": 23
+        "columnEnd": 22
       },
       "text": { "key": "" }
     }
@@ -589,7 +589,7 @@
         "lineBegin": 51,
         "columnBegin": 24,
         "lineEnd": 51,
-        "columnEnd": 27
+        "columnEnd": 26
       },
       "text": { "key": "" }
     }
@@ -600,7 +600,7 @@
         "lineBegin": 51,
         "columnBegin": 28,
         "lineEnd": 51,
-        "columnEnd": 40
+        "columnEnd": 39
       },
       "text": { "key": "" }
     }
@@ -611,7 +611,7 @@
         "lineBegin": 51,
         "columnBegin": 42,
         "lineEnd": 51,
-        "columnEnd": 46
+        "columnEnd": 45
       },
       "text": { "key": "" }
     }
@@ -622,7 +622,7 @@
         "lineBegin": 56,
         "columnBegin": 2,
         "lineEnd": 56,
-        "columnEnd": 6
+        "columnEnd": 5
       },
       "text": { "key": "" }
     }
@@ -633,7 +633,7 @@
         "lineBegin": 56,
         "columnBegin": 10,
         "lineEnd": 56,
-        "columnEnd": 13
+        "columnEnd": 12
       },
       "text": { "key": "" }
     }
@@ -644,7 +644,7 @@
         "lineBegin": 56,
         "columnBegin": 14,
         "lineEnd": 56,
-        "columnEnd": 21
+        "columnEnd": 20
       },
       "text": { "key": "" }
     }
@@ -655,7 +655,7 @@
         "lineBegin": 56,
         "columnBegin": 28,
         "lineEnd": 56,
-        "columnEnd": 32
+        "columnEnd": 31
       },
       "text": { "key": "" }
     }
@@ -666,7 +666,7 @@
         "lineBegin": 56,
         "columnBegin": 33,
         "lineEnd": 56,
-        "columnEnd": 36
+        "columnEnd": 35
       },
       "text": { "key": "" }
     }
@@ -677,7 +677,7 @@
         "lineBegin": 56,
         "columnBegin": 44,
         "lineEnd": 56,
-        "columnEnd": 52
+        "columnEnd": 51
       },
       "text": { "key": "" }
     }
@@ -688,7 +688,7 @@
         "lineBegin": 58,
         "columnBegin": 6,
         "lineEnd": 58,
-        "columnEnd": 17
+        "columnEnd": 16
       },
       "text": { "key": "" }
     }
@@ -699,7 +699,7 @@
         "lineBegin": 60,
         "columnBegin": 6,
         "lineEnd": 60,
-        "columnEnd": 7
+        "columnEnd": 6
       },
       "text": { "key": "" }
     }
@@ -710,7 +710,7 @@
         "lineBegin": 60,
         "columnBegin": 14,
         "lineEnd": 60,
-        "columnEnd": 15
+        "columnEnd": 14
       },
       "text": { "key": "" }
     }
@@ -721,7 +721,7 @@
         "lineBegin": 60,
         "columnBegin": 21,
         "lineEnd": 60,
-        "columnEnd": 22
+        "columnEnd": 21
       },
       "text": { "key": "" }
     }
@@ -732,7 +732,7 @@
         "lineBegin": 61,
         "columnBegin": 6,
         "lineEnd": 61,
-        "columnEnd": 17
+        "columnEnd": 16
       },
       "text": { "key": "" }
     }
@@ -743,7 +743,7 @@
         "lineBegin": 62,
         "columnBegin": 4,
         "lineEnd": 62,
-        "columnEnd": 15
+        "columnEnd": 14
       },
       "text": { "key": "" }
     }
@@ -754,7 +754,7 @@
         "lineBegin": 64,
         "columnBegin": 3,
         "lineEnd": 64,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "" }
     }
@@ -765,7 +765,7 @@
         "lineBegin": 64,
         "columnBegin": 18,
         "lineEnd": 64,
-        "columnEnd": 22
+        "columnEnd": 21
       },
       "text": { "key": "" }
     }
@@ -776,7 +776,7 @@
         "lineBegin": 64,
         "columnBegin": 23,
         "lineEnd": 64,
-        "columnEnd": 24
+        "columnEnd": 23
       },
       "text": { "key": "" }
     }
@@ -787,7 +787,7 @@
         "lineBegin": 64,
         "columnBegin": 30,
         "lineEnd": 64,
-        "columnEnd": 31
+        "columnEnd": 30
       },
       "text": { "key": "" }
     }
@@ -798,7 +798,7 @@
         "lineBegin": 67,
         "columnBegin": 9,
         "lineEnd": 67,
-        "columnEnd": 20
+        "columnEnd": 19
       },
       "text": { "key": "" }
     }

--- a/glean/lang/go/tests/cases/xrefs/uses.out
+++ b/glean/lang/go/tests/cases/xrefs/uses.out
@@ -16,7 +16,7 @@
                 "lineBegin": 24,
                 "columnBegin": 14,
                 "lineEnd": 24,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "text": { "key": "" }
             }
@@ -35,7 +35,7 @@
             "lineBegin": 25,
             "columnBegin": 32,
             "lineEnd": 25,
-            "columnEnd": 36
+            "columnEnd": 35
           },
           "text": { "key": "" }
         }
@@ -58,7 +58,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -77,7 +77,7 @@
             "lineBegin": 35,
             "columnBegin": 22,
             "lineEnd": 35,
-            "columnEnd": 27
+            "columnEnd": 26
           },
           "text": { "key": "" }
         }
@@ -100,7 +100,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -119,7 +119,7 @@
             "lineBegin": 36,
             "columnBegin": 24,
             "lineEnd": 36,
-            "columnEnd": 29
+            "columnEnd": 28
           },
           "text": { "key": "" }
         }
@@ -142,7 +142,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -161,7 +161,7 @@
             "lineBegin": 36,
             "columnBegin": 61,
             "lineEnd": 36,
-            "columnEnd": 66
+            "columnEnd": 65
           },
           "text": { "key": "" }
         }
@@ -184,7 +184,7 @@
                 "lineBegin": 25,
                 "columnBegin": 2,
                 "lineEnd": 25,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -203,972 +203,6 @@
             "lineBegin": 39,
             "columnBegin": 42,
             "lineEnd": 39,
-            "columnEnd": 47
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 25,
-                "columnBegin": 2,
-                "lineEnd": 25,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 39,
-            "columnBegin": 57,
-            "lineEnd": 39,
-            "columnEnd": 62
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 25,
-                "columnBegin": 2,
-                "lineEnd": 25,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 40,
-            "columnBegin": 31,
-            "lineEnd": 40,
-            "columnEnd": 36
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 25,
-                "columnBegin": 2,
-                "lineEnd": 25,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 44,
-            "columnBegin": 12,
-            "lineEnd": 44,
-            "columnEnd": 17
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 6,
-                "lineEnd": 27,
-                "columnEnd": 14
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 39,
-            "columnBegin": 4,
-            "lineEnd": 39,
-            "columnEnd": 12
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 6,
-                "lineEnd": 27,
-                "columnEnd": 14
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 51,
-            "columnBegin": 4,
-            "lineEnd": 51,
-            "columnEnd": 12
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 6,
-                "lineEnd": 27,
-                "columnEnd": 14
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 56,
-            "columnBegin": 44,
-            "lineEnd": 56,
-            "columnEnd": 52
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 28,
-                "columnBegin": 2,
-                "lineEnd": 28,
-                "columnEnd": 14
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 39,
-            "columnBegin": 28,
-            "lineEnd": 39,
-            "columnEnd": 40
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 28,
-                "columnBegin": 2,
-                "lineEnd": 28,
-                "columnEnd": 14
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 51,
-            "columnBegin": 28,
-            "lineEnd": 51,
-            "columnEnd": 40
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 28,
-                "columnBegin": 23,
-                "lineEnd": 28,
-                "columnEnd": 24
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 29,
-            "columnBegin": 6,
-            "lineEnd": 29,
-            "columnEnd": 7
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 28,
-                "columnBegin": 23,
-                "lineEnd": 28,
-                "columnEnd": 24
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 29,
-            "columnBegin": 18,
-            "lineEnd": 29,
-            "columnEnd": 19
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 28,
-                "columnBegin": 23,
-                "lineEnd": 28,
-                "columnEnd": 24
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 32,
-            "columnBegin": 10,
-            "lineEnd": 32,
-            "columnEnd": 11
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 6,
-                "lineEnd": 35,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 35,
-            "columnBegin": 14,
-            "lineEnd": 35,
-            "columnEnd": 15
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 6,
-                "lineEnd": 35,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 35,
-            "columnBegin": 30,
-            "lineEnd": 35,
-            "columnEnd": 31
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 6,
-                "lineEnd": 35,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 36,
-            "columnBegin": 30,
-            "lineEnd": 36,
-            "columnEnd": 31
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 6,
-                "lineEnd": 35,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 36,
-            "columnBegin": 67,
-            "lineEnd": 36,
-            "columnEnd": 68
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 6,
-                "lineEnd": 35,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 39,
-            "columnBegin": 48,
-            "lineEnd": 39,
-            "columnEnd": 49
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 6,
-                "lineEnd": 35,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 39,
-            "columnBegin": 63,
-            "lineEnd": 39,
-            "columnEnd": 64
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 6,
-                "lineEnd": 35,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 40,
-            "columnBegin": 37,
-            "lineEnd": 40,
-            "columnEnd": 38
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 6,
-                "lineEnd": 35,
-                "columnEnd": 7
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 44,
-            "columnBegin": 18,
-            "lineEnd": 44,
-            "columnEnd": 19
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 44,
-                "columnBegin": 4,
-                "lineEnd": 44,
-                "columnEnd": 8
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 46,
-            "columnBegin": 32,
-            "lineEnd": 46,
-            "columnEnd": 36
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 44,
-                "columnBegin": 4,
-                "lineEnd": 44,
-                "columnEnd": 8
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 48,
-            "columnBegin": 5,
-            "lineEnd": 48,
-            "columnEnd": 9
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 44,
-                "columnBegin": 4,
-                "lineEnd": 44,
-                "columnEnd": 8
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 48,
-            "columnBegin": 12,
-            "lineEnd": 48,
-            "columnEnd": 16
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 44,
-                "columnBegin": 4,
-                "lineEnd": 44,
-                "columnEnd": 8
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 51,
-            "columnBegin": 42,
-            "lineEnd": 51,
             "columnEnd": 46
           },
           "text": { "key": "" }
@@ -1189,10 +223,10 @@
           "range": {
             "key": {
               "range": {
-                "lineBegin": 46,
-                "columnBegin": 4,
-                "lineEnd": 46,
-                "columnEnd": 14
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -1208,10 +242,934 @@
       "range": {
         "key": {
           "range": {
-            "lineBegin": 47,
-            "columnBegin": 7,
-            "lineEnd": 47,
-            "columnEnd": 17
+            "lineBegin": 39,
+            "columnBegin": 57,
+            "lineEnd": 39,
+            "columnEnd": 61
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 6
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 40,
+            "columnBegin": 31,
+            "lineEnd": 40,
+            "columnEnd": 35
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 25,
+                "columnBegin": 2,
+                "lineEnd": 25,
+                "columnEnd": 6
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 44,
+            "columnBegin": 12,
+            "lineEnd": 44,
+            "columnEnd": 16
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 27,
+                "columnBegin": 6,
+                "lineEnd": 27,
+                "columnEnd": 13
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 4,
+            "lineEnd": 39,
+            "columnEnd": 11
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 27,
+                "columnBegin": 6,
+                "lineEnd": 27,
+                "columnEnd": 13
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 51,
+            "columnBegin": 4,
+            "lineEnd": 51,
+            "columnEnd": 11
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 27,
+                "columnBegin": 6,
+                "lineEnd": 27,
+                "columnEnd": 13
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 56,
+            "columnBegin": 44,
+            "lineEnd": 56,
+            "columnEnd": 51
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 28,
+                "columnBegin": 2,
+                "lineEnd": 28,
+                "columnEnd": 13
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 28,
+            "lineEnd": 39,
+            "columnEnd": 39
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 28,
+                "columnBegin": 2,
+                "lineEnd": 28,
+                "columnEnd": 13
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 51,
+            "columnBegin": 28,
+            "lineEnd": 51,
+            "columnEnd": 39
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 28,
+                "columnBegin": 23,
+                "lineEnd": 28,
+                "columnEnd": 23
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 29,
+            "columnBegin": 6,
+            "lineEnd": 29,
+            "columnEnd": 6
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 28,
+                "columnBegin": 23,
+                "lineEnd": 28,
+                "columnEnd": 23
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 29,
+            "columnBegin": 18,
+            "lineEnd": 29,
+            "columnEnd": 18
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 28,
+                "columnBegin": 23,
+                "lineEnd": 28,
+                "columnEnd": 23
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 32,
+            "columnBegin": 10,
+            "lineEnd": 32,
+            "columnEnd": 10
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 6
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 14,
+            "lineEnd": 35,
+            "columnEnd": 14
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 6
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 30,
+            "lineEnd": 35,
+            "columnEnd": 30
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 6
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 30,
+            "lineEnd": 36,
+            "columnEnd": 30
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 6
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 67,
+            "lineEnd": 36,
+            "columnEnd": 67
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 6
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 48,
+            "lineEnd": 39,
+            "columnEnd": 48
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 6
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 63,
+            "lineEnd": 39,
+            "columnEnd": 63
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 6
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 40,
+            "columnBegin": 37,
+            "lineEnd": 40,
+            "columnEnd": 37
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 6,
+                "lineEnd": 35,
+                "columnEnd": 6
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 44,
+            "columnBegin": 18,
+            "lineEnd": 44,
+            "columnEnd": 18
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 7
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 46,
+            "columnBegin": 32,
+            "lineEnd": 46,
+            "columnEnd": 35
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 7
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 48,
+            "columnBegin": 5,
+            "lineEnd": 48,
+            "columnEnd": 8
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 7
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 48,
+            "columnBegin": 12,
+            "lineEnd": 48,
+            "columnEnd": 15
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 44,
+                "columnBegin": 4,
+                "lineEnd": 44,
+                "columnEnd": 7
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 51,
+            "columnBegin": 42,
+            "lineEnd": 51,
+            "columnEnd": 45
           },
           "text": { "key": "" }
         }
@@ -1234,7 +1192,49 @@
                 "lineBegin": 46,
                 "columnBegin": 4,
                 "lineEnd": 46,
-                "columnEnd": 14
+                "columnEnd": 13
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 47,
+            "columnBegin": 7,
+            "lineEnd": 47,
+            "columnEnd": 16
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 46,
+                "columnBegin": 4,
+                "lineEnd": 46,
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -1253,7 +1253,7 @@
             "lineBegin": 48,
             "columnBegin": 21,
             "lineEnd": 48,
-            "columnEnd": 31
+            "columnEnd": 30
           },
           "text": { "key": "" }
         }
@@ -1276,7 +1276,7 @@
                 "lineBegin": 56,
                 "columnBegin": 2,
                 "lineEnd": 56,
-                "columnEnd": 6
+                "columnEnd": 5
               },
               "text": { "key": "" }
             }
@@ -1295,7 +1295,7 @@
             "lineBegin": 64,
             "columnBegin": 18,
             "lineEnd": 64,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "" }
         }
@@ -1318,7 +1318,7 @@
                 "lineBegin": 58,
                 "columnBegin": 6,
                 "lineEnd": 58,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "text": { "key": "" }
             }
@@ -1337,7 +1337,7 @@
             "lineBegin": 61,
             "columnBegin": 6,
             "lineEnd": 61,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "" }
         }
@@ -1360,7 +1360,7 @@
                 "lineBegin": 58,
                 "columnBegin": 6,
                 "lineEnd": 58,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "text": { "key": "" }
             }
@@ -1379,48 +1379,6 @@
             "lineBegin": 62,
             "columnBegin": 4,
             "lineEnd": 62,
-            "columnEnd": 15
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": {
-              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-              "language": 16
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 58,
-                "columnBegin": 6,
-                "lineEnd": 58,
-                "columnEnd": 17
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": {
-        "key": {
-          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
-          "language": 16
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 64,
-            "columnBegin": 3,
-            "lineEnd": 64,
             "columnEnd": 14
           },
           "text": { "key": "" }
@@ -1444,7 +1402,49 @@
                 "lineBegin": 58,
                 "columnBegin": 6,
                 "lineEnd": 58,
-                "columnEnd": 17
+                "columnEnd": 16
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": {
+        "key": {
+          "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+          "language": 16
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 64,
+            "columnBegin": 3,
+            "lineEnd": 64,
+            "columnEnd": 13
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": {
+              "file": { "key": "glean/lang/go/tests/cases/xrefs/leaphash.go" },
+              "language": 16
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 58,
+                "columnBegin": 6,
+                "lineEnd": 58,
+                "columnEnd": 16
               },
               "text": { "key": "" }
             }
@@ -1463,7 +1463,7 @@
             "lineBegin": 67,
             "columnBegin": 9,
             "lineEnd": 67,
-            "columnEnd": 20
+            "columnEnd": 19
           },
           "text": { "key": "" }
         }
@@ -1486,7 +1486,7 @@
                 "lineBegin": 60,
                 "columnBegin": 6,
                 "lineEnd": 60,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -1505,7 +1505,7 @@
             "lineBegin": 60,
             "columnBegin": 14,
             "lineEnd": 60,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "" }
         }
@@ -1528,7 +1528,7 @@
                 "lineBegin": 60,
                 "columnBegin": 6,
                 "lineEnd": 60,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -1547,7 +1547,7 @@
             "lineBegin": 60,
             "columnBegin": 21,
             "lineEnd": 60,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "" }
         }
@@ -1570,7 +1570,7 @@
                 "lineBegin": 60,
                 "columnBegin": 6,
                 "lineEnd": 60,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -1589,7 +1589,7 @@
             "lineBegin": 64,
             "columnBegin": 23,
             "lineEnd": 64,
-            "columnEnd": 24
+            "columnEnd": 23
           },
           "text": { "key": "" }
         }
@@ -1612,7 +1612,7 @@
                 "lineBegin": 60,
                 "columnBegin": 6,
                 "lineEnd": 60,
-                "columnEnd": 7
+                "columnEnd": 6
               },
               "text": { "key": "" }
             }
@@ -1631,7 +1631,7 @@
             "lineBegin": 64,
             "columnBegin": 30,
             "lineEnd": 64,
-            "columnEnd": 31
+            "columnEnd": 30
           },
           "text": { "key": "" }
         }

--- a/glean/lang/rust-lsif/tests/cases/xrefs/defhover.out
+++ b/glean/lang/rust-lsif/tests/cases/xrefs/defhover.out
@@ -13,7 +13,7 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -43,7 +43,7 @@
                 "lineBegin": 12,
                 "columnBegin": 15,
                 "lineEnd": 12,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -71,7 +71,7 @@
                 "lineBegin": 16,
                 "columnBegin": 4,
                 "lineEnd": 16,
-                "columnEnd": 9
+                "columnEnd": 8
               },
               "text": { "key": "" }
             }
@@ -101,7 +101,7 @@
                 "lineBegin": 16,
                 "columnBegin": 10,
                 "lineEnd": 16,
-                "columnEnd": 11
+                "columnEnd": 10
               },
               "text": { "key": "" }
             }
@@ -129,7 +129,7 @@
                 "lineBegin": 16,
                 "columnBegin": 18,
                 "lineEnd": 16,
-                "columnEnd": 21
+                "columnEnd": 20
               },
               "text": { "key": "" }
             }
@@ -157,7 +157,7 @@
                 "lineBegin": 22,
                 "columnBegin": 8,
                 "lineEnd": 22,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -187,7 +187,7 @@
                 "lineBegin": 22,
                 "columnBegin": 15,
                 "lineEnd": 22,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -215,7 +215,7 @@
                 "lineBegin": 23,
                 "columnBegin": 13,
                 "lineEnd": 23,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -243,7 +243,7 @@
                 "lineBegin": 24,
                 "columnBegin": 13,
                 "lineEnd": 24,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -271,7 +271,7 @@
                 "lineBegin": 37,
                 "columnBegin": 8,
                 "lineEnd": 37,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -301,7 +301,7 @@
                 "lineBegin": 37,
                 "columnBegin": 15,
                 "lineEnd": 37,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -329,7 +329,7 @@
                 "lineBegin": 38,
                 "columnBegin": 13,
                 "lineEnd": 38,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -357,7 +357,7 @@
                 "lineBegin": 39,
                 "columnBegin": 9,
                 "lineEnd": 39,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "" }
             }

--- a/glean/lang/rust-lsif/tests/cases/xrefs/definition.out
+++ b/glean/lang/rust-lsif/tests/cases/xrefs/definition.out
@@ -9,7 +9,7 @@
             "lineBegin": 12,
             "columnBegin": 8,
             "lineEnd": 12,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "" }
         }
@@ -25,7 +25,7 @@
             "lineBegin": 12,
             "columnBegin": 15,
             "lineEnd": 12,
-            "columnEnd": 16
+            "columnEnd": 15
           },
           "text": { "key": "" }
         }
@@ -41,7 +41,7 @@
             "lineBegin": 16,
             "columnBegin": 4,
             "lineEnd": 16,
-            "columnEnd": 9
+            "columnEnd": 8
           },
           "text": { "key": "" }
         }
@@ -57,7 +57,7 @@
             "lineBegin": 16,
             "columnBegin": 10,
             "lineEnd": 16,
-            "columnEnd": 11
+            "columnEnd": 10
           },
           "text": { "key": "" }
         }
@@ -73,7 +73,7 @@
             "lineBegin": 16,
             "columnBegin": 18,
             "lineEnd": 16,
-            "columnEnd": 21
+            "columnEnd": 20
           },
           "text": { "key": "" }
         }
@@ -89,7 +89,7 @@
             "lineBegin": 22,
             "columnBegin": 8,
             "lineEnd": 22,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "" }
         }
@@ -105,7 +105,7 @@
             "lineBegin": 22,
             "columnBegin": 15,
             "lineEnd": 22,
-            "columnEnd": 16
+            "columnEnd": 15
           },
           "text": { "key": "" }
         }
@@ -121,7 +121,7 @@
             "lineBegin": 23,
             "columnBegin": 13,
             "lineEnd": 23,
-            "columnEnd": 16
+            "columnEnd": 15
           },
           "text": { "key": "" }
         }
@@ -137,7 +137,7 @@
             "lineBegin": 24,
             "columnBegin": 13,
             "lineEnd": 24,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "" }
         }
@@ -153,7 +153,7 @@
             "lineBegin": 37,
             "columnBegin": 8,
             "lineEnd": 37,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "" }
         }
@@ -169,7 +169,7 @@
             "lineBegin": 37,
             "columnBegin": 15,
             "lineEnd": 37,
-            "columnEnd": 16
+            "columnEnd": 15
           },
           "text": { "key": "" }
         }
@@ -185,7 +185,7 @@
             "lineBegin": 38,
             "columnBegin": 13,
             "lineEnd": 38,
-            "columnEnd": 16
+            "columnEnd": 15
           },
           "text": { "key": "" }
         }
@@ -201,7 +201,7 @@
             "lineBegin": 39,
             "columnBegin": 9,
             "lineEnd": 39,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "text": { "key": "" }
         }

--- a/glean/lang/rust-lsif/tests/cases/xrefs/range.out
+++ b/glean/lang/rust-lsif/tests/cases/xrefs/range.out
@@ -6,7 +6,7 @@
         "lineBegin": 11,
         "columnBegin": 3,
         "lineEnd": 11,
-        "columnEnd": 9
+        "columnEnd": 8
       },
       "text": { "key": "" }
     }
@@ -17,7 +17,7 @@
         "lineBegin": 12,
         "columnBegin": 8,
         "lineEnd": 12,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "" }
     }
@@ -28,7 +28,7 @@
         "lineBegin": 12,
         "columnBegin": 15,
         "lineEnd": 12,
-        "columnEnd": 16
+        "columnEnd": 15
       },
       "text": { "key": "" }
     }
@@ -39,7 +39,7 @@
         "lineBegin": 12,
         "columnBegin": 18,
         "lineEnd": 12,
-        "columnEnd": 21
+        "columnEnd": 20
       },
       "text": { "key": "" }
     }
@@ -50,7 +50,7 @@
         "lineBegin": 12,
         "columnBegin": 26,
         "lineEnd": 12,
-        "columnEnd": 29
+        "columnEnd": 28
       },
       "text": { "key": "" }
     }
@@ -61,7 +61,7 @@
         "lineBegin": 13,
         "columnBegin": 5,
         "lineEnd": 13,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "text": { "key": "" }
     }
@@ -72,7 +72,7 @@
         "lineBegin": 13,
         "columnBegin": 11,
         "lineEnd": 13,
-        "columnEnd": 12
+        "columnEnd": 11
       },
       "text": { "key": "" }
     }
@@ -83,7 +83,7 @@
         "lineBegin": 16,
         "columnBegin": 4,
         "lineEnd": 16,
-        "columnEnd": 9
+        "columnEnd": 8
       },
       "text": { "key": "" }
     }
@@ -94,7 +94,7 @@
         "lineBegin": 16,
         "columnBegin": 10,
         "lineEnd": 16,
-        "columnEnd": 11
+        "columnEnd": 10
       },
       "text": { "key": "" }
     }
@@ -105,7 +105,7 @@
         "lineBegin": 16,
         "columnBegin": 13,
         "lineEnd": 16,
-        "columnEnd": 16
+        "columnEnd": 15
       },
       "text": { "key": "" }
     }
@@ -116,7 +116,7 @@
         "lineBegin": 16,
         "columnBegin": 18,
         "lineEnd": 16,
-        "columnEnd": 21
+        "columnEnd": 20
       },
       "text": { "key": "" }
     }
@@ -127,7 +127,7 @@
         "lineBegin": 16,
         "columnBegin": 23,
         "lineEnd": 16,
-        "columnEnd": 26
+        "columnEnd": 25
       },
       "text": { "key": "" }
     }
@@ -138,7 +138,7 @@
         "lineBegin": 16,
         "columnBegin": 31,
         "lineEnd": 16,
-        "columnEnd": 34
+        "columnEnd": 33
       },
       "text": { "key": "" }
     }
@@ -149,7 +149,7 @@
         "lineBegin": 17,
         "columnBegin": 8,
         "lineEnd": 17,
-        "columnEnd": 9
+        "columnEnd": 8
       },
       "text": { "key": "" }
     }
@@ -160,7 +160,7 @@
         "lineBegin": 17,
         "columnBegin": 17,
         "lineEnd": 17,
-        "columnEnd": 20
+        "columnEnd": 19
       },
       "text": { "key": "" }
     }
@@ -171,7 +171,7 @@
         "lineBegin": 17,
         "columnBegin": 30,
         "lineEnd": 17,
-        "columnEnd": 35
+        "columnEnd": 34
       },
       "text": { "key": "" }
     }
@@ -182,7 +182,7 @@
         "lineBegin": 17,
         "columnBegin": 36,
         "lineEnd": 17,
-        "columnEnd": 37
+        "columnEnd": 36
       },
       "text": { "key": "" }
     }
@@ -193,7 +193,7 @@
         "lineBegin": 17,
         "columnBegin": 43,
         "lineEnd": 17,
-        "columnEnd": 46
+        "columnEnd": 45
       },
       "text": { "key": "" }
     }
@@ -204,7 +204,7 @@
         "lineBegin": 17,
         "columnBegin": 49,
         "lineEnd": 17,
-        "columnEnd": 50
+        "columnEnd": 49
       },
       "text": { "key": "" }
     }
@@ -215,7 +215,7 @@
         "lineBegin": 21,
         "columnBegin": 3,
         "lineEnd": 21,
-        "columnEnd": 9
+        "columnEnd": 8
       },
       "text": { "key": "" }
     }
@@ -226,7 +226,7 @@
         "lineBegin": 22,
         "columnBegin": 8,
         "lineEnd": 22,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "" }
     }
@@ -237,7 +237,7 @@
         "lineBegin": 22,
         "columnBegin": 15,
         "lineEnd": 22,
-        "columnEnd": 16
+        "columnEnd": 15
       },
       "text": { "key": "" }
     }
@@ -248,7 +248,7 @@
         "lineBegin": 22,
         "columnBegin": 18,
         "lineEnd": 22,
-        "columnEnd": 21
+        "columnEnd": 20
       },
       "text": { "key": "" }
     }
@@ -259,7 +259,7 @@
         "lineBegin": 22,
         "columnBegin": 26,
         "lineEnd": 22,
-        "columnEnd": 29
+        "columnEnd": 28
       },
       "text": { "key": "" }
     }
@@ -270,7 +270,7 @@
         "lineBegin": 23,
         "columnBegin": 13,
         "lineEnd": 23,
-        "columnEnd": 16
+        "columnEnd": 15
       },
       "text": { "key": "" }
     }
@@ -281,7 +281,7 @@
         "lineBegin": 24,
         "columnBegin": 13,
         "lineEnd": 24,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "" }
     }
@@ -292,7 +292,7 @@
         "lineBegin": 24,
         "columnBegin": 17,
         "lineEnd": 24,
-        "columnEnd": 18
+        "columnEnd": 17
       },
       "text": { "key": "" }
     }
@@ -303,7 +303,7 @@
         "lineBegin": 26,
         "columnBegin": 12,
         "lineEnd": 26,
-        "columnEnd": 13
+        "columnEnd": 12
       },
       "text": { "key": "" }
     }
@@ -314,7 +314,7 @@
         "lineBegin": 27,
         "columnBegin": 20,
         "lineEnd": 27,
-        "columnEnd": 23
+        "columnEnd": 22
       },
       "text": { "key": "" }
     }
@@ -325,7 +325,7 @@
         "lineBegin": 29,
         "columnBegin": 13,
         "lineEnd": 29,
-        "columnEnd": 16
+        "columnEnd": 15
       },
       "text": { "key": "" }
     }
@@ -336,7 +336,7 @@
         "lineBegin": 29,
         "columnBegin": 20,
         "lineEnd": 29,
-        "columnEnd": 21
+        "columnEnd": 20
       },
       "text": { "key": "" }
     }
@@ -347,7 +347,7 @@
         "lineBegin": 30,
         "columnBegin": 13,
         "lineEnd": 30,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "" }
     }
@@ -358,7 +358,7 @@
         "lineBegin": 36,
         "columnBegin": 3,
         "lineEnd": 36,
-        "columnEnd": 9
+        "columnEnd": 8
       },
       "text": { "key": "" }
     }
@@ -369,7 +369,7 @@
         "lineBegin": 37,
         "columnBegin": 8,
         "lineEnd": 37,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "" }
     }
@@ -380,7 +380,7 @@
         "lineBegin": 37,
         "columnBegin": 15,
         "lineEnd": 37,
-        "columnEnd": 16
+        "columnEnd": 15
       },
       "text": { "key": "" }
     }
@@ -391,7 +391,7 @@
         "lineBegin": 37,
         "columnBegin": 18,
         "lineEnd": 37,
-        "columnEnd": 21
+        "columnEnd": 20
       },
       "text": { "key": "" }
     }
@@ -402,7 +402,7 @@
         "lineBegin": 37,
         "columnBegin": 26,
         "lineEnd": 37,
-        "columnEnd": 29
+        "columnEnd": 28
       },
       "text": { "key": "" }
     }
@@ -413,7 +413,7 @@
         "lineBegin": 38,
         "columnBegin": 13,
         "lineEnd": 38,
-        "columnEnd": 16
+        "columnEnd": 15
       },
       "text": { "key": "" }
     }
@@ -424,7 +424,7 @@
         "lineBegin": 39,
         "columnBegin": 9,
         "lineEnd": 39,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "text": { "key": "" }
     }
@@ -435,7 +435,7 @@
         "lineBegin": 39,
         "columnBegin": 18,
         "lineEnd": 39,
-        "columnEnd": 19
+        "columnEnd": 18
       },
       "text": { "key": "" }
     }
@@ -446,7 +446,7 @@
         "lineBegin": 40,
         "columnBegin": 9,
         "lineEnd": 40,
-        "columnEnd": 12
+        "columnEnd": 11
       },
       "text": { "key": "" }
     }
@@ -457,7 +457,7 @@
         "lineBegin": 40,
         "columnBegin": 16,
         "lineEnd": 40,
-        "columnEnd": 17
+        "columnEnd": 16
       },
       "text": { "key": "" }
     }
@@ -468,7 +468,7 @@
         "lineBegin": 42,
         "columnBegin": 5,
         "lineEnd": 42,
-        "columnEnd": 8
+        "columnEnd": 7
       },
       "text": { "key": "" }
     }

--- a/glean/lang/rust-lsif/tests/cases/xrefs/uses.out
+++ b/glean/lang/rust-lsif/tests/cases/xrefs/uses.out
@@ -13,7 +13,7 @@
                 "lineBegin": 12,
                 "columnBegin": 15,
                 "lineEnd": 12,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -27,7 +27,7 @@
             "lineBegin": 13,
             "columnBegin": 11,
             "lineEnd": 13,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "text": { "key": "" }
         }
@@ -47,7 +47,7 @@
                 "lineBegin": 16,
                 "columnBegin": 4,
                 "lineEnd": 16,
-                "columnEnd": 9
+                "columnEnd": 8
               },
               "text": { "key": "" }
             }
@@ -61,74 +61,6 @@
             "lineBegin": 13,
             "columnBegin": 5,
             "lineEnd": 13,
-            "columnEnd": 10
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": { "file": { "key": "src/lib.rs" }, "language": 42 }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 16,
-                "columnBegin": 4,
-                "lineEnd": 16,
-                "columnEnd": 9
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": { "key": { "file": { "key": "src/lib.rs" }, "language": 42 } },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 17,
-            "columnBegin": 30,
-            "lineEnd": 17,
-            "columnEnd": 35
-          },
-          "text": { "key": "" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "target": {
-        "key": {
-          "file": {
-            "key": { "file": { "key": "src/lib.rs" }, "language": 42 }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 16,
-                "columnBegin": 10,
-                "lineEnd": 16,
-                "columnEnd": 11
-              },
-              "text": { "key": "" }
-            }
-          }
-        }
-      },
-      "file": { "key": { "file": { "key": "src/lib.rs" }, "language": 42 } },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 17,
-            "columnBegin": 8,
-            "lineEnd": 17,
             "columnEnd": 9
           },
           "text": { "key": "" }
@@ -147,9 +79,77 @@
             "key": {
               "range": {
                 "lineBegin": 16,
+                "columnBegin": 4,
+                "lineEnd": 16,
+                "columnEnd": 8
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": { "key": { "file": { "key": "src/lib.rs" }, "language": 42 } },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 30,
+            "lineEnd": 17,
+            "columnEnd": 34
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": { "file": { "key": "src/lib.rs" }, "language": 42 }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
                 "columnBegin": 10,
                 "lineEnd": 16,
-                "columnEnd": 11
+                "columnEnd": 10
+              },
+              "text": { "key": "" }
+            }
+          }
+        }
+      },
+      "file": { "key": { "file": { "key": "src/lib.rs" }, "language": 42 } },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 8,
+            "lineEnd": 17,
+            "columnEnd": 8
+          },
+          "text": { "key": "" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "file": {
+            "key": { "file": { "key": "src/lib.rs" }, "language": 42 }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 10,
+                "lineEnd": 16,
+                "columnEnd": 10
               },
               "text": { "key": "" }
             }
@@ -163,7 +163,7 @@
             "lineBegin": 17,
             "columnBegin": 36,
             "lineEnd": 17,
-            "columnEnd": 37
+            "columnEnd": 36
           },
           "text": { "key": "" }
         }
@@ -183,7 +183,7 @@
                 "lineBegin": 16,
                 "columnBegin": 10,
                 "lineEnd": 16,
-                "columnEnd": 11
+                "columnEnd": 10
               },
               "text": { "key": "" }
             }
@@ -197,7 +197,7 @@
             "lineBegin": 17,
             "columnBegin": 49,
             "lineEnd": 17,
-            "columnEnd": 50
+            "columnEnd": 49
           },
           "text": { "key": "" }
         }
@@ -217,7 +217,7 @@
                 "lineBegin": 16,
                 "columnBegin": 18,
                 "lineEnd": 16,
-                "columnEnd": 21
+                "columnEnd": 20
               },
               "text": { "key": "" }
             }
@@ -231,7 +231,7 @@
             "lineBegin": 17,
             "columnBegin": 17,
             "lineEnd": 17,
-            "columnEnd": 20
+            "columnEnd": 19
           },
           "text": { "key": "" }
         }
@@ -251,7 +251,7 @@
                 "lineBegin": 16,
                 "columnBegin": 18,
                 "lineEnd": 16,
-                "columnEnd": 21
+                "columnEnd": 20
               },
               "text": { "key": "" }
             }
@@ -265,7 +265,7 @@
             "lineBegin": 17,
             "columnBegin": 43,
             "lineEnd": 17,
-            "columnEnd": 46
+            "columnEnd": 45
           },
           "text": { "key": "" }
         }
@@ -285,7 +285,7 @@
                 "lineBegin": 22,
                 "columnBegin": 15,
                 "lineEnd": 22,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -299,7 +299,7 @@
             "lineBegin": 24,
             "columnBegin": 17,
             "lineEnd": 24,
-            "columnEnd": 18
+            "columnEnd": 17
           },
           "text": { "key": "" }
         }
@@ -319,7 +319,7 @@
                 "lineBegin": 23,
                 "columnBegin": 13,
                 "lineEnd": 23,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -333,7 +333,7 @@
             "lineBegin": 27,
             "columnBegin": 20,
             "lineEnd": 27,
-            "columnEnd": 23
+            "columnEnd": 22
           },
           "text": { "key": "" }
         }
@@ -353,7 +353,7 @@
                 "lineBegin": 23,
                 "columnBegin": 13,
                 "lineEnd": 23,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -367,7 +367,7 @@
             "lineBegin": 29,
             "columnBegin": 13,
             "lineEnd": 29,
-            "columnEnd": 16
+            "columnEnd": 15
           },
           "text": { "key": "" }
         }
@@ -387,7 +387,7 @@
                 "lineBegin": 24,
                 "columnBegin": 13,
                 "lineEnd": 24,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -401,7 +401,7 @@
             "lineBegin": 26,
             "columnBegin": 12,
             "lineEnd": 26,
-            "columnEnd": 13
+            "columnEnd": 12
           },
           "text": { "key": "" }
         }
@@ -421,7 +421,7 @@
                 "lineBegin": 24,
                 "columnBegin": 13,
                 "lineEnd": 24,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -435,7 +435,7 @@
             "lineBegin": 29,
             "columnBegin": 20,
             "lineEnd": 29,
-            "columnEnd": 21
+            "columnEnd": 20
           },
           "text": { "key": "" }
         }
@@ -455,7 +455,7 @@
                 "lineBegin": 24,
                 "columnBegin": 13,
                 "lineEnd": 24,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -469,7 +469,7 @@
             "lineBegin": 30,
             "columnBegin": 13,
             "lineEnd": 30,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "" }
         }
@@ -489,7 +489,7 @@
                 "lineBegin": 37,
                 "columnBegin": 15,
                 "lineEnd": 37,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -503,7 +503,7 @@
             "lineBegin": 39,
             "columnBegin": 18,
             "lineEnd": 39,
-            "columnEnd": 19
+            "columnEnd": 18
           },
           "text": { "key": "" }
         }
@@ -523,7 +523,7 @@
                 "lineBegin": 38,
                 "columnBegin": 13,
                 "lineEnd": 38,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -537,7 +537,7 @@
             "lineBegin": 40,
             "columnBegin": 9,
             "lineEnd": 40,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "text": { "key": "" }
         }
@@ -557,7 +557,7 @@
                 "lineBegin": 38,
                 "columnBegin": 13,
                 "lineEnd": 38,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -571,7 +571,7 @@
             "lineBegin": 42,
             "columnBegin": 5,
             "lineEnd": 42,
-            "columnEnd": 8
+            "columnEnd": 7
           },
           "text": { "key": "" }
         }
@@ -591,7 +591,7 @@
                 "lineBegin": 39,
                 "columnBegin": 9,
                 "lineEnd": 39,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "" }
             }
@@ -605,7 +605,7 @@
             "lineBegin": 40,
             "columnBegin": 16,
             "lineEnd": 40,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "" }
         }

--- a/glean/lang/rust-lsif/tests/cases/xrefs/xrefs.out
+++ b/glean/lang/rust-lsif/tests/cases/xrefs/xrefs.out
@@ -9,7 +9,7 @@
             "lineBegin": 13,
             "columnBegin": 5,
             "lineEnd": 13,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "text": { "key": "" }
         }
@@ -25,7 +25,7 @@
                 "lineBegin": 16,
                 "columnBegin": 4,
                 "lineEnd": 16,
-                "columnEnd": 9
+                "columnEnd": 8
               },
               "text": { "key": "" }
             }
@@ -43,7 +43,7 @@
             "lineBegin": 13,
             "columnBegin": 11,
             "lineEnd": 13,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "text": { "key": "" }
         }
@@ -59,7 +59,7 @@
                 "lineBegin": 12,
                 "columnBegin": 15,
                 "lineEnd": 12,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -77,7 +77,7 @@
             "lineBegin": 17,
             "columnBegin": 8,
             "lineEnd": 17,
-            "columnEnd": 9
+            "columnEnd": 8
           },
           "text": { "key": "" }
         }
@@ -93,7 +93,7 @@
                 "lineBegin": 16,
                 "columnBegin": 10,
                 "lineEnd": 16,
-                "columnEnd": 11
+                "columnEnd": 10
               },
               "text": { "key": "" }
             }
@@ -111,7 +111,7 @@
             "lineBegin": 17,
             "columnBegin": 17,
             "lineEnd": 17,
-            "columnEnd": 20
+            "columnEnd": 19
           },
           "text": { "key": "" }
         }
@@ -127,7 +127,7 @@
                 "lineBegin": 16,
                 "columnBegin": 18,
                 "lineEnd": 16,
-                "columnEnd": 21
+                "columnEnd": 20
               },
               "text": { "key": "" }
             }
@@ -145,7 +145,7 @@
             "lineBegin": 17,
             "columnBegin": 30,
             "lineEnd": 17,
-            "columnEnd": 35
+            "columnEnd": 34
           },
           "text": { "key": "" }
         }
@@ -161,7 +161,7 @@
                 "lineBegin": 16,
                 "columnBegin": 4,
                 "lineEnd": 16,
-                "columnEnd": 9
+                "columnEnd": 8
               },
               "text": { "key": "" }
             }
@@ -179,7 +179,7 @@
             "lineBegin": 17,
             "columnBegin": 36,
             "lineEnd": 17,
-            "columnEnd": 37
+            "columnEnd": 36
           },
           "text": { "key": "" }
         }
@@ -195,7 +195,7 @@
                 "lineBegin": 16,
                 "columnBegin": 10,
                 "lineEnd": 16,
-                "columnEnd": 11
+                "columnEnd": 10
               },
               "text": { "key": "" }
             }
@@ -213,7 +213,7 @@
             "lineBegin": 17,
             "columnBegin": 43,
             "lineEnd": 17,
-            "columnEnd": 46
+            "columnEnd": 45
           },
           "text": { "key": "" }
         }
@@ -229,7 +229,7 @@
                 "lineBegin": 16,
                 "columnBegin": 18,
                 "lineEnd": 16,
-                "columnEnd": 21
+                "columnEnd": 20
               },
               "text": { "key": "" }
             }
@@ -247,7 +247,7 @@
             "lineBegin": 17,
             "columnBegin": 49,
             "lineEnd": 17,
-            "columnEnd": 50
+            "columnEnd": 49
           },
           "text": { "key": "" }
         }
@@ -263,7 +263,7 @@
                 "lineBegin": 16,
                 "columnBegin": 10,
                 "lineEnd": 16,
-                "columnEnd": 11
+                "columnEnd": 10
               },
               "text": { "key": "" }
             }
@@ -281,7 +281,7 @@
             "lineBegin": 24,
             "columnBegin": 17,
             "lineEnd": 24,
-            "columnEnd": 18
+            "columnEnd": 17
           },
           "text": { "key": "" }
         }
@@ -297,7 +297,7 @@
                 "lineBegin": 22,
                 "columnBegin": 15,
                 "lineEnd": 22,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -315,7 +315,7 @@
             "lineBegin": 26,
             "columnBegin": 12,
             "lineEnd": 26,
-            "columnEnd": 13
+            "columnEnd": 12
           },
           "text": { "key": "" }
         }
@@ -331,7 +331,7 @@
                 "lineBegin": 24,
                 "columnBegin": 13,
                 "lineEnd": 24,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -349,7 +349,7 @@
             "lineBegin": 27,
             "columnBegin": 20,
             "lineEnd": 27,
-            "columnEnd": 23
+            "columnEnd": 22
           },
           "text": { "key": "" }
         }
@@ -365,7 +365,7 @@
                 "lineBegin": 23,
                 "columnBegin": 13,
                 "lineEnd": 23,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -383,7 +383,7 @@
             "lineBegin": 29,
             "columnBegin": 13,
             "lineEnd": 29,
-            "columnEnd": 16
+            "columnEnd": 15
           },
           "text": { "key": "" }
         }
@@ -399,7 +399,7 @@
                 "lineBegin": 23,
                 "columnBegin": 13,
                 "lineEnd": 23,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -417,7 +417,7 @@
             "lineBegin": 29,
             "columnBegin": 20,
             "lineEnd": 29,
-            "columnEnd": 21
+            "columnEnd": 20
           },
           "text": { "key": "" }
         }
@@ -433,7 +433,7 @@
                 "lineBegin": 24,
                 "columnBegin": 13,
                 "lineEnd": 24,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -451,7 +451,7 @@
             "lineBegin": 30,
             "columnBegin": 13,
             "lineEnd": 30,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "" }
         }
@@ -467,7 +467,7 @@
                 "lineBegin": 24,
                 "columnBegin": 13,
                 "lineEnd": 24,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "text": { "key": "" }
             }
@@ -485,7 +485,7 @@
             "lineBegin": 39,
             "columnBegin": 18,
             "lineEnd": 39,
-            "columnEnd": 19
+            "columnEnd": 18
           },
           "text": { "key": "" }
         }
@@ -501,7 +501,7 @@
                 "lineBegin": 37,
                 "columnBegin": 15,
                 "lineEnd": 37,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -519,7 +519,7 @@
             "lineBegin": 40,
             "columnBegin": 9,
             "lineEnd": 40,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "text": { "key": "" }
         }
@@ -535,7 +535,7 @@
                 "lineBegin": 38,
                 "columnBegin": 13,
                 "lineEnd": 38,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }
@@ -553,7 +553,7 @@
             "lineBegin": 40,
             "columnBegin": 16,
             "lineEnd": 40,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "" }
         }
@@ -569,7 +569,7 @@
                 "lineBegin": 39,
                 "columnBegin": 9,
                 "lineEnd": 39,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "" }
             }
@@ -587,7 +587,7 @@
             "lineBegin": 42,
             "columnBegin": 5,
             "lineEnd": 42,
-            "columnEnd": 8
+            "columnEnd": 7
           },
           "text": { "key": "" }
         }
@@ -603,7 +603,7 @@
                 "lineBegin": 38,
                 "columnBegin": 13,
                 "lineEnd": 38,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "text": { "key": "" }
             }

--- a/glean/lang/typescript/tests/cases/xrefs/definition.out
+++ b/glean/lang/typescript/tests/cases/xrefs/definition.out
@@ -45,13 +45,13 @@
             "lineBegin": 9,
             "columnBegin": 8,
             "lineEnd": 9,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "fullRange": {
             "lineBegin": 9,
             "columnBegin": 8,
             "lineEnd": 9,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "text": { "key": "fs" }
         }
@@ -74,13 +74,13 @@
             "lineBegin": 10,
             "columnBegin": 8,
             "lineEnd": 10,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "fullRange": {
             "lineBegin": 10,
             "columnBegin": 8,
             "lineEnd": 10,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "text": { "key": "os" }
         }
@@ -103,13 +103,13 @@
             "lineBegin": 11,
             "columnBegin": 8,
             "lineEnd": 11,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "fullRange": {
             "lineBegin": 11,
             "columnBegin": 8,
             "lineEnd": 11,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "text": { "key": "path" }
         }
@@ -132,13 +132,13 @@
             "lineBegin": 12,
             "columnBegin": 8,
             "lineEnd": 12,
-            "columnEnd": 13
+            "columnEnd": 12
           },
           "fullRange": {
             "lineBegin": 12,
             "columnBegin": 8,
             "lineEnd": 12,
-            "columnEnd": 13
+            "columnEnd": 12
           },
           "text": { "key": "shell" }
         }
@@ -161,13 +161,13 @@
             "lineBegin": 14,
             "columnBegin": 7,
             "lineEnd": 14,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "fullRange": {
             "lineBegin": 14,
             "columnBegin": 1,
             "lineEnd": 42,
-            "columnEnd": 4
+            "columnEnd": 3
           },
           "text": { "key": "Git" }
         }
@@ -190,13 +190,13 @@
             "lineBegin": 15,
             "columnBegin": 23,
             "lineEnd": 15,
-            "columnEnd": 26
+            "columnEnd": 25
           },
           "fullRange": {
             "lineBegin": 15,
             "columnBegin": 15,
             "lineEnd": 15,
-            "columnEnd": 34
+            "columnEnd": 33
           },
           "text": { "key": "dir" }
         }
@@ -219,13 +219,13 @@
             "lineBegin": 16,
             "columnBegin": 11,
             "lineEnd": 16,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "fullRange": {
             "lineBegin": 16,
             "columnBegin": 11,
             "lineEnd": 16,
-            "columnEnd": 65
+            "columnEnd": 64
           },
           "text": { "key": "res" }
         }
@@ -248,13 +248,13 @@
             "lineBegin": 16,
             "columnBegin": 41,
             "lineEnd": 16,
-            "columnEnd": 44
+            "columnEnd": 43
           },
           "fullRange": {
             "lineBegin": 16,
             "columnBegin": 41,
             "lineEnd": 16,
-            "columnEnd": 49
+            "columnEnd": 48
           },
           "text": { "key": "cwd" }
         }
@@ -277,101 +277,101 @@
             "lineBegin": 16,
             "columnBegin": 51,
             "lineEnd": 16,
-            "columnEnd": 57
-          },
-          "fullRange": {
-            "lineBegin": 16,
-            "columnBegin": 51,
-            "lineEnd": 16,
-            "columnEnd": 63
-          },
-          "text": { "key": "silent" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "language": 49
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 24,
-            "columnBegin": 7,
-            "lineEnd": 24,
-            "columnEnd": 10
-          },
-          "fullRange": {
-            "lineBegin": 24,
-            "columnBegin": 7,
-            "lineEnd": 24,
-            "columnEnd": 15
-          },
-          "text": { "key": "cwd" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "language": 49
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 25,
-            "columnBegin": 7,
-            "lineEnd": 25,
-            "columnEnd": 13
-          },
-          "fullRange": {
-            "lineBegin": 25,
-            "columnBegin": 7,
-            "lineEnd": 25,
-            "columnEnd": 19
-          },
-          "text": { "key": "silent" }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": {
-        "key": {
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "language": 49
-        }
-      },
-      "range": {
-        "key": {
-          "range": {
-            "lineBegin": 27,
-            "columnBegin": 48,
-            "lineEnd": 27,
-            "columnEnd": 51
-          },
-          "fullRange": {
-            "lineBegin": 27,
-            "columnBegin": 48,
-            "lineEnd": 27,
             "columnEnd": 56
           },
+          "fullRange": {
+            "lineBegin": 16,
+            "columnBegin": 51,
+            "lineEnd": 16,
+            "columnEnd": 62
+          },
+          "text": { "key": "silent" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "language": 49
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 24,
+            "columnBegin": 7,
+            "lineEnd": 24,
+            "columnEnd": 9
+          },
+          "fullRange": {
+            "lineBegin": 24,
+            "columnBegin": 7,
+            "lineEnd": 24,
+            "columnEnd": 14
+          },
+          "text": { "key": "cwd" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "language": 49
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 25,
+            "columnBegin": 7,
+            "lineEnd": 25,
+            "columnEnd": 12
+          },
+          "fullRange": {
+            "lineBegin": 25,
+            "columnBegin": 7,
+            "lineEnd": 25,
+            "columnEnd": 18
+          },
+          "text": { "key": "silent" }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": {
+        "key": {
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "language": 49
+        }
+      },
+      "range": {
+        "key": {
+          "range": {
+            "lineBegin": 27,
+            "columnBegin": 48,
+            "lineEnd": 27,
+            "columnEnd": 50
+          },
+          "fullRange": {
+            "lineBegin": 27,
+            "columnBegin": 48,
+            "lineEnd": 27,
+            "columnEnd": 55
+          },
           "text": { "key": "cwd" }
         }
       }
@@ -393,13 +393,13 @@
             "lineBegin": 27,
             "columnBegin": 58,
             "lineEnd": 27,
-            "columnEnd": 64
+            "columnEnd": 63
           },
           "fullRange": {
             "lineBegin": 27,
             "columnBegin": 58,
             "lineEnd": 27,
-            "columnEnd": 70
+            "columnEnd": 69
           },
           "text": { "key": "silent" }
         }
@@ -422,13 +422,13 @@
             "lineBegin": 30,
             "columnBegin": 7,
             "lineEnd": 30,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "fullRange": {
             "lineBegin": 30,
             "columnBegin": 7,
             "lineEnd": 30,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "cwd" }
         }
@@ -451,13 +451,13 @@
             "lineBegin": 31,
             "columnBegin": 7,
             "lineEnd": 31,
-            "columnEnd": 13
+            "columnEnd": 12
           },
           "fullRange": {
             "lineBegin": 31,
             "columnBegin": 7,
             "lineEnd": 31,
-            "columnEnd": 19
+            "columnEnd": 18
           },
           "text": { "key": "silent" }
         }
@@ -480,13 +480,13 @@
             "lineBegin": 34,
             "columnBegin": 3,
             "lineEnd": 34,
-            "columnEnd": 9
+            "columnEnd": 8
           },
           "fullRange": {
             "lineBegin": 34,
             "columnBegin": 3,
             "lineEnd": 41,
-            "columnEnd": 6
+            "columnEnd": 5
           },
           "text": { "key": "commit" }
         }
@@ -509,13 +509,13 @@
             "lineBegin": 34,
             "columnBegin": 10,
             "lineEnd": 34,
-            "columnEnd": 13
+            "columnEnd": 12
           },
           "fullRange": {
             "lineBegin": 34,
             "columnBegin": 10,
             "lineEnd": 34,
-            "columnEnd": 21
+            "columnEnd": 20
           },
           "text": { "key": "msg" }
         }
@@ -538,13 +538,13 @@
             "lineBegin": 34,
             "columnBegin": 23,
             "lineEnd": 34,
-            "columnEnd": 27
+            "columnEnd": 26
           },
           "fullRange": {
             "lineBegin": 34,
             "columnBegin": 23,
             "lineEnd": 34,
-            "columnEnd": 35
+            "columnEnd": 34
           },
           "text": { "key": "date" }
         }
@@ -567,13 +567,13 @@
             "lineBegin": 34,
             "columnBegin": 37,
             "lineEnd": 34,
-            "columnEnd": 43
+            "columnEnd": 42
           },
           "fullRange": {
             "lineBegin": 34,
             "columnBegin": 37,
             "lineEnd": 34,
-            "columnEnd": 51
+            "columnEnd": 50
           },
           "text": { "key": "author" }
         }
@@ -596,13 +596,13 @@
             "lineBegin": 35,
             "columnBegin": 11,
             "lineEnd": 35,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "fullRange": {
             "lineBegin": 35,
             "columnBegin": 11,
             "lineEnd": 35,
-            "columnEnd": 74
+            "columnEnd": 73
           },
           "text": { "key": "addRes" }
         }
@@ -625,13 +625,13 @@
             "lineBegin": 35,
             "columnBegin": 45,
             "lineEnd": 35,
-            "columnEnd": 48
+            "columnEnd": 47
           },
           "fullRange": {
             "lineBegin": 35,
             "columnBegin": 45,
             "lineEnd": 35,
-            "columnEnd": 58
+            "columnEnd": 57
           },
           "text": { "key": "cwd" }
         }
@@ -654,13 +654,13 @@
             "lineBegin": 35,
             "columnBegin": 60,
             "lineEnd": 35,
-            "columnEnd": 66
+            "columnEnd": 65
           },
           "fullRange": {
             "lineBegin": 35,
             "columnBegin": 60,
             "lineEnd": 35,
-            "columnEnd": 72
+            "columnEnd": 71
           },
           "text": { "key": "silent" }
         }
@@ -683,13 +683,13 @@
             "lineBegin": 46,
             "columnBegin": 17,
             "lineEnd": 46,
-            "columnEnd": 31
+            "columnEnd": 30
           },
           "fullRange": {
             "lineBegin": 46,
             "columnBegin": 1,
             "lineEnd": 52,
-            "columnEnd": 2
+            "columnEnd": 1
           },
           "text": { "key": "createTempRepo" }
         }
@@ -712,13 +712,13 @@
             "lineBegin": 46,
             "columnBegin": 36,
             "lineEnd": 46,
-            "columnEnd": 43
+            "columnEnd": 42
           },
           "fullRange": {
             "lineBegin": 46,
             "columnBegin": 36,
             "lineEnd": 46,
-            "columnEnd": 52
+            "columnEnd": 51
           },
           "text": { "key": "repoDir" }
         }
@@ -741,13 +741,13 @@
             "lineBegin": 46,
             "columnBegin": 53,
             "lineEnd": 46,
-            "columnEnd": 56
+            "columnEnd": 55
           },
           "fullRange": {
             "lineBegin": 46,
             "columnBegin": 53,
             "lineEnd": 46,
-            "columnEnd": 61
+            "columnEnd": 60
           },
           "text": { "key": "git" }
         }
@@ -770,13 +770,13 @@
             "lineBegin": 47,
             "columnBegin": 9,
             "lineEnd": 47,
-            "columnEnd": 16
+            "columnEnd": 15
           },
           "fullRange": {
             "lineBegin": 47,
             "columnBegin": 9,
             "lineEnd": 47,
-            "columnEnd": 74
+            "columnEnd": 73
           },
           "text": { "key": "repoDir" }
         }
@@ -799,13 +799,13 @@
             "lineBegin": 49,
             "columnBegin": 9,
             "lineEnd": 49,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "fullRange": {
             "lineBegin": 49,
             "columnBegin": 9,
             "lineEnd": 49,
-            "columnEnd": 31
+            "columnEnd": 30
           },
           "text": { "key": "git" }
         }
@@ -828,13 +828,13 @@
             "lineBegin": 51,
             "columnBegin": 11,
             "lineEnd": 51,
-            "columnEnd": 18
+            "columnEnd": 17
           },
           "fullRange": {
             "lineBegin": 51,
             "columnBegin": 11,
             "lineEnd": 51,
-            "columnEnd": 18
+            "columnEnd": 17
           },
           "text": { "key": "repoDir" }
         }
@@ -857,13 +857,13 @@
             "lineBegin": 51,
             "columnBegin": 20,
             "lineEnd": 51,
-            "columnEnd": 23
+            "columnEnd": 22
           },
           "fullRange": {
             "lineBegin": 51,
             "columnBegin": 20,
             "lineEnd": 51,
-            "columnEnd": 23
+            "columnEnd": 22
           },
           "text": { "key": "git" }
         }
@@ -886,13 +886,13 @@
             "lineBegin": 972,
             "columnBegin": 11,
             "lineEnd": 972,
-            "columnEnd": 16
+            "columnEnd": 15
           },
           "fullRange": {
             "lineBegin": 972,
             "columnBegin": 1,
             "lineEnd": 976,
-            "columnEnd": 2
+            "columnEnd": 1
           },
           "text": { "key": "Error" }
         }
@@ -915,13 +915,13 @@
             "lineBegin": 984,
             "columnBegin": 13,
             "lineEnd": 984,
-            "columnEnd": 18
+            "columnEnd": 17
           },
           "fullRange": {
             "lineBegin": 984,
             "columnBegin": 13,
             "lineEnd": 984,
-            "columnEnd": 36
+            "columnEnd": 35
           },
           "text": { "key": "Error" }
         }

--- a/glean/lang/typescript/tests/cases/xrefs/entitylocation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/entitylocation.out
@@ -29,7 +29,7 @@
           "lineBegin": 972,
           "columnBegin": 11,
           "lineEnd": 972,
-          "columnEnd": 16
+          "columnEnd": 15
         }
       }
     }
@@ -46,7 +46,7 @@
           "lineBegin": 984,
           "columnBegin": 13,
           "lineEnd": 984,
-          "columnEnd": 18
+          "columnEnd": 17
         }
       }
     }
@@ -63,7 +63,7 @@
           "lineBegin": 14,
           "columnBegin": 7,
           "lineEnd": 14,
-          "columnEnd": 10
+          "columnEnd": 9
         }
       }
     }
@@ -80,7 +80,7 @@
           "lineBegin": 35,
           "columnBegin": 11,
           "lineEnd": 35,
-          "columnEnd": 17
+          "columnEnd": 16
         }
       }
     }
@@ -97,7 +97,7 @@
           "lineBegin": 34,
           "columnBegin": 37,
           "lineEnd": 34,
-          "columnEnd": 43
+          "columnEnd": 42
         }
       }
     }
@@ -114,7 +114,7 @@
           "lineBegin": 34,
           "columnBegin": 3,
           "lineEnd": 34,
-          "columnEnd": 9
+          "columnEnd": 8
         }
       }
     }
@@ -131,7 +131,7 @@
           "lineBegin": 46,
           "columnBegin": 17,
           "lineEnd": 46,
-          "columnEnd": 31
+          "columnEnd": 30
         }
       }
     }
@@ -148,7 +148,7 @@
           "lineBegin": 16,
           "columnBegin": 41,
           "lineEnd": 16,
-          "columnEnd": 44
+          "columnEnd": 43
         }
       }
     }
@@ -165,7 +165,7 @@
           "lineBegin": 24,
           "columnBegin": 7,
           "lineEnd": 24,
-          "columnEnd": 10
+          "columnEnd": 9
         }
       }
     }
@@ -182,7 +182,7 @@
           "lineBegin": 27,
           "columnBegin": 48,
           "lineEnd": 27,
-          "columnEnd": 51
+          "columnEnd": 50
         }
       }
     }
@@ -199,7 +199,7 @@
           "lineBegin": 30,
           "columnBegin": 7,
           "lineEnd": 30,
-          "columnEnd": 10
+          "columnEnd": 9
         }
       }
     }
@@ -216,7 +216,7 @@
           "lineBegin": 35,
           "columnBegin": 45,
           "lineEnd": 35,
-          "columnEnd": 48
+          "columnEnd": 47
         }
       }
     }
@@ -233,7 +233,7 @@
           "lineBegin": 34,
           "columnBegin": 23,
           "lineEnd": 34,
-          "columnEnd": 27
+          "columnEnd": 26
         }
       }
     }
@@ -250,7 +250,7 @@
           "lineBegin": 15,
           "columnBegin": 23,
           "lineEnd": 15,
-          "columnEnd": 26
+          "columnEnd": 25
         }
       }
     }
@@ -267,7 +267,7 @@
           "lineBegin": 9,
           "columnBegin": 8,
           "lineEnd": 9,
-          "columnEnd": 10
+          "columnEnd": 9
         }
       }
     }
@@ -284,7 +284,7 @@
           "lineBegin": 46,
           "columnBegin": 53,
           "lineEnd": 46,
-          "columnEnd": 56
+          "columnEnd": 55
         }
       }
     }
@@ -301,7 +301,7 @@
           "lineBegin": 49,
           "columnBegin": 9,
           "lineEnd": 49,
-          "columnEnd": 12
+          "columnEnd": 11
         }
       }
     }
@@ -318,7 +318,7 @@
           "lineBegin": 51,
           "columnBegin": 20,
           "lineEnd": 51,
-          "columnEnd": 23
+          "columnEnd": 22
         }
       }
     }
@@ -335,7 +335,7 @@
           "lineBegin": 34,
           "columnBegin": 10,
           "lineEnd": 34,
-          "columnEnd": 13
+          "columnEnd": 12
         }
       }
     }
@@ -352,7 +352,7 @@
           "lineBegin": 10,
           "columnBegin": 8,
           "lineEnd": 10,
-          "columnEnd": 10
+          "columnEnd": 9
         }
       }
     }
@@ -369,7 +369,7 @@
           "lineBegin": 11,
           "columnBegin": 8,
           "lineEnd": 11,
-          "columnEnd": 12
+          "columnEnd": 11
         }
       }
     }
@@ -386,7 +386,7 @@
           "lineBegin": 46,
           "columnBegin": 36,
           "lineEnd": 46,
-          "columnEnd": 43
+          "columnEnd": 42
         }
       }
     }
@@ -403,7 +403,7 @@
           "lineBegin": 47,
           "columnBegin": 9,
           "lineEnd": 47,
-          "columnEnd": 16
+          "columnEnd": 15
         }
       }
     }
@@ -420,7 +420,7 @@
           "lineBegin": 51,
           "columnBegin": 11,
           "lineEnd": 51,
-          "columnEnd": 18
+          "columnEnd": 17
         }
       }
     }
@@ -437,7 +437,7 @@
           "lineBegin": 16,
           "columnBegin": 11,
           "lineEnd": 16,
-          "columnEnd": 14
+          "columnEnd": 13
         }
       }
     }
@@ -454,7 +454,7 @@
           "lineBegin": 12,
           "columnBegin": 8,
           "lineEnd": 12,
-          "columnEnd": 13
+          "columnEnd": 12
         }
       }
     }
@@ -471,7 +471,7 @@
           "lineBegin": 16,
           "columnBegin": 51,
           "lineEnd": 16,
-          "columnEnd": 57
+          "columnEnd": 56
         }
       }
     }
@@ -488,7 +488,7 @@
           "lineBegin": 25,
           "columnBegin": 7,
           "lineEnd": 25,
-          "columnEnd": 13
+          "columnEnd": 12
         }
       }
     }
@@ -505,7 +505,7 @@
           "lineBegin": 27,
           "columnBegin": 58,
           "lineEnd": 27,
-          "columnEnd": 64
+          "columnEnd": 63
         }
       }
     }
@@ -522,7 +522,7 @@
           "lineBegin": 31,
           "columnBegin": 7,
           "lineEnd": 31,
-          "columnEnd": 13
+          "columnEnd": 12
         }
       }
     }
@@ -539,7 +539,7 @@
           "lineBegin": 35,
           "columnBegin": 60,
           "lineEnd": 35,
-          "columnEnd": 66
+          "columnEnd": 65
         }
       }
     }

--- a/glean/lang/typescript/tests/cases/xrefs/entityreferences.out
+++ b/glean/lang/typescript/tests/cases/xrefs/entityreferences.out
@@ -23,13 +23,13 @@
                           "lineBegin": 972,
                           "columnBegin": 11,
                           "lineEnd": 972,
-                          "columnEnd": 16
+                          "columnEnd": 15
                         },
                         "fullRange": {
                           "lineBegin": 972,
                           "columnBegin": 1,
                           "lineEnd": 976,
-                          "columnEnd": 2
+                          "columnEnd": 1
                         },
                         "text": { "key": "Error" }
                       }
@@ -57,7 +57,7 @@
           "lineBegin": 18,
           "columnBegin": 17,
           "lineEnd": 18,
-          "columnEnd": 22
+          "columnEnd": 21
         }
       }
     }
@@ -85,13 +85,13 @@
                           "lineBegin": 972,
                           "columnBegin": 11,
                           "lineEnd": 972,
-                          "columnEnd": 16
+                          "columnEnd": 15
                         },
                         "fullRange": {
                           "lineBegin": 972,
                           "columnBegin": 1,
                           "lineEnd": 976,
-                          "columnEnd": 2
+                          "columnEnd": 1
                         },
                         "text": { "key": "Error" }
                       }
@@ -119,7 +119,7 @@
           "lineBegin": 37,
           "columnBegin": 17,
           "lineEnd": 37,
-          "columnEnd": 22
+          "columnEnd": 21
         }
       }
     }
@@ -147,13 +147,13 @@
                           "lineBegin": 984,
                           "columnBegin": 13,
                           "lineEnd": 984,
-                          "columnEnd": 18
+                          "columnEnd": 17
                         },
                         "fullRange": {
                           "lineBegin": 984,
                           "columnBegin": 13,
                           "lineEnd": 984,
-                          "columnEnd": 36
+                          "columnEnd": 35
                         },
                         "text": { "key": "Error" }
                       }
@@ -181,7 +181,7 @@
           "lineBegin": 18,
           "columnBegin": 17,
           "lineEnd": 18,
-          "columnEnd": 22
+          "columnEnd": 21
         }
       }
     }
@@ -209,13 +209,13 @@
                           "lineBegin": 984,
                           "columnBegin": 13,
                           "lineEnd": 984,
-                          "columnEnd": 18
+                          "columnEnd": 17
                         },
                         "fullRange": {
                           "lineBegin": 984,
                           "columnBegin": 13,
                           "lineEnd": 984,
-                          "columnEnd": 36
+                          "columnEnd": 35
                         },
                         "text": { "key": "Error" }
                       }
@@ -243,7 +243,7 @@
           "lineBegin": 37,
           "columnBegin": 17,
           "lineEnd": 37,
-          "columnEnd": 22
+          "columnEnd": 21
         }
       }
     }

--- a/glean/lang/typescript/tests/cases/xrefs/fileentitylocations.out
+++ b/glean/lang/typescript/tests/cases/xrefs/fileentitylocations.out
@@ -80,7 +80,7 @@
             "lineBegin": 46,
             "columnBegin": 17,
             "lineEnd": 46,
-            "columnEnd": 31
+            "columnEnd": 30
           }
         }
       },
@@ -105,13 +105,13 @@
                           "lineBegin": 46,
                           "columnBegin": 17,
                           "lineEnd": 46,
-                          "columnEnd": 31
+                          "columnEnd": 30
                         },
                         "fullRange": {
                           "lineBegin": 46,
                           "columnBegin": 1,
                           "lineEnd": 52,
-                          "columnEnd": 2
+                          "columnEnd": 1
                         },
                         "text": { "key": "createTempRepo" }
                       }
@@ -148,7 +148,7 @@
             "lineBegin": 972,
             "columnBegin": 11,
             "lineEnd": 972,
-            "columnEnd": 16
+            "columnEnd": 15
           }
         }
       },
@@ -173,13 +173,13 @@
                           "lineBegin": 972,
                           "columnBegin": 11,
                           "lineEnd": 972,
-                          "columnEnd": 16
+                          "columnEnd": 15
                         },
                         "fullRange": {
                           "lineBegin": 972,
                           "columnBegin": 1,
                           "lineEnd": 976,
-                          "columnEnd": 2
+                          "columnEnd": 1
                         },
                         "text": { "key": "Error" }
                       }
@@ -216,7 +216,7 @@
             "lineBegin": 984,
             "columnBegin": 13,
             "lineEnd": 984,
-            "columnEnd": 18
+            "columnEnd": 17
           }
         }
       },
@@ -241,13 +241,13 @@
                           "lineBegin": 984,
                           "columnBegin": 13,
                           "lineEnd": 984,
-                          "columnEnd": 18
+                          "columnEnd": 17
                         },
                         "fullRange": {
                           "lineBegin": 984,
                           "columnBegin": 13,
                           "lineEnd": 984,
-                          "columnEnd": 36
+                          "columnEnd": 35
                         },
                         "text": { "key": "Error" }
                       }

--- a/glean/lang/typescript/tests/cases/xrefs/fileentityxreflocations.out
+++ b/glean/lang/typescript/tests/cases/xrefs/fileentityxreflocations.out
@@ -19,7 +19,7 @@
               "lineBegin": 972,
               "columnBegin": 11,
               "lineEnd": 972,
-              "columnEnd": 16
+              "columnEnd": 15
             }
           }
         },
@@ -31,7 +31,7 @@
             "lineBegin": 18,
             "columnBegin": 17,
             "lineEnd": 18,
-            "columnEnd": 22
+            "columnEnd": 21
           }
         }
       },
@@ -51,13 +51,13 @@
                 "lineBegin": 972,
                 "columnBegin": 11,
                 "lineEnd": 972,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 972,
                 "columnBegin": 1,
                 "lineEnd": 976,
-                "columnEnd": 2
+                "columnEnd": 1
               },
               "text": { "key": "Error" }
             }
@@ -85,7 +85,7 @@
               "lineBegin": 972,
               "columnBegin": 11,
               "lineEnd": 972,
-              "columnEnd": 16
+              "columnEnd": 15
             }
           }
         },
@@ -97,7 +97,7 @@
             "lineBegin": 37,
             "columnBegin": 17,
             "lineEnd": 37,
-            "columnEnd": 22
+            "columnEnd": 21
           }
         }
       },
@@ -117,13 +117,13 @@
                 "lineBegin": 972,
                 "columnBegin": 11,
                 "lineEnd": 972,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 972,
                 "columnBegin": 1,
                 "lineEnd": 976,
-                "columnEnd": 2
+                "columnEnd": 1
               },
               "text": { "key": "Error" }
             }
@@ -151,7 +151,7 @@
               "lineBegin": 984,
               "columnBegin": 13,
               "lineEnd": 984,
-              "columnEnd": 18
+              "columnEnd": 17
             }
           }
         },
@@ -163,7 +163,7 @@
             "lineBegin": 18,
             "columnBegin": 17,
             "lineEnd": 18,
-            "columnEnd": 22
+            "columnEnd": 21
           }
         }
       },
@@ -183,13 +183,13 @@
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "fullRange": {
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 36
+                "columnEnd": 35
               },
               "text": { "key": "Error" }
             }
@@ -217,7 +217,7 @@
               "lineBegin": 984,
               "columnBegin": 13,
               "lineEnd": 984,
-              "columnEnd": 18
+              "columnEnd": 17
             }
           }
         },
@@ -229,7 +229,7 @@
             "lineBegin": 37,
             "columnBegin": 17,
             "lineEnd": 37,
-            "columnEnd": 22
+            "columnEnd": 21
           }
         }
       },
@@ -249,13 +249,13 @@
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "fullRange": {
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 36
+                "columnEnd": 35
               },
               "text": { "key": "Error" }
             }
@@ -283,7 +283,7 @@
               "lineBegin": 14,
               "columnBegin": 7,
               "lineEnd": 14,
-              "columnEnd": 10
+              "columnEnd": 9
             }
           }
         },
@@ -295,7 +295,7 @@
             "lineBegin": 46,
             "columnBegin": 58,
             "lineEnd": 46,
-            "columnEnd": 61
+            "columnEnd": 60
           }
         }
       },
@@ -315,13 +315,13 @@
                 "lineBegin": 14,
                 "columnBegin": 7,
                 "lineEnd": 14,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 14,
                 "columnBegin": 1,
                 "lineEnd": 42,
-                "columnEnd": 4
+                "columnEnd": 3
               },
               "text": { "key": "Git" }
             }
@@ -349,7 +349,7 @@
               "lineBegin": 14,
               "columnBegin": 7,
               "lineEnd": 14,
-              "columnEnd": 10
+              "columnEnd": 9
             }
           }
         },
@@ -361,7 +361,7 @@
             "lineBegin": 49,
             "columnBegin": 19,
             "lineEnd": 49,
-            "columnEnd": 22
+            "columnEnd": 21
           }
         }
       },
@@ -381,13 +381,13 @@
                 "lineBegin": 14,
                 "columnBegin": 7,
                 "lineEnd": 14,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 14,
                 "columnBegin": 1,
                 "lineEnd": 42,
-                "columnEnd": 4
+                "columnEnd": 3
               },
               "text": { "key": "Git" }
             }
@@ -415,7 +415,7 @@
               "lineBegin": 35,
               "columnBegin": 11,
               "lineEnd": 35,
-              "columnEnd": 17
+              "columnEnd": 16
             }
           }
         },
@@ -427,7 +427,7 @@
             "lineBegin": 36,
             "columnBegin": 9,
             "lineEnd": 36,
-            "columnEnd": 15
+            "columnEnd": 14
           }
         }
       },
@@ -447,13 +447,13 @@
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "addRes" }
             }
@@ -481,7 +481,7 @@
               "lineBegin": 35,
               "columnBegin": 11,
               "lineEnd": 35,
-              "columnEnd": 17
+              "columnEnd": 16
             }
           }
         },
@@ -493,336 +493,6 @@
             "lineBegin": 37,
             "columnBegin": 51,
             "lineEnd": 37,
-            "columnEnd": 57
-          }
-        }
-      },
-      "tuplefield2": {
-        "key": {
-          "file": {
-            "key": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "language": 49
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 11,
-                "lineEnd": 35,
-                "columnEnd": 17
-              },
-              "fullRange": {
-                "lineBegin": 35,
-                "columnBegin": 11,
-                "lineEnd": 35,
-                "columnEnd": 74
-              },
-              "text": { "key": "addRes" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "tuplefield0": {
-        "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-      },
-      "tuplefield1": {
-        "target": {
-          "name": "addRes",
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "location": {
-            "range": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "lineBegin": 35,
-              "columnBegin": 11,
-              "lineEnd": 35,
-              "columnEnd": 17
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": {
-              "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-            },
-            "lineBegin": 38,
-            "columnBegin": 11,
-            "lineEnd": 38,
-            "columnEnd": 17
-          }
-        }
-      },
-      "tuplefield2": {
-        "key": {
-          "file": {
-            "key": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "language": 49
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 11,
-                "lineEnd": 35,
-                "columnEnd": 17
-              },
-              "fullRange": {
-                "lineBegin": 35,
-                "columnBegin": 11,
-                "lineEnd": 35,
-                "columnEnd": 74
-              },
-              "text": { "key": "addRes" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "tuplefield0": {
-        "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-      },
-      "tuplefield1": {
-        "target": {
-          "name": "addRes",
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "location": {
-            "range": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "lineBegin": 35,
-              "columnBegin": 11,
-              "lineEnd": 35,
-              "columnEnd": 17
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": {
-              "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-            },
-            "lineBegin": 39,
-            "columnBegin": 11,
-            "lineEnd": 39,
-            "columnEnd": 17
-          }
-        }
-      },
-      "tuplefield2": {
-        "key": {
-          "file": {
-            "key": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "language": 49
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 35,
-                "columnBegin": 11,
-                "lineEnd": 35,
-                "columnEnd": 17
-              },
-              "fullRange": {
-                "lineBegin": 35,
-                "columnBegin": 11,
-                "lineEnd": 35,
-                "columnEnd": 74
-              },
-              "text": { "key": "addRes" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "tuplefield0": {
-        "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-      },
-      "tuplefield1": {
-        "target": {
-          "name": "dir",
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "location": {
-            "range": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "lineBegin": 15,
-              "columnBegin": 23,
-              "lineEnd": 15,
-              "columnEnd": 26
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": {
-              "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-            },
-            "lineBegin": 16,
-            "columnBegin": 46,
-            "lineEnd": 16,
-            "columnEnd": 49
-          }
-        }
-      },
-      "tuplefield2": {
-        "key": {
-          "file": {
-            "key": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "language": 49
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 23,
-                "lineEnd": 15,
-                "columnEnd": 26
-              },
-              "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 15,
-                "lineEnd": 15,
-                "columnEnd": 34
-              },
-              "text": { "key": "dir" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "tuplefield0": {
-        "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-      },
-      "tuplefield1": {
-        "target": {
-          "name": "dir",
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "location": {
-            "range": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "lineBegin": 15,
-              "columnBegin": 23,
-              "lineEnd": 15,
-              "columnEnd": 26
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": {
-              "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-            },
-            "lineBegin": 24,
-            "columnBegin": 12,
-            "lineEnd": 24,
-            "columnEnd": 15
-          }
-        }
-      },
-      "tuplefield2": {
-        "key": {
-          "file": {
-            "key": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "language": 49
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 15,
-                "columnBegin": 23,
-                "lineEnd": 15,
-                "columnEnd": 26
-              },
-              "fullRange": {
-                "lineBegin": 15,
-                "columnBegin": 15,
-                "lineEnd": 15,
-                "columnEnd": 34
-              },
-              "text": { "key": "dir" }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "tuplefield0": {
-        "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-      },
-      "tuplefield1": {
-        "target": {
-          "name": "dir",
-          "file": {
-            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-          },
-          "location": {
-            "range": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "lineBegin": 15,
-              "columnBegin": 23,
-              "lineEnd": 15,
-              "columnEnd": 26
-            }
-          }
-        },
-        "source": {
-          "range": {
-            "file": {
-              "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-            },
-            "lineBegin": 27,
-            "columnBegin": 53,
-            "lineEnd": 27,
             "columnEnd": 56
           }
         }
@@ -840,16 +510,214 @@
           "range": {
             "key": {
               "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              },
+              "fullRange": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 73
+              },
+              "text": { "key": "addRes" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "tuplefield0": {
+        "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+      },
+      "tuplefield1": {
+        "target": {
+          "name": "addRes",
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "location": {
+            "range": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "lineBegin": 35,
+              "columnBegin": 11,
+              "lineEnd": 35,
+              "columnEnd": 16
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": {
+              "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+            },
+            "lineBegin": 38,
+            "columnBegin": 11,
+            "lineEnd": 38,
+            "columnEnd": 16
+          }
+        }
+      },
+      "tuplefield2": {
+        "key": {
+          "file": {
+            "key": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "language": 49
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              },
+              "fullRange": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 73
+              },
+              "text": { "key": "addRes" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "tuplefield0": {
+        "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+      },
+      "tuplefield1": {
+        "target": {
+          "name": "addRes",
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "location": {
+            "range": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "lineBegin": 35,
+              "columnBegin": 11,
+              "lineEnd": 35,
+              "columnEnd": 16
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": {
+              "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+            },
+            "lineBegin": 39,
+            "columnBegin": 11,
+            "lineEnd": 39,
+            "columnEnd": 16
+          }
+        }
+      },
+      "tuplefield2": {
+        "key": {
+          "file": {
+            "key": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "language": 49
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              },
+              "fullRange": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 73
+              },
+              "text": { "key": "addRes" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "tuplefield0": {
+        "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+      },
+      "tuplefield1": {
+        "target": {
+          "name": "dir",
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "location": {
+            "range": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "lineBegin": 15,
+              "columnBegin": 23,
+              "lineEnd": 15,
+              "columnEnd": 25
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": {
+              "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+            },
+            "lineBegin": 16,
+            "columnBegin": 46,
+            "lineEnd": 16,
+            "columnEnd": 48
+          }
+        }
+      },
+      "tuplefield2": {
+        "key": {
+          "file": {
+            "key": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "language": 49
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -877,7 +745,139 @@
               "lineBegin": 15,
               "columnBegin": 23,
               "lineEnd": 15,
-              "columnEnd": 26
+              "columnEnd": 25
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": {
+              "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+            },
+            "lineBegin": 24,
+            "columnBegin": 12,
+            "lineEnd": 24,
+            "columnEnd": 14
+          }
+        }
+      },
+      "tuplefield2": {
+        "key": {
+          "file": {
+            "key": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "language": 49
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 25
+              },
+              "fullRange": {
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 33
+              },
+              "text": { "key": "dir" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "tuplefield0": {
+        "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+      },
+      "tuplefield1": {
+        "target": {
+          "name": "dir",
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "location": {
+            "range": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "lineBegin": 15,
+              "columnBegin": 23,
+              "lineEnd": 15,
+              "columnEnd": 25
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": {
+              "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+            },
+            "lineBegin": 27,
+            "columnBegin": 53,
+            "lineEnd": 27,
+            "columnEnd": 55
+          }
+        }
+      },
+      "tuplefield2": {
+        "key": {
+          "file": {
+            "key": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "language": 49
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 15,
+                "columnBegin": 23,
+                "lineEnd": 15,
+                "columnEnd": 25
+              },
+              "fullRange": {
+                "lineBegin": 15,
+                "columnBegin": 15,
+                "lineEnd": 15,
+                "columnEnd": 33
+              },
+              "text": { "key": "dir" }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "tuplefield0": {
+        "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+      },
+      "tuplefield1": {
+        "target": {
+          "name": "dir",
+          "file": {
+            "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+          },
+          "location": {
+            "range": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "lineBegin": 15,
+              "columnBegin": 23,
+              "lineEnd": 15,
+              "columnEnd": 25
             }
           }
         },
@@ -889,7 +889,7 @@
             "lineBegin": 30,
             "columnBegin": 12,
             "lineEnd": 30,
-            "columnEnd": 15
+            "columnEnd": 14
           }
         }
       },
@@ -909,13 +909,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -943,7 +943,7 @@
               "lineBegin": 15,
               "columnBegin": 23,
               "lineEnd": 15,
-              "columnEnd": 26
+              "columnEnd": 25
             }
           }
         },
@@ -955,7 +955,7 @@
             "lineBegin": 35,
             "columnBegin": 55,
             "lineEnd": 35,
-            "columnEnd": 58
+            "columnEnd": 57
           }
         }
       },
@@ -975,13 +975,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -1009,7 +1009,7 @@
               "lineBegin": 9,
               "columnBegin": 8,
               "lineEnd": 9,
-              "columnEnd": 10
+              "columnEnd": 9
             }
           }
         },
@@ -1021,7 +1021,7 @@
             "lineBegin": 47,
             "columnBegin": 19,
             "lineEnd": 47,
-            "columnEnd": 21
+            "columnEnd": 20
           }
         }
       },
@@ -1041,13 +1041,13 @@
                 "lineBegin": 9,
                 "columnBegin": 8,
                 "lineEnd": 9,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 9,
                 "columnBegin": 8,
                 "lineEnd": 9,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "fs" }
             }
@@ -1075,7 +1075,7 @@
               "lineBegin": 10,
               "columnBegin": 8,
               "lineEnd": 10,
-              "columnEnd": 10
+              "columnEnd": 9
             }
           }
         },
@@ -1087,7 +1087,7 @@
             "lineBegin": 47,
             "columnBegin": 44,
             "lineEnd": 47,
-            "columnEnd": 46
+            "columnEnd": 45
           }
         }
       },
@@ -1107,13 +1107,13 @@
                 "lineBegin": 10,
                 "columnBegin": 8,
                 "lineEnd": 10,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 10,
                 "columnBegin": 8,
                 "lineEnd": 10,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "os" }
             }
@@ -1141,7 +1141,7 @@
               "lineBegin": 11,
               "columnBegin": 8,
               "lineEnd": 11,
-              "columnEnd": 12
+              "columnEnd": 11
             }
           }
         },
@@ -1153,7 +1153,7 @@
             "lineBegin": 47,
             "columnBegin": 34,
             "lineEnd": 47,
-            "columnEnd": 38
+            "columnEnd": 37
           }
         }
       },
@@ -1173,13 +1173,13 @@
                 "lineBegin": 11,
                 "columnBegin": 8,
                 "lineEnd": 11,
-                "columnEnd": 12
+                "columnEnd": 11
               },
               "fullRange": {
                 "lineBegin": 11,
                 "columnBegin": 8,
                 "lineEnd": 11,
-                "columnEnd": 12
+                "columnEnd": 11
               },
               "text": { "key": "path" }
             }
@@ -1207,7 +1207,7 @@
               "lineBegin": 47,
               "columnBegin": 9,
               "lineEnd": 47,
-              "columnEnd": 16
+              "columnEnd": 15
             }
           }
         },
@@ -1219,7 +1219,7 @@
             "lineBegin": 49,
             "columnBegin": 23,
             "lineEnd": 49,
-            "columnEnd": 30
+            "columnEnd": 29
           }
         }
       },
@@ -1239,13 +1239,13 @@
                 "lineBegin": 47,
                 "columnBegin": 9,
                 "lineEnd": 47,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 47,
                 "columnBegin": 9,
                 "lineEnd": 47,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "repoDir" }
             }
@@ -1273,7 +1273,7 @@
               "lineBegin": 16,
               "columnBegin": 11,
               "lineEnd": 16,
-              "columnEnd": 14
+              "columnEnd": 13
             }
           }
         },
@@ -1285,7 +1285,7 @@
             "lineBegin": 17,
             "columnBegin": 9,
             "lineEnd": 17,
-            "columnEnd": 12
+            "columnEnd": 11
           }
         }
       },
@@ -1305,13 +1305,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -1339,7 +1339,7 @@
               "lineBegin": 16,
               "columnBegin": 11,
               "lineEnd": 16,
-              "columnEnd": 14
+              "columnEnd": 13
             }
           }
         },
@@ -1351,7 +1351,7 @@
             "lineBegin": 18,
             "columnBegin": 52,
             "lineEnd": 18,
-            "columnEnd": 55
+            "columnEnd": 54
           }
         }
       },
@@ -1371,13 +1371,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -1405,7 +1405,7 @@
               "lineBegin": 16,
               "columnBegin": 11,
               "lineEnd": 16,
-              "columnEnd": 14
+              "columnEnd": 13
             }
           }
         },
@@ -1417,7 +1417,7 @@
             "lineBegin": 19,
             "columnBegin": 11,
             "lineEnd": 19,
-            "columnEnd": 14
+            "columnEnd": 13
           }
         }
       },
@@ -1437,13 +1437,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -1471,7 +1471,7 @@
               "lineBegin": 16,
               "columnBegin": 11,
               "lineEnd": 16,
-              "columnEnd": 14
+              "columnEnd": 13
             }
           }
         },
@@ -1483,7 +1483,7 @@
             "lineBegin": 20,
             "columnBegin": 11,
             "lineEnd": 20,
-            "columnEnd": 14
+            "columnEnd": 13
           }
         }
       },
@@ -1503,13 +1503,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -1537,7 +1537,7 @@
               "lineBegin": 12,
               "columnBegin": 8,
               "lineEnd": 12,
-              "columnEnd": 13
+              "columnEnd": 12
             }
           }
         },
@@ -1549,7 +1549,7 @@
             "lineBegin": 16,
             "columnBegin": 17,
             "lineEnd": 16,
-            "columnEnd": 22
+            "columnEnd": 21
           }
         }
       },
@@ -1569,13 +1569,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -1603,7 +1603,7 @@
               "lineBegin": 12,
               "columnBegin": 8,
               "lineEnd": 12,
-              "columnEnd": 13
+              "columnEnd": 12
             }
           }
         },
@@ -1615,7 +1615,7 @@
             "lineBegin": 23,
             "columnBegin": 5,
             "lineEnd": 23,
-            "columnEnd": 10
+            "columnEnd": 9
           }
         }
       },
@@ -1635,13 +1635,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -1669,7 +1669,7 @@
               "lineBegin": 12,
               "columnBegin": 8,
               "lineEnd": 12,
-              "columnEnd": 13
+              "columnEnd": 12
             }
           }
         },
@@ -1681,7 +1681,7 @@
             "lineBegin": 27,
             "columnBegin": 5,
             "lineEnd": 27,
-            "columnEnd": 10
+            "columnEnd": 9
           }
         }
       },
@@ -1701,13 +1701,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -1735,7 +1735,7 @@
               "lineBegin": 12,
               "columnBegin": 8,
               "lineEnd": 12,
-              "columnEnd": 13
+              "columnEnd": 12
             }
           }
         },
@@ -1747,7 +1747,7 @@
             "lineBegin": 29,
             "columnBegin": 5,
             "lineEnd": 29,
-            "columnEnd": 10
+            "columnEnd": 9
           }
         }
       },
@@ -1767,13 +1767,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -1801,7 +1801,7 @@
               "lineBegin": 12,
               "columnBegin": 8,
               "lineEnd": 12,
-              "columnEnd": 13
+              "columnEnd": 12
             }
           }
         },
@@ -1813,7 +1813,7 @@
             "lineBegin": 35,
             "columnBegin": 20,
             "lineEnd": 35,
-            "columnEnd": 25
+            "columnEnd": 24
           }
         }
       },
@@ -1833,13 +1833,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }

--- a/glean/lang/typescript/tests/cases/xrefs/hovertext.out
+++ b/glean/lang/typescript/tests/cases/xrefs/hovertext.out
@@ -18,13 +18,13 @@
                 "lineBegin": 9,
                 "columnBegin": 8,
                 "lineEnd": 9,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 9,
                 "columnBegin": 8,
                 "lineEnd": 9,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "fs" }
             }
@@ -52,13 +52,13 @@
                 "lineBegin": 10,
                 "columnBegin": 8,
                 "lineEnd": 10,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 10,
                 "columnBegin": 8,
                 "lineEnd": 10,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "os" }
             }
@@ -86,13 +86,13 @@
                 "lineBegin": 11,
                 "columnBegin": 8,
                 "lineEnd": 11,
-                "columnEnd": 12
+                "columnEnd": 11
               },
               "fullRange": {
                 "lineBegin": 11,
                 "columnBegin": 8,
                 "lineEnd": 11,
-                "columnEnd": 12
+                "columnEnd": 11
               },
               "text": { "key": "path" }
             }
@@ -120,13 +120,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -154,13 +154,13 @@
                 "lineBegin": 14,
                 "columnBegin": 7,
                 "lineEnd": 14,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 14,
                 "columnBegin": 1,
                 "lineEnd": 42,
-                "columnEnd": 4
+                "columnEnd": 3
               },
               "text": { "key": "Git" }
             }
@@ -188,13 +188,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -227,13 +227,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -263,13 +263,13 @@
                 "lineBegin": 16,
                 "columnBegin": 41,
                 "lineEnd": 16,
-                "columnEnd": 44
+                "columnEnd": 43
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 41,
                 "lineEnd": 16,
-                "columnEnd": 49
+                "columnEnd": 48
               },
               "text": { "key": "cwd" }
             }
@@ -299,128 +299,128 @@
                 "lineBegin": 16,
                 "columnBegin": 51,
                 "lineEnd": 16,
-                "columnEnd": 57
-              },
-              "fullRange": {
-                "lineBegin": 16,
-                "columnBegin": 51,
-                "lineEnd": 16,
-                "columnEnd": 63
-              },
-              "text": { "key": "silent" }
-            }
-          }
-        }
-      },
-      "hover": {
-        "key": {
-          "text": { "key": "(property) silent: boolean" },
-          "language": 49
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "defn": {
-        "key": {
-          "file": {
-            "key": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "language": 49
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 24,
-                "columnBegin": 7,
-                "lineEnd": 24,
-                "columnEnd": 10
-              },
-              "fullRange": {
-                "lineBegin": 24,
-                "columnBegin": 7,
-                "lineEnd": 24,
-                "columnEnd": 15
-              },
-              "text": { "key": "cwd" }
-            }
-          }
-        }
-      },
-      "hover": {
-        "key": { "text": { "key": "(property) cwd: string" }, "language": 49 }
-      }
-    }
-  },
-  {
-    "key": {
-      "defn": {
-        "key": {
-          "file": {
-            "key": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "language": 49
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 25,
-                "columnBegin": 7,
-                "lineEnd": 25,
-                "columnEnd": 13
-              },
-              "fullRange": {
-                "lineBegin": 25,
-                "columnBegin": 7,
-                "lineEnd": 25,
-                "columnEnd": 19
-              },
-              "text": { "key": "silent" }
-            }
-          }
-        }
-      },
-      "hover": {
-        "key": {
-          "text": { "key": "(property) silent: boolean" },
-          "language": 49
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "defn": {
-        "key": {
-          "file": {
-            "key": {
-              "file": {
-                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
-              },
-              "language": 49
-            }
-          },
-          "range": {
-            "key": {
-              "range": {
-                "lineBegin": 27,
-                "columnBegin": 48,
-                "lineEnd": 27,
-                "columnEnd": 51
-              },
-              "fullRange": {
-                "lineBegin": 27,
-                "columnBegin": 48,
-                "lineEnd": 27,
                 "columnEnd": 56
               },
+              "fullRange": {
+                "lineBegin": 16,
+                "columnBegin": 51,
+                "lineEnd": 16,
+                "columnEnd": 62
+              },
+              "text": { "key": "silent" }
+            }
+          }
+        }
+      },
+      "hover": {
+        "key": {
+          "text": { "key": "(property) silent: boolean" },
+          "language": 49
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
+          "file": {
+            "key": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "language": 49
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 24,
+                "columnBegin": 7,
+                "lineEnd": 24,
+                "columnEnd": 9
+              },
+              "fullRange": {
+                "lineBegin": 24,
+                "columnBegin": 7,
+                "lineEnd": 24,
+                "columnEnd": 14
+              },
+              "text": { "key": "cwd" }
+            }
+          }
+        }
+      },
+      "hover": {
+        "key": { "text": { "key": "(property) cwd: string" }, "language": 49 }
+      }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
+          "file": {
+            "key": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "language": 49
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 25,
+                "columnBegin": 7,
+                "lineEnd": 25,
+                "columnEnd": 12
+              },
+              "fullRange": {
+                "lineBegin": 25,
+                "columnBegin": 7,
+                "lineEnd": 25,
+                "columnEnd": 18
+              },
+              "text": { "key": "silent" }
+            }
+          }
+        }
+      },
+      "hover": {
+        "key": {
+          "text": { "key": "(property) silent: boolean" },
+          "language": 49
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
+          "file": {
+            "key": {
+              "file": {
+                "key": "glean/lang/typescript/tests/cases/xrefs/example.ts"
+              },
+              "language": 49
+            }
+          },
+          "range": {
+            "key": {
+              "range": {
+                "lineBegin": 27,
+                "columnBegin": 48,
+                "lineEnd": 27,
+                "columnEnd": 50
+              },
+              "fullRange": {
+                "lineBegin": 27,
+                "columnBegin": 48,
+                "lineEnd": 27,
+                "columnEnd": 55
+              },
               "text": { "key": "cwd" }
             }
           }
@@ -449,13 +449,13 @@
                 "lineBegin": 27,
                 "columnBegin": 58,
                 "lineEnd": 27,
-                "columnEnd": 64
+                "columnEnd": 63
               },
               "fullRange": {
                 "lineBegin": 27,
                 "columnBegin": 58,
                 "lineEnd": 27,
-                "columnEnd": 70
+                "columnEnd": 69
               },
               "text": { "key": "silent" }
             }
@@ -488,13 +488,13 @@
                 "lineBegin": 30,
                 "columnBegin": 7,
                 "lineEnd": 30,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 30,
                 "columnBegin": 7,
                 "lineEnd": 30,
-                "columnEnd": 15
+                "columnEnd": 14
               },
               "text": { "key": "cwd" }
             }
@@ -524,13 +524,13 @@
                 "lineBegin": 31,
                 "columnBegin": 7,
                 "lineEnd": 31,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 31,
                 "columnBegin": 7,
                 "lineEnd": 31,
-                "columnEnd": 19
+                "columnEnd": 18
               },
               "text": { "key": "silent" }
             }
@@ -563,13 +563,13 @@
                 "lineBegin": 34,
                 "columnBegin": 3,
                 "lineEnd": 34,
-                "columnEnd": 9
+                "columnEnd": 8
               },
               "fullRange": {
                 "lineBegin": 34,
                 "columnBegin": 3,
                 "lineEnd": 41,
-                "columnEnd": 6
+                "columnEnd": 5
               },
               "text": { "key": "commit" }
             }
@@ -604,13 +604,13 @@
                 "lineBegin": 34,
                 "columnBegin": 10,
                 "lineEnd": 34,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 34,
                 "columnBegin": 10,
                 "lineEnd": 34,
-                "columnEnd": 21
+                "columnEnd": 20
               },
               "text": { "key": "msg" }
             }
@@ -640,13 +640,13 @@
                 "lineBegin": 34,
                 "columnBegin": 23,
                 "lineEnd": 34,
-                "columnEnd": 27
+                "columnEnd": 26
               },
               "fullRange": {
                 "lineBegin": 34,
                 "columnBegin": 23,
                 "lineEnd": 34,
-                "columnEnd": 35
+                "columnEnd": 34
               },
               "text": { "key": "date" }
             }
@@ -676,13 +676,13 @@
                 "lineBegin": 34,
                 "columnBegin": 37,
                 "lineEnd": 34,
-                "columnEnd": 43
+                "columnEnd": 42
               },
               "fullRange": {
                 "lineBegin": 34,
                 "columnBegin": 37,
                 "lineEnd": 34,
-                "columnEnd": 51
+                "columnEnd": 50
               },
               "text": { "key": "author" }
             }
@@ -715,13 +715,13 @@
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "addRes" }
             }
@@ -751,13 +751,13 @@
                 "lineBegin": 35,
                 "columnBegin": 45,
                 "lineEnd": 35,
-                "columnEnd": 48
+                "columnEnd": 47
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 45,
                 "lineEnd": 35,
-                "columnEnd": 58
+                "columnEnd": 57
               },
               "text": { "key": "cwd" }
             }
@@ -787,13 +787,13 @@
                 "lineBegin": 35,
                 "columnBegin": 60,
                 "lineEnd": 35,
-                "columnEnd": 66
+                "columnEnd": 65
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 60,
                 "lineEnd": 35,
-                "columnEnd": 72
+                "columnEnd": 71
               },
               "text": { "key": "silent" }
             }
@@ -826,13 +826,13 @@
                 "lineBegin": 46,
                 "columnBegin": 17,
                 "lineEnd": 46,
-                "columnEnd": 31
+                "columnEnd": 30
               },
               "fullRange": {
                 "lineBegin": 46,
                 "columnBegin": 1,
                 "lineEnd": 52,
-                "columnEnd": 2
+                "columnEnd": 1
               },
               "text": { "key": "createTempRepo" }
             }
@@ -867,13 +867,13 @@
                 "lineBegin": 46,
                 "columnBegin": 36,
                 "lineEnd": 46,
-                "columnEnd": 43
+                "columnEnd": 42
               },
               "fullRange": {
                 "lineBegin": 46,
                 "columnBegin": 36,
                 "lineEnd": 46,
-                "columnEnd": 52
+                "columnEnd": 51
               },
               "text": { "key": "repoDir" }
             }
@@ -906,13 +906,13 @@
                 "lineBegin": 46,
                 "columnBegin": 53,
                 "lineEnd": 46,
-                "columnEnd": 56
+                "columnEnd": 55
               },
               "fullRange": {
                 "lineBegin": 46,
                 "columnBegin": 53,
                 "lineEnd": 46,
-                "columnEnd": 61
+                "columnEnd": 60
               },
               "text": { "key": "git" }
             }
@@ -942,13 +942,13 @@
                 "lineBegin": 47,
                 "columnBegin": 9,
                 "lineEnd": 47,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 47,
                 "columnBegin": 9,
                 "lineEnd": 47,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "repoDir" }
             }
@@ -978,13 +978,13 @@
                 "lineBegin": 49,
                 "columnBegin": 9,
                 "lineEnd": 49,
-                "columnEnd": 12
+                "columnEnd": 11
               },
               "fullRange": {
                 "lineBegin": 49,
                 "columnBegin": 9,
                 "lineEnd": 49,
-                "columnEnd": 31
+                "columnEnd": 30
               },
               "text": { "key": "git" }
             }
@@ -1014,13 +1014,13 @@
                 "lineBegin": 51,
                 "columnBegin": 11,
                 "lineEnd": 51,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "fullRange": {
                 "lineBegin": 51,
                 "columnBegin": 11,
                 "lineEnd": 51,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "text": { "key": "repoDir" }
             }
@@ -1053,13 +1053,13 @@
                 "lineBegin": 51,
                 "columnBegin": 20,
                 "lineEnd": 51,
-                "columnEnd": 23
+                "columnEnd": 22
               },
               "fullRange": {
                 "lineBegin": 51,
                 "columnBegin": 20,
                 "lineEnd": 51,
-                "columnEnd": 23
+                "columnEnd": 22
               },
               "text": { "key": "git" }
             }
@@ -1089,13 +1089,13 @@
                 "lineBegin": 972,
                 "columnBegin": 11,
                 "lineEnd": 972,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 972,
                 "columnBegin": 1,
                 "lineEnd": 976,
-                "columnEnd": 2
+                "columnEnd": 1
               },
               "text": { "key": "Error" }
             }
@@ -1125,13 +1125,13 @@
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "fullRange": {
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 36
+                "columnEnd": 35
               },
               "text": { "key": "Error" }
             }

--- a/glean/lang/typescript/tests/cases/xrefs/range.out
+++ b/glean/lang/typescript/tests/cases/xrefs/range.out
@@ -23,13 +23,13 @@
         "lineBegin": 9,
         "columnBegin": 8,
         "lineEnd": 9,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "fullRange": {
         "lineBegin": 9,
         "columnBegin": 8,
         "lineEnd": 9,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "text": { "key": "fs" }
     }
@@ -40,13 +40,13 @@
         "lineBegin": 10,
         "columnBegin": 8,
         "lineEnd": 10,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "fullRange": {
         "lineBegin": 10,
         "columnBegin": 8,
         "lineEnd": 10,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "text": { "key": "os" }
     }
@@ -57,13 +57,13 @@
         "lineBegin": 11,
         "columnBegin": 8,
         "lineEnd": 11,
-        "columnEnd": 12
+        "columnEnd": 11
       },
       "fullRange": {
         "lineBegin": 11,
         "columnBegin": 8,
         "lineEnd": 11,
-        "columnEnd": 12
+        "columnEnd": 11
       },
       "text": { "key": "path" }
     }
@@ -74,13 +74,13 @@
         "lineBegin": 12,
         "columnBegin": 8,
         "lineEnd": 12,
-        "columnEnd": 13
+        "columnEnd": 12
       },
       "fullRange": {
         "lineBegin": 12,
         "columnBegin": 8,
         "lineEnd": 12,
-        "columnEnd": 13
+        "columnEnd": 12
       },
       "text": { "key": "shell" }
     }
@@ -91,13 +91,13 @@
         "lineBegin": 14,
         "columnBegin": 7,
         "lineEnd": 14,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "fullRange": {
         "lineBegin": 14,
         "columnBegin": 1,
         "lineEnd": 42,
-        "columnEnd": 4
+        "columnEnd": 3
       },
       "text": { "key": "Git" }
     }
@@ -108,7 +108,7 @@
         "lineBegin": 15,
         "columnBegin": 3,
         "lineEnd": 33,
-        "columnEnd": 4
+        "columnEnd": 3
       },
       "text": {
         "key": "constructor(private dir: string) {\u000a    const res = shell.exec('git init', {cwd: dir, silent: true});\u000a    if (res.code !== 0) {\u000a      throw new Error(`git init exited with code ${res.code}.\u000astderr: ${res.stderr}\u000astdout: ${res.stdout}`);\u000a    }\u000a    // Doesn't matter currently\u000a    shell.exec('git config user.email \"test@jc-verse.com\"', {\u000a      cwd: dir,\u000a      silent: true,\u000a    });\u000a    shell.exec('git config user.name \"Test\"', {cwd: dir, silent: true});\u000a\u000a    shell.exec('git commit --allow-empty -m \"First commit\"', {\u000a      cwd: dir,\u000a      silent: true,\u000a    });\u000a  }"
@@ -121,13 +121,13 @@
         "lineBegin": 15,
         "columnBegin": 23,
         "lineEnd": 15,
-        "columnEnd": 26
+        "columnEnd": 25
       },
       "fullRange": {
         "lineBegin": 15,
         "columnBegin": 15,
         "lineEnd": 15,
-        "columnEnd": 34
+        "columnEnd": 33
       },
       "text": { "key": "dir" }
     }
@@ -138,13 +138,13 @@
         "lineBegin": 16,
         "columnBegin": 11,
         "lineEnd": 16,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "fullRange": {
         "lineBegin": 16,
         "columnBegin": 11,
         "lineEnd": 16,
-        "columnEnd": 65
+        "columnEnd": 64
       },
       "text": { "key": "res" }
     }
@@ -155,7 +155,7 @@
         "lineBegin": 16,
         "columnBegin": 17,
         "lineEnd": 16,
-        "columnEnd": 22
+        "columnEnd": 21
       },
       "text": { "key": "shell" }
     }
@@ -166,7 +166,7 @@
         "lineBegin": 16,
         "columnBegin": 40,
         "lineEnd": 16,
-        "columnEnd": 64
+        "columnEnd": 63
       },
       "text": { "key": "{cwd: dir, silent: true}" }
     }
@@ -177,13 +177,13 @@
         "lineBegin": 16,
         "columnBegin": 41,
         "lineEnd": 16,
-        "columnEnd": 44
+        "columnEnd": 43
       },
       "fullRange": {
         "lineBegin": 16,
         "columnBegin": 41,
         "lineEnd": 16,
-        "columnEnd": 49
+        "columnEnd": 48
       },
       "text": { "key": "cwd" }
     }
@@ -194,7 +194,7 @@
         "lineBegin": 16,
         "columnBegin": 46,
         "lineEnd": 16,
-        "columnEnd": 49
+        "columnEnd": 48
       },
       "text": { "key": "dir" }
     }
@@ -205,13 +205,13 @@
         "lineBegin": 16,
         "columnBegin": 51,
         "lineEnd": 16,
-        "columnEnd": 57
+        "columnEnd": 56
       },
       "fullRange": {
         "lineBegin": 16,
         "columnBegin": 51,
         "lineEnd": 16,
-        "columnEnd": 63
+        "columnEnd": 62
       },
       "text": { "key": "silent" }
     }
@@ -222,7 +222,7 @@
         "lineBegin": 17,
         "columnBegin": 9,
         "lineEnd": 17,
-        "columnEnd": 12
+        "columnEnd": 11
       },
       "text": { "key": "res" }
     }
@@ -233,7 +233,7 @@
         "lineBegin": 18,
         "columnBegin": 17,
         "lineEnd": 18,
-        "columnEnd": 22
+        "columnEnd": 21
       },
       "text": { "key": "Error" }
     }
@@ -244,7 +244,7 @@
         "lineBegin": 18,
         "columnBegin": 52,
         "lineEnd": 18,
-        "columnEnd": 55
+        "columnEnd": 54
       },
       "text": { "key": "res" }
     }
@@ -255,7 +255,7 @@
         "lineBegin": 19,
         "columnBegin": 11,
         "lineEnd": 19,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "res" }
     }
@@ -266,7 +266,7 @@
         "lineBegin": 20,
         "columnBegin": 11,
         "lineEnd": 20,
-        "columnEnd": 14
+        "columnEnd": 13
       },
       "text": { "key": "res" }
     }
@@ -277,7 +277,7 @@
         "lineBegin": 23,
         "columnBegin": 5,
         "lineEnd": 23,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "text": { "key": "shell" }
     }
@@ -288,7 +288,7 @@
         "lineBegin": 23,
         "columnBegin": 61,
         "lineEnd": 26,
-        "columnEnd": 6
+        "columnEnd": 61
       },
       "text": {
         "key": "{\u000a      cwd: dir,\u000a      silent: true,\u000a    }"
@@ -301,13 +301,13 @@
         "lineBegin": 24,
         "columnBegin": 7,
         "lineEnd": 24,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "fullRange": {
         "lineBegin": 24,
         "columnBegin": 7,
         "lineEnd": 24,
-        "columnEnd": 15
+        "columnEnd": 14
       },
       "text": { "key": "cwd" }
     }
@@ -318,7 +318,7 @@
         "lineBegin": 24,
         "columnBegin": 12,
         "lineEnd": 24,
-        "columnEnd": 15
+        "columnEnd": 14
       },
       "text": { "key": "dir" }
     }
@@ -329,13 +329,13 @@
         "lineBegin": 25,
         "columnBegin": 7,
         "lineEnd": 25,
-        "columnEnd": 13
+        "columnEnd": 12
       },
       "fullRange": {
         "lineBegin": 25,
         "columnBegin": 7,
         "lineEnd": 25,
-        "columnEnd": 19
+        "columnEnd": 18
       },
       "text": { "key": "silent" }
     }
@@ -346,7 +346,7 @@
         "lineBegin": 27,
         "columnBegin": 5,
         "lineEnd": 27,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "text": { "key": "shell" }
     }
@@ -357,7 +357,7 @@
         "lineBegin": 27,
         "columnBegin": 47,
         "lineEnd": 27,
-        "columnEnd": 71
+        "columnEnd": 70
       },
       "text": { "key": "{cwd: dir, silent: true}" }
     }
@@ -368,13 +368,13 @@
         "lineBegin": 27,
         "columnBegin": 48,
         "lineEnd": 27,
-        "columnEnd": 51
+        "columnEnd": 50
       },
       "fullRange": {
         "lineBegin": 27,
         "columnBegin": 48,
         "lineEnd": 27,
-        "columnEnd": 56
+        "columnEnd": 55
       },
       "text": { "key": "cwd" }
     }
@@ -385,7 +385,7 @@
         "lineBegin": 27,
         "columnBegin": 53,
         "lineEnd": 27,
-        "columnEnd": 56
+        "columnEnd": 55
       },
       "text": { "key": "dir" }
     }
@@ -396,13 +396,13 @@
         "lineBegin": 27,
         "columnBegin": 58,
         "lineEnd": 27,
-        "columnEnd": 64
+        "columnEnd": 63
       },
       "fullRange": {
         "lineBegin": 27,
         "columnBegin": 58,
         "lineEnd": 27,
-        "columnEnd": 70
+        "columnEnd": 69
       },
       "text": { "key": "silent" }
     }
@@ -413,7 +413,7 @@
         "lineBegin": 29,
         "columnBegin": 5,
         "lineEnd": 29,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "text": { "key": "shell" }
     }
@@ -424,7 +424,7 @@
         "lineBegin": 29,
         "columnBegin": 62,
         "lineEnd": 32,
-        "columnEnd": 6
+        "columnEnd": 62
       },
       "text": {
         "key": "{\u000a      cwd: dir,\u000a      silent: true,\u000a    }"
@@ -437,13 +437,13 @@
         "lineBegin": 30,
         "columnBegin": 7,
         "lineEnd": 30,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "fullRange": {
         "lineBegin": 30,
         "columnBegin": 7,
         "lineEnd": 30,
-        "columnEnd": 15
+        "columnEnd": 14
       },
       "text": { "key": "cwd" }
     }
@@ -454,7 +454,7 @@
         "lineBegin": 30,
         "columnBegin": 12,
         "lineEnd": 30,
-        "columnEnd": 15
+        "columnEnd": 14
       },
       "text": { "key": "dir" }
     }
@@ -465,13 +465,13 @@
         "lineBegin": 31,
         "columnBegin": 7,
         "lineEnd": 31,
-        "columnEnd": 13
+        "columnEnd": 12
       },
       "fullRange": {
         "lineBegin": 31,
         "columnBegin": 7,
         "lineEnd": 31,
-        "columnEnd": 19
+        "columnEnd": 18
       },
       "text": { "key": "silent" }
     }
@@ -482,13 +482,13 @@
         "lineBegin": 34,
         "columnBegin": 3,
         "lineEnd": 34,
-        "columnEnd": 9
+        "columnEnd": 8
       },
       "fullRange": {
         "lineBegin": 34,
         "columnBegin": 3,
         "lineEnd": 41,
-        "columnEnd": 6
+        "columnEnd": 5
       },
       "text": { "key": "commit" }
     }
@@ -499,13 +499,13 @@
         "lineBegin": 34,
         "columnBegin": 10,
         "lineEnd": 34,
-        "columnEnd": 13
+        "columnEnd": 12
       },
       "fullRange": {
         "lineBegin": 34,
         "columnBegin": 10,
         "lineEnd": 34,
-        "columnEnd": 21
+        "columnEnd": 20
       },
       "text": { "key": "msg" }
     }
@@ -516,13 +516,13 @@
         "lineBegin": 34,
         "columnBegin": 23,
         "lineEnd": 34,
-        "columnEnd": 27
+        "columnEnd": 26
       },
       "fullRange": {
         "lineBegin": 34,
         "columnBegin": 23,
         "lineEnd": 34,
-        "columnEnd": 35
+        "columnEnd": 34
       },
       "text": { "key": "date" }
     }
@@ -533,13 +533,13 @@
         "lineBegin": 34,
         "columnBegin": 37,
         "lineEnd": 34,
-        "columnEnd": 43
+        "columnEnd": 42
       },
       "fullRange": {
         "lineBegin": 34,
         "columnBegin": 37,
         "lineEnd": 34,
-        "columnEnd": 51
+        "columnEnd": 50
       },
       "text": { "key": "author" }
     }
@@ -550,13 +550,13 @@
         "lineBegin": 35,
         "columnBegin": 11,
         "lineEnd": 35,
-        "columnEnd": 17
+        "columnEnd": 16
       },
       "fullRange": {
         "lineBegin": 35,
         "columnBegin": 11,
         "lineEnd": 35,
-        "columnEnd": 74
+        "columnEnd": 73
       },
       "text": { "key": "addRes" }
     }
@@ -567,7 +567,7 @@
         "lineBegin": 35,
         "columnBegin": 20,
         "lineEnd": 35,
-        "columnEnd": 25
+        "columnEnd": 24
       },
       "text": { "key": "shell" }
     }
@@ -578,7 +578,7 @@
         "lineBegin": 35,
         "columnBegin": 44,
         "lineEnd": 35,
-        "columnEnd": 73
+        "columnEnd": 72
       },
       "text": { "key": "{cwd: this.dir, silent: true}" }
     }
@@ -589,13 +589,13 @@
         "lineBegin": 35,
         "columnBegin": 45,
         "lineEnd": 35,
-        "columnEnd": 48
+        "columnEnd": 47
       },
       "fullRange": {
         "lineBegin": 35,
         "columnBegin": 45,
         "lineEnd": 35,
-        "columnEnd": 58
+        "columnEnd": 57
       },
       "text": { "key": "cwd" }
     }
@@ -606,7 +606,7 @@
         "lineBegin": 35,
         "columnBegin": 55,
         "lineEnd": 35,
-        "columnEnd": 58
+        "columnEnd": 57
       },
       "text": { "key": "dir" }
     }
@@ -617,13 +617,13 @@
         "lineBegin": 35,
         "columnBegin": 60,
         "lineEnd": 35,
-        "columnEnd": 66
+        "columnEnd": 65
       },
       "fullRange": {
         "lineBegin": 35,
         "columnBegin": 60,
         "lineEnd": 35,
-        "columnEnd": 72
+        "columnEnd": 71
       },
       "text": { "key": "silent" }
     }
@@ -634,7 +634,7 @@
         "lineBegin": 36,
         "columnBegin": 9,
         "lineEnd": 36,
-        "columnEnd": 15
+        "columnEnd": 14
       },
       "text": { "key": "addRes" }
     }
@@ -645,7 +645,7 @@
         "lineBegin": 37,
         "columnBegin": 17,
         "lineEnd": 37,
-        "columnEnd": 22
+        "columnEnd": 21
       },
       "text": { "key": "Error" }
     }
@@ -656,7 +656,7 @@
         "lineBegin": 37,
         "columnBegin": 51,
         "lineEnd": 37,
-        "columnEnd": 57
+        "columnEnd": 56
       },
       "text": { "key": "addRes" }
     }
@@ -667,7 +667,7 @@
         "lineBegin": 38,
         "columnBegin": 11,
         "lineEnd": 38,
-        "columnEnd": 17
+        "columnEnd": 16
       },
       "text": { "key": "addRes" }
     }
@@ -678,7 +678,7 @@
         "lineBegin": 39,
         "columnBegin": 11,
         "lineEnd": 39,
-        "columnEnd": 17
+        "columnEnd": 16
       },
       "text": { "key": "addRes" }
     }
@@ -689,13 +689,13 @@
         "lineBegin": 46,
         "columnBegin": 17,
         "lineEnd": 46,
-        "columnEnd": 31
+        "columnEnd": 30
       },
       "fullRange": {
         "lineBegin": 46,
         "columnBegin": 1,
         "lineEnd": 52,
-        "columnEnd": 2
+        "columnEnd": 1
       },
       "text": { "key": "createTempRepo" }
     }
@@ -706,7 +706,7 @@
         "lineBegin": 46,
         "columnBegin": 35,
         "lineEnd": 46,
-        "columnEnd": 62
+        "columnEnd": 61
       },
       "text": { "key": "{repoDir: string; git: Git}" }
     }
@@ -717,13 +717,13 @@
         "lineBegin": 46,
         "columnBegin": 36,
         "lineEnd": 46,
-        "columnEnd": 43
+        "columnEnd": 42
       },
       "fullRange": {
         "lineBegin": 46,
         "columnBegin": 36,
         "lineEnd": 46,
-        "columnEnd": 52
+        "columnEnd": 51
       },
       "text": { "key": "repoDir" }
     }
@@ -734,13 +734,13 @@
         "lineBegin": 46,
         "columnBegin": 53,
         "lineEnd": 46,
-        "columnEnd": 56
+        "columnEnd": 55
       },
       "fullRange": {
         "lineBegin": 46,
         "columnBegin": 53,
         "lineEnd": 46,
-        "columnEnd": 61
+        "columnEnd": 60
       },
       "text": { "key": "git" }
     }
@@ -751,7 +751,7 @@
         "lineBegin": 46,
         "columnBegin": 58,
         "lineEnd": 46,
-        "columnEnd": 61
+        "columnEnd": 60
       },
       "text": { "key": "Git" }
     }
@@ -762,13 +762,13 @@
         "lineBegin": 47,
         "columnBegin": 9,
         "lineEnd": 47,
-        "columnEnd": 16
+        "columnEnd": 15
       },
       "fullRange": {
         "lineBegin": 47,
         "columnBegin": 9,
         "lineEnd": 47,
-        "columnEnd": 74
+        "columnEnd": 73
       },
       "text": { "key": "repoDir" }
     }
@@ -779,7 +779,7 @@
         "lineBegin": 47,
         "columnBegin": 19,
         "lineEnd": 47,
-        "columnEnd": 21
+        "columnEnd": 20
       },
       "text": { "key": "fs" }
     }
@@ -790,7 +790,7 @@
         "lineBegin": 47,
         "columnBegin": 34,
         "lineEnd": 47,
-        "columnEnd": 38
+        "columnEnd": 37
       },
       "text": { "key": "path" }
     }
@@ -801,7 +801,7 @@
         "lineBegin": 47,
         "columnBegin": 44,
         "lineEnd": 47,
-        "columnEnd": 46
+        "columnEnd": 45
       },
       "text": { "key": "os" }
     }
@@ -812,13 +812,13 @@
         "lineBegin": 49,
         "columnBegin": 9,
         "lineEnd": 49,
-        "columnEnd": 12
+        "columnEnd": 11
       },
       "fullRange": {
         "lineBegin": 49,
         "columnBegin": 9,
         "lineEnd": 49,
-        "columnEnd": 31
+        "columnEnd": 30
       },
       "text": { "key": "git" }
     }
@@ -829,7 +829,7 @@
         "lineBegin": 49,
         "columnBegin": 19,
         "lineEnd": 49,
-        "columnEnd": 22
+        "columnEnd": 21
       },
       "text": { "key": "Git" }
     }
@@ -840,7 +840,7 @@
         "lineBegin": 49,
         "columnBegin": 23,
         "lineEnd": 49,
-        "columnEnd": 30
+        "columnEnd": 29
       },
       "text": { "key": "repoDir" }
     }
@@ -851,7 +851,7 @@
         "lineBegin": 51,
         "columnBegin": 10,
         "lineEnd": 51,
-        "columnEnd": 24
+        "columnEnd": 23
       },
       "text": { "key": "{repoDir, git}" }
     }
@@ -862,13 +862,13 @@
         "lineBegin": 51,
         "columnBegin": 11,
         "lineEnd": 51,
-        "columnEnd": 18
+        "columnEnd": 17
       },
       "fullRange": {
         "lineBegin": 51,
         "columnBegin": 11,
         "lineEnd": 51,
-        "columnEnd": 18
+        "columnEnd": 17
       },
       "text": { "key": "repoDir" }
     }
@@ -879,13 +879,13 @@
         "lineBegin": 51,
         "columnBegin": 20,
         "lineEnd": 51,
-        "columnEnd": 23
+        "columnEnd": 22
       },
       "fullRange": {
         "lineBegin": 51,
         "columnBegin": 20,
         "lineEnd": 51,
-        "columnEnd": 23
+        "columnEnd": 22
       },
       "text": { "key": "git" }
     }
@@ -896,13 +896,13 @@
         "lineBegin": 972,
         "columnBegin": 11,
         "lineEnd": 972,
-        "columnEnd": 16
+        "columnEnd": 15
       },
       "fullRange": {
         "lineBegin": 972,
         "columnBegin": 1,
         "lineEnd": 976,
-        "columnEnd": 2
+        "columnEnd": 1
       },
       "text": { "key": "Error" }
     }
@@ -913,13 +913,13 @@
         "lineBegin": 984,
         "columnBegin": 13,
         "lineEnd": 984,
-        "columnEnd": 18
+        "columnEnd": 17
       },
       "fullRange": {
         "lineBegin": 984,
         "columnBegin": 13,
         "lineEnd": 984,
-        "columnEnd": 36
+        "columnEnd": 35
       },
       "text": { "key": "Error" }
     }

--- a/glean/lang/typescript/tests/cases/xrefs/references.out
+++ b/glean/lang/typescript/tests/cases/xrefs/references.out
@@ -16,7 +16,7 @@
             "lineBegin": 16,
             "columnBegin": 17,
             "lineEnd": 16,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "shell" }
         }
@@ -37,13 +37,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -68,7 +68,7 @@
             "lineBegin": 16,
             "columnBegin": 46,
             "lineEnd": 16,
-            "columnEnd": 49
+            "columnEnd": 48
           },
           "text": { "key": "dir" }
         }
@@ -89,13 +89,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -120,7 +120,7 @@
             "lineBegin": 17,
             "columnBegin": 9,
             "lineEnd": 17,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "text": { "key": "res" }
         }
@@ -141,13 +141,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -172,7 +172,7 @@
             "lineBegin": 18,
             "columnBegin": 17,
             "lineEnd": 18,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "Error" }
         }
@@ -193,13 +193,13 @@
                 "lineBegin": 972,
                 "columnBegin": 11,
                 "lineEnd": 972,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 972,
                 "columnBegin": 1,
                 "lineEnd": 976,
-                "columnEnd": 2
+                "columnEnd": 1
               },
               "text": { "key": "Error" }
             }
@@ -224,7 +224,7 @@
             "lineBegin": 18,
             "columnBegin": 17,
             "lineEnd": 18,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "Error" }
         }
@@ -245,13 +245,13 @@
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "fullRange": {
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 36
+                "columnEnd": 35
               },
               "text": { "key": "Error" }
             }
@@ -276,7 +276,7 @@
             "lineBegin": 18,
             "columnBegin": 52,
             "lineEnd": 18,
-            "columnEnd": 55
+            "columnEnd": 54
           },
           "text": { "key": "res" }
         }
@@ -297,13 +297,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -328,7 +328,7 @@
             "lineBegin": 19,
             "columnBegin": 11,
             "lineEnd": 19,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "res" }
         }
@@ -349,13 +349,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -380,7 +380,7 @@
             "lineBegin": 20,
             "columnBegin": 11,
             "lineEnd": 20,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "res" }
         }
@@ -401,13 +401,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -432,7 +432,7 @@
             "lineBegin": 23,
             "columnBegin": 5,
             "lineEnd": 23,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "text": { "key": "shell" }
         }
@@ -453,13 +453,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -484,7 +484,7 @@
             "lineBegin": 24,
             "columnBegin": 12,
             "lineEnd": 24,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "dir" }
         }
@@ -505,13 +505,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -536,7 +536,7 @@
             "lineBegin": 27,
             "columnBegin": 5,
             "lineEnd": 27,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "text": { "key": "shell" }
         }
@@ -557,13 +557,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -588,7 +588,7 @@
             "lineBegin": 27,
             "columnBegin": 53,
             "lineEnd": 27,
-            "columnEnd": 56
+            "columnEnd": 55
           },
           "text": { "key": "dir" }
         }
@@ -609,13 +609,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -640,7 +640,7 @@
             "lineBegin": 29,
             "columnBegin": 5,
             "lineEnd": 29,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "text": { "key": "shell" }
         }
@@ -661,13 +661,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -692,7 +692,7 @@
             "lineBegin": 30,
             "columnBegin": 12,
             "lineEnd": 30,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "dir" }
         }
@@ -713,13 +713,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -744,7 +744,7 @@
             "lineBegin": 35,
             "columnBegin": 20,
             "lineEnd": 35,
-            "columnEnd": 25
+            "columnEnd": 24
           },
           "text": { "key": "shell" }
         }
@@ -765,13 +765,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -796,7 +796,7 @@
             "lineBegin": 35,
             "columnBegin": 55,
             "lineEnd": 35,
-            "columnEnd": 58
+            "columnEnd": 57
           },
           "text": { "key": "dir" }
         }
@@ -817,13 +817,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -848,7 +848,7 @@
             "lineBegin": 36,
             "columnBegin": 9,
             "lineEnd": 36,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "addRes" }
         }
@@ -869,13 +869,13 @@
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "addRes" }
             }
@@ -900,7 +900,7 @@
             "lineBegin": 37,
             "columnBegin": 17,
             "lineEnd": 37,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "Error" }
         }
@@ -921,13 +921,13 @@
                 "lineBegin": 972,
                 "columnBegin": 11,
                 "lineEnd": 972,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 972,
                 "columnBegin": 1,
                 "lineEnd": 976,
-                "columnEnd": 2
+                "columnEnd": 1
               },
               "text": { "key": "Error" }
             }
@@ -952,7 +952,7 @@
             "lineBegin": 37,
             "columnBegin": 17,
             "lineEnd": 37,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "Error" }
         }
@@ -973,13 +973,13 @@
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "fullRange": {
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 36
+                "columnEnd": 35
               },
               "text": { "key": "Error" }
             }
@@ -1004,7 +1004,7 @@
             "lineBegin": 37,
             "columnBegin": 51,
             "lineEnd": 37,
-            "columnEnd": 57
+            "columnEnd": 56
           },
           "text": { "key": "addRes" }
         }
@@ -1025,13 +1025,13 @@
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "addRes" }
             }
@@ -1056,7 +1056,7 @@
             "lineBegin": 38,
             "columnBegin": 11,
             "lineEnd": 38,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "addRes" }
         }
@@ -1077,13 +1077,13 @@
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "addRes" }
             }
@@ -1108,7 +1108,7 @@
             "lineBegin": 39,
             "columnBegin": 11,
             "lineEnd": 39,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "addRes" }
         }
@@ -1129,13 +1129,13 @@
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "addRes" }
             }
@@ -1160,7 +1160,7 @@
             "lineBegin": 46,
             "columnBegin": 58,
             "lineEnd": 46,
-            "columnEnd": 61
+            "columnEnd": 60
           },
           "text": { "key": "Git" }
         }
@@ -1181,13 +1181,13 @@
                 "lineBegin": 14,
                 "columnBegin": 7,
                 "lineEnd": 14,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 14,
                 "columnBegin": 1,
                 "lineEnd": 42,
-                "columnEnd": 4
+                "columnEnd": 3
               },
               "text": { "key": "Git" }
             }
@@ -1212,7 +1212,7 @@
             "lineBegin": 47,
             "columnBegin": 19,
             "lineEnd": 47,
-            "columnEnd": 21
+            "columnEnd": 20
           },
           "text": { "key": "fs" }
         }
@@ -1233,13 +1233,13 @@
                 "lineBegin": 9,
                 "columnBegin": 8,
                 "lineEnd": 9,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 9,
                 "columnBegin": 8,
                 "lineEnd": 9,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "fs" }
             }
@@ -1264,7 +1264,7 @@
             "lineBegin": 47,
             "columnBegin": 34,
             "lineEnd": 47,
-            "columnEnd": 38
+            "columnEnd": 37
           },
           "text": { "key": "path" }
         }
@@ -1285,13 +1285,13 @@
                 "lineBegin": 11,
                 "columnBegin": 8,
                 "lineEnd": 11,
-                "columnEnd": 12
+                "columnEnd": 11
               },
               "fullRange": {
                 "lineBegin": 11,
                 "columnBegin": 8,
                 "lineEnd": 11,
-                "columnEnd": 12
+                "columnEnd": 11
               },
               "text": { "key": "path" }
             }
@@ -1316,7 +1316,7 @@
             "lineBegin": 47,
             "columnBegin": 44,
             "lineEnd": 47,
-            "columnEnd": 46
+            "columnEnd": 45
           },
           "text": { "key": "os" }
         }
@@ -1337,13 +1337,13 @@
                 "lineBegin": 10,
                 "columnBegin": 8,
                 "lineEnd": 10,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 10,
                 "columnBegin": 8,
                 "lineEnd": 10,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "os" }
             }
@@ -1368,7 +1368,7 @@
             "lineBegin": 49,
             "columnBegin": 19,
             "lineEnd": 49,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "Git" }
         }
@@ -1389,13 +1389,13 @@
                 "lineBegin": 14,
                 "columnBegin": 7,
                 "lineEnd": 14,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 14,
                 "columnBegin": 1,
                 "lineEnd": 42,
-                "columnEnd": 4
+                "columnEnd": 3
               },
               "text": { "key": "Git" }
             }
@@ -1420,7 +1420,7 @@
             "lineBegin": 49,
             "columnBegin": 23,
             "lineEnd": 49,
-            "columnEnd": 30
+            "columnEnd": 29
           },
           "text": { "key": "repoDir" }
         }
@@ -1441,13 +1441,13 @@
                 "lineBegin": 47,
                 "columnBegin": 9,
                 "lineEnd": 47,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 47,
                 "columnBegin": 9,
                 "lineEnd": 47,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "repoDir" }
             }

--- a/glean/lang/typescript/tests/cases/xrefs/uses.out
+++ b/glean/lang/typescript/tests/cases/xrefs/uses.out
@@ -18,13 +18,13 @@
                 "lineBegin": 9,
                 "columnBegin": 8,
                 "lineEnd": 9,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 9,
                 "columnBegin": 8,
                 "lineEnd": 9,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "fs" }
             }
@@ -45,7 +45,7 @@
             "lineBegin": 47,
             "columnBegin": 19,
             "lineEnd": 47,
-            "columnEnd": 21
+            "columnEnd": 20
           },
           "text": { "key": "fs" }
         }
@@ -70,13 +70,13 @@
                 "lineBegin": 10,
                 "columnBegin": 8,
                 "lineEnd": 10,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 10,
                 "columnBegin": 8,
                 "lineEnd": 10,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "text": { "key": "os" }
             }
@@ -97,7 +97,7 @@
             "lineBegin": 47,
             "columnBegin": 44,
             "lineEnd": 47,
-            "columnEnd": 46
+            "columnEnd": 45
           },
           "text": { "key": "os" }
         }
@@ -122,13 +122,13 @@
                 "lineBegin": 11,
                 "columnBegin": 8,
                 "lineEnd": 11,
-                "columnEnd": 12
+                "columnEnd": 11
               },
               "fullRange": {
                 "lineBegin": 11,
                 "columnBegin": 8,
                 "lineEnd": 11,
-                "columnEnd": 12
+                "columnEnd": 11
               },
               "text": { "key": "path" }
             }
@@ -149,7 +149,7 @@
             "lineBegin": 47,
             "columnBegin": 34,
             "lineEnd": 47,
-            "columnEnd": 38
+            "columnEnd": 37
           },
           "text": { "key": "path" }
         }
@@ -174,13 +174,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -201,7 +201,7 @@
             "lineBegin": 16,
             "columnBegin": 17,
             "lineEnd": 16,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "shell" }
         }
@@ -226,13 +226,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -253,7 +253,7 @@
             "lineBegin": 23,
             "columnBegin": 5,
             "lineEnd": 23,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "text": { "key": "shell" }
         }
@@ -278,13 +278,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -305,7 +305,7 @@
             "lineBegin": 27,
             "columnBegin": 5,
             "lineEnd": 27,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "text": { "key": "shell" }
         }
@@ -330,13 +330,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -357,7 +357,7 @@
             "lineBegin": 29,
             "columnBegin": 5,
             "lineEnd": 29,
-            "columnEnd": 10
+            "columnEnd": 9
           },
           "text": { "key": "shell" }
         }
@@ -382,13 +382,13 @@
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "fullRange": {
                 "lineBegin": 12,
                 "columnBegin": 8,
                 "lineEnd": 12,
-                "columnEnd": 13
+                "columnEnd": 12
               },
               "text": { "key": "shell" }
             }
@@ -409,7 +409,7 @@
             "lineBegin": 35,
             "columnBegin": 20,
             "lineEnd": 35,
-            "columnEnd": 25
+            "columnEnd": 24
           },
           "text": { "key": "shell" }
         }
@@ -434,13 +434,13 @@
                 "lineBegin": 14,
                 "columnBegin": 7,
                 "lineEnd": 14,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 14,
                 "columnBegin": 1,
                 "lineEnd": 42,
-                "columnEnd": 4
+                "columnEnd": 3
               },
               "text": { "key": "Git" }
             }
@@ -461,7 +461,7 @@
             "lineBegin": 46,
             "columnBegin": 58,
             "lineEnd": 46,
-            "columnEnd": 61
+            "columnEnd": 60
           },
           "text": { "key": "Git" }
         }
@@ -486,13 +486,13 @@
                 "lineBegin": 14,
                 "columnBegin": 7,
                 "lineEnd": 14,
-                "columnEnd": 10
+                "columnEnd": 9
               },
               "fullRange": {
                 "lineBegin": 14,
                 "columnBegin": 1,
                 "lineEnd": 42,
-                "columnEnd": 4
+                "columnEnd": 3
               },
               "text": { "key": "Git" }
             }
@@ -513,7 +513,7 @@
             "lineBegin": 49,
             "columnBegin": 19,
             "lineEnd": 49,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "Git" }
         }
@@ -538,13 +538,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -565,7 +565,7 @@
             "lineBegin": 16,
             "columnBegin": 46,
             "lineEnd": 16,
-            "columnEnd": 49
+            "columnEnd": 48
           },
           "text": { "key": "dir" }
         }
@@ -590,13 +590,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -617,7 +617,7 @@
             "lineBegin": 24,
             "columnBegin": 12,
             "lineEnd": 24,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "dir" }
         }
@@ -642,13 +642,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -669,7 +669,7 @@
             "lineBegin": 27,
             "columnBegin": 53,
             "lineEnd": 27,
-            "columnEnd": 56
+            "columnEnd": 55
           },
           "text": { "key": "dir" }
         }
@@ -694,13 +694,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -721,7 +721,7 @@
             "lineBegin": 30,
             "columnBegin": 12,
             "lineEnd": 30,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "dir" }
         }
@@ -746,13 +746,13 @@
                 "lineBegin": 15,
                 "columnBegin": 23,
                 "lineEnd": 15,
-                "columnEnd": 26
+                "columnEnd": 25
               },
               "fullRange": {
                 "lineBegin": 15,
                 "columnBegin": 15,
                 "lineEnd": 15,
-                "columnEnd": 34
+                "columnEnd": 33
               },
               "text": { "key": "dir" }
             }
@@ -773,7 +773,7 @@
             "lineBegin": 35,
             "columnBegin": 55,
             "lineEnd": 35,
-            "columnEnd": 58
+            "columnEnd": 57
           },
           "text": { "key": "dir" }
         }
@@ -798,13 +798,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -825,7 +825,7 @@
             "lineBegin": 17,
             "columnBegin": 9,
             "lineEnd": 17,
-            "columnEnd": 12
+            "columnEnd": 11
           },
           "text": { "key": "res" }
         }
@@ -850,13 +850,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -877,7 +877,7 @@
             "lineBegin": 18,
             "columnBegin": 52,
             "lineEnd": 18,
-            "columnEnd": 55
+            "columnEnd": 54
           },
           "text": { "key": "res" }
         }
@@ -902,13 +902,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -929,7 +929,7 @@
             "lineBegin": 19,
             "columnBegin": 11,
             "lineEnd": 19,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "res" }
         }
@@ -954,13 +954,13 @@
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 14
+                "columnEnd": 13
               },
               "fullRange": {
                 "lineBegin": 16,
                 "columnBegin": 11,
                 "lineEnd": 16,
-                "columnEnd": 65
+                "columnEnd": 64
               },
               "text": { "key": "res" }
             }
@@ -981,7 +981,7 @@
             "lineBegin": 20,
             "columnBegin": 11,
             "lineEnd": 20,
-            "columnEnd": 14
+            "columnEnd": 13
           },
           "text": { "key": "res" }
         }
@@ -1006,13 +1006,13 @@
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "addRes" }
             }
@@ -1033,7 +1033,7 @@
             "lineBegin": 36,
             "columnBegin": 9,
             "lineEnd": 36,
-            "columnEnd": 15
+            "columnEnd": 14
           },
           "text": { "key": "addRes" }
         }
@@ -1058,13 +1058,13 @@
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "addRes" }
             }
@@ -1085,7 +1085,7 @@
             "lineBegin": 37,
             "columnBegin": 51,
             "lineEnd": 37,
-            "columnEnd": 57
+            "columnEnd": 56
           },
           "text": { "key": "addRes" }
         }
@@ -1110,13 +1110,13 @@
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "addRes" }
             }
@@ -1137,7 +1137,7 @@
             "lineBegin": 38,
             "columnBegin": 11,
             "lineEnd": 38,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "addRes" }
         }
@@ -1162,13 +1162,13 @@
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 17
+                "columnEnd": 16
               },
               "fullRange": {
                 "lineBegin": 35,
                 "columnBegin": 11,
                 "lineEnd": 35,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "addRes" }
             }
@@ -1189,7 +1189,7 @@
             "lineBegin": 39,
             "columnBegin": 11,
             "lineEnd": 39,
-            "columnEnd": 17
+            "columnEnd": 16
           },
           "text": { "key": "addRes" }
         }
@@ -1214,13 +1214,13 @@
                 "lineBegin": 47,
                 "columnBegin": 9,
                 "lineEnd": 47,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 47,
                 "columnBegin": 9,
                 "lineEnd": 47,
-                "columnEnd": 74
+                "columnEnd": 73
               },
               "text": { "key": "repoDir" }
             }
@@ -1241,7 +1241,7 @@
             "lineBegin": 49,
             "columnBegin": 23,
             "lineEnd": 49,
-            "columnEnd": 30
+            "columnEnd": 29
           },
           "text": { "key": "repoDir" }
         }
@@ -1266,13 +1266,13 @@
                 "lineBegin": 972,
                 "columnBegin": 11,
                 "lineEnd": 972,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 972,
                 "columnBegin": 1,
                 "lineEnd": 976,
-                "columnEnd": 2
+                "columnEnd": 1
               },
               "text": { "key": "Error" }
             }
@@ -1293,7 +1293,7 @@
             "lineBegin": 18,
             "columnBegin": 17,
             "lineEnd": 18,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "Error" }
         }
@@ -1318,13 +1318,13 @@
                 "lineBegin": 972,
                 "columnBegin": 11,
                 "lineEnd": 972,
-                "columnEnd": 16
+                "columnEnd": 15
               },
               "fullRange": {
                 "lineBegin": 972,
                 "columnBegin": 1,
                 "lineEnd": 976,
-                "columnEnd": 2
+                "columnEnd": 1
               },
               "text": { "key": "Error" }
             }
@@ -1345,7 +1345,7 @@
             "lineBegin": 37,
             "columnBegin": 17,
             "lineEnd": 37,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "Error" }
         }
@@ -1370,13 +1370,13 @@
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "fullRange": {
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 36
+                "columnEnd": 35
               },
               "text": { "key": "Error" }
             }
@@ -1397,7 +1397,7 @@
             "lineBegin": 18,
             "columnBegin": 17,
             "lineEnd": 18,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "Error" }
         }
@@ -1422,13 +1422,13 @@
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 18
+                "columnEnd": 17
               },
               "fullRange": {
                 "lineBegin": 984,
                 "columnBegin": 13,
                 "lineEnd": 984,
-                "columnEnd": 36
+                "columnEnd": 35
               },
               "text": { "key": "Error" }
             }
@@ -1449,7 +1449,7 @@
             "lineBegin": 37,
             "columnBegin": 17,
             "lineEnd": 37,
-            "columnEnd": 22
+            "columnEnd": 21
           },
           "text": { "key": "Error" }
         }


### PR DESCRIPTION
We were writing exclusive-of-end ranges, leading to an extra off-by-1
when adding converting from Glean -> Glass on the way out. Store LSIF
ranges as inclusive-of-end col like rest of src.angle:Range

Spotted via manual reconcilliation

Test plan: update regression tests