### PR TITLE
Switch Glass Query.findReferences to Query.findReferenceRanges

### DIFF
--- a/glean/glass/Glean/Glass/Query.hs
+++ b/glean/glass/Glean/Glass/Query.hs
@@ -18,7 +18,6 @@ module Glean.Glass.Query
   , fileEntityXRefLocations
 
   -- * Finding refernces to declarations
-  , findReferences
   , findReferenceRangeSpan
 
   -- * offsets and conversions to lines
@@ -118,24 +117,7 @@ fileEntityXRefLocations fileid =
         end)
       ]
 
--- | Entity-based find-references
-findReferences
-  :: Angle Code.Entity
-  -> Angle (Src.File, Src.ByteSpan)
-findReferences ent =
-  vars $ \(reffile :: Angle Src.File) (refspan :: Angle Src.ByteSpan) ->
-    Angle.tuple (reffile, refspan) `where_` [
-      wild .= predicate @Code.EntityUses (
-      rec $
-          field @"target" ent $
-          field @"file" (asPredicate reffile) $
-          field @"span" refspan
-        end
-      )
-    ]
-
 -- | Entity-based find-references returning native range or bytespan
--- (Unused, replace findReferences in Handler.fetchSymbolReference*)
 findReferenceRangeSpan
   :: Angle Code.Entity
   -> Angle (Src.File, Code.RangeSpan)

--- a/glean/glass/Glean/Glass/Range.hs
+++ b/glean/glass/Glean/Glass/Range.hs
@@ -6,7 +6,6 @@
   LICENSE file in the root directory of this source tree.
 -}
 
-
 module Glean.Glass.Range
   (
   -- * bytespans to ranges
@@ -16,7 +15,6 @@ module Glean.Glass.Range
   , inclusiveRangeToExclusiveRange
   , exclusiveRangeToInclusiveRange
   -- * locations
-  , toLocation
   , toLocationRange
   , resolveLocationToRange
   -- * Glass Thrift types to/from Angle


### PR DESCRIPTION
- uses the more general RangeSpan location type
- more efficient for these calls on C++ and LSIF, where the underlying
  type is a range
- works for range types where no lineSpans are available (LSIF)

(cherry picked from commit 05f470186fcc7153bd48dc9a005591684c483fc4)