### PR TITLE
Pass args through wrapper to snapshot driver

### DIFF
--- a/glean/glass/test/regression/Glean/Glass/Regression/Flow/Main.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/Flow/Main.hs
@@ -12,6 +12,6 @@ import System.Environment
 import qualified Glean.Glass.Regression.Flow as Glass
 
 main :: IO ()
-main = withArgs ["--root", path] Glass.main
+main = getArgs >>= \args -> withArgs (["--root", path] ++ args) Glass.main
   where
     path = "glean/lang/codemarkup/tests/flow/cases/xrefs"

--- a/glean/glass/test/regression/Glean/Glass/Regression/Go/Main.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/Go/Main.hs
@@ -12,6 +12,6 @@ import System.Environment
 import qualified Glean.Glass.Regression.Go as Glass
 
 main :: IO ()
-main = withArgs ["--root", path] Glass.main
+main = getArgs >>= \args -> withArgs (["--root", path] ++ args) Glass.main
   where
     path = "glean/lang/go/tests/cases/xrefs"

--- a/glean/glass/test/regression/Glean/Glass/Regression/Hack/Main.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/Hack/Main.hs
@@ -12,6 +12,6 @@ import System.Environment
 import qualified Glean.Glass.Regression.Hack as Glass
 
 main :: IO ()
-main = withArgs ["--root", path] Glass.main
+main = getArgs >>= \args -> withArgs (["--root", path] ++ args) Glass.main
   where
     path = "glean/lang/codemarkup/tests/hack/cases/xrefs"

--- a/glean/glass/test/regression/Glean/Glass/Regression/RustLsif/Main.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/RustLsif/Main.hs
@@ -12,6 +12,6 @@ import System.Environment
 import qualified Glean.Glass.Regression.RustLsif as Glass
 
 main :: IO ()
-main = withArgs ["--root", path] Glass.main
+main = getArgs >>= \args -> withArgs (["--root", path] ++ args) Glass.main
   where
     path = "glean/lang/rust-lsif/tests/cases/xrefs"

--- a/glean/glass/test/regression/Glean/Glass/Regression/TypeScript/Main.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/TypeScript/Main.hs
@@ -12,6 +12,6 @@ import System.Environment
 import qualified Glean.Glass.Regression.TypeScript as Glass
 
 main :: IO ()
-main = withArgs ["--root", path] Glass.main
+main = getArgs >>= \args -> withArgs (["--root", path] ++ args) Glass.main
   where
     path = "glean/lang/typescript/tests/cases/xrefs"


### PR DESCRIPTION
Means --replace foo works in oss.