### PR TITLE
Implement glass.thrift:resolveLocationRange

### DIFF
--- a/glean/glass/Glean/Glass/Logging.hs
+++ b/glean/glass/Glean/Glass/Logging.hs
@@ -93,6 +93,12 @@ instance LogResult Location where
     , Logger.setRepo $ unRepoName location_repository
     ]
 
+instance LogResult LocationRange where
+  logResult (LocationRange{..},log) = log <> mconcat
+    [ Logger.setItemCount 1
+    , Logger.setRepo $ unRepoName locationRange_repository
+    ]
+
 instance LogResult SymbolDescription where
   logResult (SymbolDescription{..}, log) = log <>
     logResult (symbolDescription_location, log) <>

--- a/glean/glass/Glean/Glass/Main.hs
+++ b/glean/glass/Glean/Glass/Main.hs
@@ -120,6 +120,7 @@ glassHandler env cmd = case cmd of
   -- Resolving symbol information
   JumpTo r opts -> Handler.jumpTo env r opts
   ResolveSymbol r opts -> Handler.resolveSymbol env r opts
+  ResolveSymbolRange r opts -> Handler.resolveSymbolRange env r opts
 
   -- Symbol info
   DescribeSymbol r opts -> Handler.describeSymbol env r opts

--- a/glean/glass/if/glass.thrift
+++ b/glean/glass/if/glass.thrift
@@ -415,6 +415,12 @@ service GlassService extends fb303.FacebookService {
     1: ServerException e,
   );
 
+  // Resolve a symbol id to its definition location range
+  LocationRange resolveSymbolRange(
+    1: SymbolId symbol,
+    2: RequestOptions options
+  ) throws (1: ServerException e);
+
   // Return basic details about a symbol, a bit more than resolveSymbol
   SymbolDescription describeSymbol(
     1: SymbolId symbol,

--- a/glean/glass/tools/Glean/Glass/Test/DemoClient.hs
+++ b/glean/glass/tools/Glean/Glass/Test/DemoClient.hs
@@ -179,15 +179,8 @@ runDescribe sym = do
 
 runResolve :: Protocol p => SymbolId -> GlassM p [Text]
 runResolve sym = do
-  loc@Location{..} <- resolveSymbol sym def
-  range <- jumpTo loc def
-  return
-    [pprLocationRange LocationRange {
-          locationRange_repository = location_repository,
-          locationRange_filepath = location_filepath,
-          locationRange_range = range
-        }
-    ]
+  range <- resolveSymbolRange sym def
+  return [pprLocationRange range]
 
 runFindRefs :: Protocol p => SymbolId -> GlassM p [Text]
 runFindRefs sym = do


### PR DESCRIPTION
- range-based resolution of a symbol id to its line/col position

We already have a bytespan version used for jumptos, but for dbs without
line/col indexing (e.g. lsif), its useful to avoid any conversion to
bytespans. Also more efficient for C++/clang, where the underlying
representation is a range.

Tests in following diff.