### PR TITLE
Tidy up the Glass Range api

### DIFF
--- a/glean/glass/Glean/Glass/Range.hs
+++ b/glean/glass/Glean/Glass/Range.hs
@@ -8,27 +8,22 @@
 
 module Glean.Glass.Range
   (
-  -- * bytespans to ranges
-    fileByteSpanToExclusiveRange
-  , exclusiveRangeToFileByteSpan
-  -- * range conversions
-  , inclusiveRangeToExclusiveRange
-  , exclusiveRangeToInclusiveRange
-  -- * locations
-  , toLocationRange
-  , resolveLocationToRange
-  -- * Glass Thrift types to/from Angle
-  , spanToSpan
-  , spanFromSpan
+  -- * working with ranges and bytespans, to and from Glean representations
+  -- ** high level
+    rangeSpanToLocation
+  , rangeSpanToLocationRange
+  -- ** lower level
+  , memoRangeSpanToRange
   , rangeSpanToRange
-  -- * Converting raw Glean rangespans to locations and paths
-  , locationFromCodeLocation
-  , locationRangeFromCodeLocation
+
+  -- * locations, these have paths and repo names
+  , resolveLocationToRange
+
   -- * File metadata
   , FileInfo(..)
   , getFileAndLines
   , getFile
-  , memoLineOffsets
+
   ) where
 
 import Data.Default ( Default(def) )
@@ -56,95 +51,80 @@ import qualified Glean.Schema.CodemarkupTypes.Types as Code
 import Glean.Angle ( query )
 import qualified Glean.Haxl.Repos as Glean
 
-unexpected :: a
-unexpected = error "unexpected RangeSpan"
+-- | Convert Glean-side Location markers to the Glass bytespan locations
+-- Like locationRangeFromCodeLocation, memoizes the file offsets needed to do
+-- span conversion.
+rangeSpanToLocation
+  :: RepoName -> Src.File -> Code.RangeSpan -> Glean.RepoHaxl u w Glass.Location
+rangeSpanToLocation repo file rangespan = do
+  span <- case rangespan of
+    Code.RangeSpan_span span -> pure span
+    Code.RangeSpan_range range -> do -- expensive:  converting back to bytespans
+      mOffsets <- memoLineOffsets file
+      return $ inclusiveRangeToFileByteSpan mOffsets range
+    Code.RangeSpan_EMPTY -> unexpected
+  toLocation repo file span
 
--- | Converts Glean-specific bytespan into client-visible line/col offsets
--- convert Glean ranges into customer range types, with exclusive line end
--- Warning: if the file doesn't have src.FileLines facts and the language
--- schema uses span instead of range, the exclusive range will be
--- incorrect (see type RangeSpan in codemarkup.angle)
-fileByteSpanToExclusiveRange
-  :: Src.File -> Maybe Range.LineOffsets -> Src.ByteSpan -> Glass.Range
-fileByteSpanToExclusiveRange _ Nothing _ = def
-fileByteSpanToExclusiveRange file (Just lineoffs) bytespan =
-  let range = Range.byteRangeToRange
-        file lineoffs
-        (Range.byteSpanToRange bytespan)
-  in inclusiveRangeToExclusiveRange range
+-- | Convert Glean-side range span and file to the Glass range locations, with
+-- ranges in exlclusive-end form, and paths adjusted to be repo-relative
+rangeSpanToLocationRange -- locationRangeFromCodeLocation
+  :: RepoName
+  -> Src.File
+  -> Code.RangeSpan
+  -> Glean.RepoHaxl u w Glass.LocationRange
+rangeSpanToLocationRange repo file rangespan = do
+  range <- memoRangeSpanToRange file rangespan
+  toLocationRange repo file range
 
--- | Convert from line/col offet ranges to bytespans.
--- converts customer range types (exclusive end) back into Glean Src.Ranges, and
--- then to spans
-exclusiveRangeToFileByteSpan
-  :: Src.File -> Maybe Range.LineOffsets -> Glass.Range -> Src.ByteSpan
-exclusiveRangeToFileByteSpan file mlineoffs range_exclusive =
-  inclusiveRangeToFileByteSpan mlineoffs range
+-- | Convert Glean-side rangeSpan to Glass Range, with memo filelines if needed
+-- Like rangeSpanToRange, but memoizes the file offsets for the span case.
+memoRangeSpanToRange
+  :: Src.File
+  -> Code.RangeSpan
+  -> Glean.RepoHaxl u w Range
+memoRangeSpanToRange file rangespan@Code.RangeSpan_span{} = do
+  mOffsets <- memoLineOffsets file
+  return $ rangeSpanToRange  file mOffsets rangespan
+memoRangeSpanToRange file rangespan =
+  pure $ rangeSpanToRange file Nothing rangespan
+
+-- | Glean provides either a bytespan or a range for a symbol location.
+-- Normalize it to Glass.Range (exclusive of end line/col spans)
+-- Only use this if you know the offsets are already memoized.
+rangeSpanToRange
+  :: Src.File -> Maybe Range.LineOffsets -> Code.RangeSpan -> Range
+rangeSpanToRange file offsets (Code.RangeSpan_span span) =
+  fileByteSpanToExclusiveRange file offsets span
+rangeSpanToRange _ _ (Code.RangeSpan_range range) =
+  inclusiveRangeToExclusiveRange range
+rangeSpanToRange _ _ Code.RangeSpan_EMPTY =
+  unexpected
+
+-- | Convert a client-side target locator to a specific line/col range
+-- Used to implement location jumpTo
+resolveLocationToRange
+  :: Glean.Repo -> Location -> Glean.RepoHaxl u w (Either ErrorTy Range)
+resolveLocationToRange repo Location{..} = do
+  let path = toGleanPath location_repository location_filepath
+  efile <- getFileAndLines repo path
+  return $ flip fmap efile $ \ FileInfo{..} ->
+    fileByteSpanToExclusiveRange srcFile offsets
+      (spanFromSpan location_span)
   where
-    range = exclusiveRangeToInclusiveRange file range_exclusive
+    -- Span un-conversion
+    spanFromSpan :: ByteSpan -> Src.ByteSpan
+    spanFromSpan ByteSpan{..} =
+      Src.ByteSpan{
+        byteSpan_start = Glean.Nat byteSpan_start,
+        byteSpan_length = Glean.Nat byteSpan_length
+      }
 
--- | Glean's Src.Range is inclusive of start/end. Glass is exclusive of end
-inclusiveRangeToExclusiveRange :: Src.Range -> Glass.Range
-inclusiveRangeToExclusiveRange Src.Range{..} =
-  Glass.Range {
-    range_lineBegin = Glean.unNat range_lineBegin,
-    range_columnBegin = Glean.unNat range_columnBegin,
-    range_lineEnd = Glean.unNat range_lineEnd,
-    range_columnEnd = Glean.unNat range_columnEnd + 1 -- n.b. exclusive end
-  }
-
--- | Range exlucsive of end to Glean's inclusive range
-exclusiveRangeToInclusiveRange :: Src.File -> Glass.Range -> Src.Range
-exclusiveRangeToInclusiveRange file Glass.Range{..} =
-  Src.Range {
-    range_file = file,
-    range_lineBegin = i64ToNat range_lineBegin,
-    range_columnBegin = i64ToNat range_columnBegin,
-    range_lineEnd = i64ToNat range_lineEnd,
-    range_columnEnd = i64ToNat (max 1 (range_columnEnd - 1))
-  }
-  where
-    i64ToNat = Glean.toNat . fromIntegral
-
--- | Convert a src.Range from glean to a src.ByteSpan
-inclusiveRangeToFileByteSpan
-  :: Maybe Range.LineOffsets -> Src.Range -> Src.ByteSpan
-inclusiveRangeToFileByteSpan Nothing _ = def
-inclusiveRangeToFileByteSpan (Just lineoffs) range =
-  Range.rangeToByteSpan (Range.srcRangeToSimpleByteRange lineoffs range)
-
--- | Target cross-references. these are unresolved (raw) spans of locations.
--- They can be resolved to Ranges via a FileLines call (client or server-side).
-toLocation
-  :: RepoName -> Src.File -> Src.ByteSpan -> Glean.RepoHaxl u w Location
-toLocation repo file bytespan = do
-  path <- GleanPath <$> Glean.keyOf file
-  let (location_repository, location_filepath) =
-        fromGleanPath repo path
-  return $ Location {
-       location_repository = location_repository,
-       location_filepath = location_filepath,
-       location_span = spanToSpan bytespan
-     }
-
--- | Like toLocation, but for ranges.
-toLocationRange
-  :: RepoName -> Src.File -> Range -> Glean.RepoHaxl u w LocationRange
-toLocationRange repo file range = do
-  path <- GleanPath <$> Glean.keyOf file
-  let (locationRange_repository, locationRange_filepath) =
-        fromGleanPath repo path
-  return $ LocationRange {
-       locationRange_repository = locationRange_repository,
-       locationRange_filepath = locationRange_filepath,
-       locationRange_range = range
-     }
-
+-- | Package of src.File metadata we typically need
 data FileInfo = FileInfo {
     fileRepo :: Glean.Repo,
-    fileId :: Glean.IdOf Src.File,
-    srcFile :: Src.File,
-    offsets :: Maybe Range.LineOffsets
+    fileId :: {-# UNPACK #-} !(Glean.IdOf Src.File),
+    srcFile :: !Src.File,
+    offsets :: !(Maybe Range.LineOffsets)
   }
 
 -- | Get file metadata. Throw if we have no src.File
@@ -170,7 +150,55 @@ getFile path = do
     Nothing -> Left $ NoSrcFileFact $ "No src.File fact for " <> gleanPath path
     Just srcFile -> Right srcFile
 
--- | Get the line offsets associated with a file
+--
+-- Internal stuff
+--
+
+unexpected :: a
+unexpected = error "unexpected RangeSpan"
+
+-- | (internal) Converts Glean-specific bytespan into client-visible line/col offsets
+-- convert Glean ranges into customer range types, with exclusive line end
+-- Warning: if the file doesn't have src.FileLines facts and the language
+-- schema uses span instead of range, the exclusive range will be
+-- incorrect (see type RangeSpan in codemarkup.angle)
+fileByteSpanToExclusiveRange
+  :: Src.File -> Maybe Range.LineOffsets -> Src.ByteSpan -> Glass.Range
+fileByteSpanToExclusiveRange _ Nothing _ = def
+fileByteSpanToExclusiveRange file (Just lineoffs) bytespan =
+  let range = Range.byteRangeToRange
+        file lineoffs
+        (Range.byteSpanToRange bytespan)
+  in inclusiveRangeToExclusiveRange range
+
+-- | (internal) Glean's Src.Range is inclusive of start/end. Glass is exclusive
+-- of end
+inclusiveRangeToExclusiveRange :: Src.Range -> Glass.Range
+inclusiveRangeToExclusiveRange Src.Range{..} =
+  Glass.Range {
+    range_lineBegin = Glean.unNat range_lineBegin,
+    range_columnBegin = Glean.unNat range_columnBegin,
+    range_lineEnd = Glean.unNat range_lineEnd,
+    range_columnEnd = Glean.unNat range_columnEnd + 1 -- n.b. exclusive end
+  }
+
+-- | (internal) Convert a src.Range from glean to a src.ByteSpan
+inclusiveRangeToFileByteSpan
+  :: Maybe Range.LineOffsets -> Src.Range -> Src.ByteSpan
+inclusiveRangeToFileByteSpan Nothing _ = def
+inclusiveRangeToFileByteSpan (Just lineoffs) range =
+  Range.rangeToByteSpan (Range.srcRangeToSimpleByteRange lineoffs range)
+
+-- | Memoize the result of computing the line offsets on a file
+-- This provides up to 15x win for xrefs on large files
+-- (internal)
+memoLineOffsets :: Src.File -> Glean.RepoHaxl u w (Maybe Range.LineOffsets)
+memoLineOffsets file = do
+  key <- Glean.keyOf file
+  Haxl.memo key $ toLineOffsets file
+
+-- | (internal) Get the line offsets associated with a file
+-- Use the memoized version, memoLineOffsets
 toLineOffsets :: Src.File -> Glean.RepoHaxl u w (Maybe Range.LineOffsets)
 toLineOffsets file = do
   let fileId = Glean.getId file
@@ -179,75 +207,38 @@ toLineOffsets file = do
     Nothing -> return Nothing
     Just offs -> Just . Range.lengthsToLineOffsets <$> Glean.keyOf offs
 
--- | Memoize the result of computing the line offsets on a file
--- This provides up to 15x win for xrefs on large files
-memoLineOffsets :: Src.File -> Glean.RepoHaxl u w (Maybe Range.LineOffsets)
-memoLineOffsets file = do
-  key <- Glean.keyOf file
-  Haxl.memo key $ toLineOffsets file
+-- | (internal) Target cross-references. these are unresolved (raw) spans of
+-- locations.  They can be resolved to Ranges via a FileLines call (client or
+-- server-side).
+toLocation
+  :: RepoName -> Src.File -> Src.ByteSpan -> Glean.RepoHaxl u w Location
+toLocation repo file bytespan = do
+  path <- GleanPath <$> Glean.keyOf file
+  let (location_repository, location_filepath) =
+        fromGleanPath repo path
+  return $ Location {
+       location_repository = location_repository,
+       location_filepath = location_filepath,
+       location_span = spanToSpan bytespan
+     }
+  where
+    -- | Span conversion. We hide any Glean-specific types
+    spanToSpan :: Src.ByteSpan -> ByteSpan
+    spanToSpan Src.ByteSpan{..} =
+      ByteSpan {
+        byteSpan_start = Glean.unNat byteSpan_start,
+        byteSpan_length = Glean.unNat byteSpan_length
+      }
 
--- | Glean provides either a bytespan or a range for a symbol location.
--- Normalize it to Glass.Range (exclusive of end line/col spans)
-rangeSpanToRange
-  :: Src.File -> Maybe Range.LineOffsets -> Code.RangeSpan -> Range
-rangeSpanToRange file offsets (Code.RangeSpan_span span) =
-  fileByteSpanToExclusiveRange file offsets span
-rangeSpanToRange _ _ (Code.RangeSpan_range range) =
-  inclusiveRangeToExclusiveRange range
-rangeSpanToRange _ _ Code.RangeSpan_EMPTY =
-  unexpected
-
--- | Convert a client-side target locator to a specific line/col range
-resolveLocationToRange
-  :: Glean.Repo -> Location -> Glean.RepoHaxl u w (Either ErrorTy Range)
-resolveLocationToRange repo Location{..} = do
-  let path = toGleanPath location_repository location_filepath
-  efile <- getFileAndLines repo path
-  return $ flip fmap efile $ \ FileInfo{..} ->
-    fileByteSpanToExclusiveRange srcFile offsets
-      (spanFromSpan location_span)
-
--- | Span conversion. We hide any Glean-specific types
-spanToSpan :: Src.ByteSpan -> ByteSpan
-spanToSpan Src.ByteSpan{..} =
-  ByteSpan {
-    byteSpan_start = Glean.unNat byteSpan_start,
-    byteSpan_length = Glean.unNat byteSpan_length
-  }
-
--- | Span un-conversion
-spanFromSpan :: ByteSpan -> Src.ByteSpan
-spanFromSpan ByteSpan{..} =
-  Src.ByteSpan{
-    byteSpan_start = Glean.Nat byteSpan_start,
-    byteSpan_length = Glean.Nat byteSpan_length
-  }
-
--- | Convert Glean-side Location markers to the Glass bytespan locations
-locationFromCodeLocation
-  :: RepoName -> Src.File -> Code.RangeSpan -> Glean.RepoHaxl u w Glass.Location
-locationFromCodeLocation repo file rangespan = case rangespan of
-  Code.RangeSpan_span span -> toLocation repo file span
-  Code.RangeSpan_range range -> do -- expensive:  converting back to bytespans
-    mOffsets <- memoLineOffsets file
-    let span = inclusiveRangeToFileByteSpan mOffsets range
-    toLocation repo file span
-  Code.RangeSpan_EMPTY -> unexpected
-
--- | Convert Glean-side Location markers to the Glass range locations
--- Like the composition of locationFromCodeLocation and resolveLocationRoRange,
--- but avoids intermediate conversion via bytespans
-locationRangeFromCodeLocation
-  :: RepoName
-  -> Src.File
-  -> Code.RangeSpan
-  -> Glean.RepoHaxl u w Glass.LocationRange
-locationRangeFromCodeLocation repo file rangespan = do
-  range <- case rangespan of
-    Code.RangeSpan_span span -> do
-      mOffsets <- memoLineOffsets file
-      return $ fileByteSpanToExclusiveRange file mOffsets span
-    Code.RangeSpan_range incRange -> do
-      return $ inclusiveRangeToExclusiveRange incRange
-    Code.RangeSpan_EMPTY -> unexpected
-  toLocationRange repo file range
+-- | (internal) Like toLocation, but for ranges.
+toLocationRange
+  :: RepoName -> Src.File -> Range -> Glean.RepoHaxl u w LocationRange
+toLocationRange repo file range = do
+  path <- GleanPath <$> Glean.keyOf file
+  let (locationRange_repository, locationRange_filepath) =
+        fromGleanPath repo path
+  return $ LocationRange {
+       locationRange_repository = locationRange_repository,
+       locationRange_filepath = locationRange_filepath,
+       locationRange_range = range
+     }

--- a/glean/glass/Glean/Glass/SymbolId.hs
+++ b/glean/glass/Glean/Glass/SymbolId.hs
@@ -8,7 +8,6 @@
 
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Glean.Glass.SymbolId

--- a/glean/glass/test/Glean/Glass/Test/Range.hs
+++ b/glean/glass/test/Glean/Glass/Test/Range.hs
@@ -21,22 +21,18 @@ import TestRunner ( testRunner )
 import Glean.Init ( withUnitTest )
 
 import Glean.Glass.Range
-    ( exclusiveRangeToFileByteSpan,
-      fileByteSpanToExclusiveRange,
-      inclusiveRangeToExclusiveRange )
 import Glean (toNat)
 
 import qualified Glean.Glass.Types as Glass
 import qualified Glean.Schema.Src.Types as Src
 import qualified Glean.Util.Range as Range
+import qualified Glean.Schema.CodemarkupTypes.Types as Code
 
 main :: IO ()
 main = withUnitTest $ testRunner $ TestList
   [ TestList
       [ TestLabel name $
-         testByteSpanToRange bs glass_range offs
-      , TestLabel ("inverse-" <> name) $
-         testRangeToByteSpan glass_range bs offs
+         testByteSpanToExcRange bs glass_range offs
       , TestLabel ("inc-exl-range" <> name) $
          testIncRangeToExcRange src_range glass_range
       ]
@@ -45,20 +41,19 @@ main = withUnitTest $ testRunner $ TestList
           (Range.byteSpanToRange bs)
   ]
 
-testByteSpanToRange :: Src.ByteSpan -> Glass.Range -> Range.LineOffsets -> Test
-testByteSpanToRange bs expected offs = TestCase $ expected @=? actual
+-- covnersion from glean-internal bytespan to glass range
+testByteSpanToExcRange
+  :: Src.ByteSpan -> Glass.Range -> Range.LineOffsets -> Test
+testByteSpanToExcRange bs expected offs = TestCase $ expected @=? actual
   where
-    actual = fileByteSpanToExclusiveRange dummyfile (Just offs) bs
+    actual = rangeSpanToRange dummyfile (Just offs) (Code.RangeSpan_span bs)
 
-testRangeToByteSpan :: Glass.Range -> Src.ByteSpan -> Range.LineOffsets -> Test
-testRangeToByteSpan grange expected offs = TestCase $ expected @=? actual
-  where
-    actual = exclusiveRangeToFileByteSpan dummyfile (Just offs) grange
-
-testIncRangeToExcRange :: Src.Range -> Glass.Range -> Test
+-- covnersion from glean-internal inclusive-end range to glass range
+testIncRangeToExcRange
+  :: Src.Range -> Glass.Range -> Test
 testIncRangeToExcRange src_range expected = TestCase $ expected @=? actual
   where
-    actual = inclusiveRangeToExclusiveRange src_range
+    actual = rangeSpanToRange dummyfile Nothing (Code.RangeSpan_range src_range)
 
 dummyfile :: Src.File
 dummyfile = Src.File 0 Nothing

--- a/glean/glass/tools/Glean/Glass/Test/DemoClient.hs
+++ b/glean/glass/tools/Glean/Glass/Test/DemoClient.hs
@@ -188,7 +188,7 @@ runListSymbols repo path = do
 runDescribe :: Protocol p => SymbolId -> GlassM p [Text]
 runDescribe sym = do
   SymbolDescription{..} <- describeSymbol sym def
-  let loc = pprLocationRange $ toLocationRange symbolDescription_location
+  let loc = pprLocationRange $ locationRange symbolDescription_location
       name = pprQName symbolDescription_name
       kind = textShow <$> symbolDescription_kind
       annot = textShow <$> symbolDescription_annotations
@@ -236,8 +236,8 @@ pprQName :: QualifiedName -> Text
 pprQName QualifiedName{..} =
   unName qualifiedName_container <> ":" <> unName qualifiedName_localName
 
-toLocationRange :: SymbolPath -> LocationRange
-toLocationRange SymbolPath{..} = LocationRange {
+locationRange :: SymbolPath -> LocationRange
+locationRange SymbolPath{..} = LocationRange {
     locationRange_repository = symbolPath_repository,
     locationRange_filepath = symbolPath_filepath,
     locationRange_range = symbolPath_range


### PR DESCRIPTION
- remove some cruft left over from old Code.Span types
- emphasize the RangeSpan, LocationRange, Location functions
- keep the memoization of FileLines internal
- standardize names a bit

Test plan:
- glass regression tests should show no change in symbol ranges