### PR TITLE
Can redefine codemarkup.EntityUses in terms of more general form

### DIFF
--- a/glean/schema/source/codemarkup.angle
+++ b/glean/schema/source/codemarkup.angle
@@ -244,22 +244,7 @@ predicate EntityUses:
     span: src.ByteSpan
   }
   {Entity, File, Span} where
-    (codemarkup.hack.HackEntityUses { E, File, Span };
-     { hack = E } = Entity) |
-    (codemarkup.flow.FlowEntityUses { E, File, Span };
-     { flow = E } = Entity) |
-    (codemarkup.python.PythonEntityUses { E, File, Span };
-     { python = E } = Entity) |
-    (codemarkup.cxx.CxxEntityUses { E, File, Span };
-     { cxx = E } = Entity) |
-    (codemarkup.haskell.HaskellEntityUses { E, File, Span };
-     { hs = E } = Entity) |
-    (codemarkup.rust.RustEntityUses { E, File, Span };
-     { rust = E } = Entity) |
-    (codemarkup.buck.BuckEntityUses { E, File, Span };
-     { buck = E } = Entity) |
-    (codemarkup.erlang.ErlangEntityUses { E, File, Span };
-     { erlang = E } = Entity);
+    codemarkup.EntityReferences { Entity, File, { span = Span }}
 
 # Find references to a language entity (same as EntityUses but with RangeSpans)
 predicate EntityReferences:


### PR DESCRIPTION
use the RangeSpan version to keep things simpler