### PR TITLE
Symbol type signatures for LSIF languages

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -1218,6 +1218,7 @@ library glass-lib
         Glean.Glass.Pretty.Annotations
         Glean.Glass.Pretty.Cxx
         Glean.Glass.Pretty.Hack
+        Glean.Glass.Pretty.LSIF
         Glean.Glass.Query
         Glean.Glass.Query.Cxx
         Glean.Glass.Range

--- a/glean/glass/Glean/Glass/Handler.hs
+++ b/glean/glass/Glean/Glass/Handler.hs
@@ -751,8 +751,8 @@ toDefinitionSymbol repoName offsets (Code.Location{..}, entity) = do
 
 -- | Decorate an entity with 'static' attributes.
 -- These are static in that they are derivable from the entity and
--- schema information alone, without additional repos
---
+-- schema information alone, without additional repos.
+-- They're expected to be cheap, as we call these once per entity in a file
 getStaticAttributes :: Code.Entity -> Glean.RepoHaxl u w AttributeList
 getStaticAttributes e = do
   mParent <- toSymbolParent e -- the "parent" of the symbol

--- a/glean/glass/Glean/Glass/Pretty/Hack.hs
+++ b/glean/glass/Glean/Glass/Pretty/Hack.hs
@@ -8,7 +8,7 @@
 
 {-# LANGUAGE TypeApplications #-}
 
-module  Glean.Glass.Pretty.Hack
+module Glean.Glass.Pretty.Hack
   ( prettyHackSignature
     -- for testing
   , prettyDecl

--- a/glean/glass/Glean/Glass/Pretty/LSIF.hs
+++ b/glean/glass/Glean/Glass/Pretty/LSIF.hs
@@ -1,0 +1,39 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+{-# LANGUAGE TypeApplications #-}
+
+module Glean.Glass.Pretty.LSIF ( prettyLsifSignature ) where
+
+import Data.Text ( Text )
+
+import qualified Glean
+import Glean.Angle as Angle
+import Glean.Haxl.Repos as Glean ( RepoHaxl )
+import Glean.Glass.Utils ( fetchData )
+
+import qualified Glean.Schema.Lsif.Types as LSIF
+
+prettyLsifSignature :: LSIF.SomeEntity -> Glean.RepoHaxl u w (Maybe Text)
+prettyLsifSignature (LSIF.SomeEntity_defn dm) = do
+  LSIF.DefinitionMoniker_key{..} <- Glean.keyOf dm
+  fetchData (definitionHover (Glean.getId definitionMoniker_key_defn))
+prettyLsifSignature _ = pure Nothing
+
+definitionHover :: Glean.IdOf LSIF.Definition -> Angle Text
+definitionHover defnId = var $ \hoverText ->
+  hoverText `where_` [
+    wild .= predicate @LSIF.DefinitionHover (
+      rec $
+        field @"defn" (asPredicate (factId defnId)) $
+        field @"hover" (
+          rec $
+            field @"text" hoverText
+          end)
+      end)
+  ]

--- a/glean/glass/Glean/Glass/SymbolId.hs
+++ b/glean/glass/Glean/Glass/SymbolId.hs
@@ -53,7 +53,7 @@ import Glean.Glass.Types as Glass
 
 import Glean.Angle ( alt, Angle )
 import qualified Glean.Haxl.Repos as Glean
-import Glean.Util.ToAngle
+import Glean.Util.ToAngle ( ToAngle(toAngle) )
 
 import Glean.Glass.SymbolId.Class
     ( Symbol(..),

--- a/glean/glass/Glean/Glass/SymbolSig.hs
+++ b/glean/glass/Glean/Glass/SymbolSig.hs
@@ -15,9 +15,11 @@ import Data.Text (Text)
 
 import qualified Glean.Haxl.Repos as Glean
 import qualified Glean.Schema.Code.Types as Code
+import qualified Glean.Schema.CodeLsif.Types as Lsif
 
 import Glean.Glass.Pretty.Cxx as Cxx ( prettyCxxSignature )
 import Glean.Glass.Pretty.Hack as Hack ( prettyHackSignature )
+import Glean.Glass.Pretty.LSIF as LSIF ( prettyLsifSignature )
 
 -- signature of symbols
 class ToSymbolSignature a where
@@ -25,9 +27,18 @@ class ToSymbolSignature a where
 
 instance ToSymbolSignature Code.Entity where
   toSymbolSignature e = case e of
-    Code.Entity_cxx x -> return $ case Cxx.prettyCxxSignature x of
+    -- cxx pretty signatures
+    Code.Entity_cxx x -> pure $ case Cxx.prettyCxxSignature x of
       "" -> Nothing
       s -> Just s
+    Code.Entity_pp{} -> pure Nothing
+    -- hack pretty signatures
     Code.Entity_hack x -> Hack.prettyHackSignature x
-    Code.Entity_pp{} -> return Nothing
+    -- lsif languages
+    Code.Entity_lsif e -> case e of
+      Lsif.Entity_go x -> LSIF.prettyLsifSignature x
+      Lsif.Entity_typescript x -> LSIF.prettyLsifSignature x
+      Lsif.Entity_rust x -> LSIF.prettyLsifSignature x
+      Lsif.Entity_EMPTY -> pure Nothing
+    -- otherwise
     _ -> return Nothing

--- a/glean/glass/test/regression/tests/go/documentSymbolIndex.out
+++ b/glean/glass/test/regression/tests/go/documentSymbolIndex.out
@@ -9,6 +9,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\npackage leaphash\n```"
                         }
                     },
                     "range": {
@@ -25,6 +28,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar data string\n```"
                         }
                     },
                     "range": {
@@ -39,6 +45,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nfunc Compute(data string) string\n```\n\n---\n\nCompute returns the sha1 sum of all non whitespace characters in data excluding comments. Since it includes logic for special lines specific to the leap-second.list format its not a general purpose function and should be only used to verify the integrity of an official leap-second.list document. \n\n"
                         }
                     },
                     "range": {
@@ -55,6 +64,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar data string\n```"
                         }
                     },
                     "range": {
@@ -79,6 +91,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar lines []string\n```"
                         }
                     },
                     "range": {
@@ -95,6 +110,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar filtered string\n```"
                         }
                     },
                     "range": {
@@ -111,6 +129,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar filterBlanks func(r rune) rune\n```"
                         }
                     },
                     "range": {
@@ -125,6 +146,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar r rune\n```"
                         }
                     },
                     "range": {
@@ -141,6 +165,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar r rune\n```"
                         }
                     },
                     "range": {
@@ -165,6 +192,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar r rune\n```"
                         }
                     },
                     "range": {
@@ -191,6 +221,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar r rune\n```"
                         }
                     },
                     "range": {
@@ -217,6 +250,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar lines []string\n```"
                         }
                     },
                     "range": {
@@ -241,6 +277,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -255,6 +294,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -279,6 +321,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -305,6 +350,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar lines []string\n```"
                         }
                     },
                     "range": {
@@ -329,6 +377,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar lines []string\n```"
                         }
                     },
                     "range": {
@@ -353,6 +404,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -377,6 +431,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -403,6 +460,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar lines []string\n```"
                         }
                     },
                     "range": {
@@ -427,6 +487,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar lines []string\n```"
                         }
                     },
                     "range": {
@@ -451,6 +514,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar filtered string\n```"
                         }
                     },
                     "range": {
@@ -475,6 +541,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar filterBlanks func(r rune) rune\n```"
                         }
                     },
                     "range": {
@@ -499,6 +568,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -523,6 +595,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -549,6 +624,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar lines []string\n```"
                         }
                     },
                     "range": {
@@ -573,6 +651,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -599,6 +680,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar lines []string\n```"
                         }
                     },
                     "range": {
@@ -623,6 +707,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -647,6 +734,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar line string\n```"
                         }
                     },
                     "range": {
@@ -663,6 +753,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar line string\n```"
                         }
                     },
                     "range": {
@@ -687,6 +780,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar commentPos int\n```"
                         }
                     },
                     "range": {
@@ -703,6 +799,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar commentPos int\n```"
                         }
                     },
                     "range": {
@@ -729,6 +828,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar line string\n```"
                         }
                     },
                     "range": {
@@ -753,6 +855,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar line string\n```"
                         }
                     },
                     "range": {
@@ -777,6 +882,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar commentPos int\n```"
                         }
                     },
                     "range": {
@@ -803,6 +911,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar filtered string\n```"
                         }
                     },
                     "range": {
@@ -827,6 +938,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar filterBlanks func(r rune) rune\n```"
                         }
                     },
                     "range": {
@@ -851,6 +965,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar line string\n```"
                         }
                     },
                     "range": {
@@ -877,6 +994,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar filtered string\n```"
                         }
                     },
                     "range": {
@@ -901,6 +1021,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar hash string\n```"
                         }
                     },
                     "range": {
@@ -917,6 +1040,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar groupedHash string\n```"
                         }
                     },
                     "range": {
@@ -933,6 +1059,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -947,6 +1076,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -971,6 +1103,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -997,6 +1132,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar groupedHash string\n```"
                         }
                     },
                     "range": {
@@ -1023,6 +1161,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar groupedHash string\n```"
                         }
                     },
                     "range": {
@@ -1049,6 +1190,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar hash string\n```"
                         }
                     },
                     "range": {
@@ -1073,6 +1217,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar groupedHash string\n```"
                         }
                     },
                     "range": {
@@ -1097,6 +1244,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -1121,6 +1271,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar i int\n```"
                         }
                     },
                     "range": {
@@ -1147,6 +1300,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 14
+                        },
+                        "symbolSignature": {
+                            "aString": "```go\nvar groupedHash string\n```"
                         }
                     },
                     "range": {

--- a/glean/glass/test/regression/tests/go/documentSymbolListX.out
+++ b/glean/glass/test/regression/tests/go/documentSymbolListX.out
@@ -6,6 +6,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar data string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -21,6 +27,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar lines []string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -40,6 +52,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar filtered string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -55,6 +73,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar filterBlanks func(r rune) rune\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -74,6 +98,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar r rune\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -89,6 +119,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -108,6 +144,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar line string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -123,6 +165,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar commentPos int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -142,6 +190,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar hash string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -157,6 +211,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar groupedHash string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -176,6 +236,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -191,6 +257,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\npackage leaphash\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -210,6 +282,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nfunc Compute(data string) string\n```\n\n---\n\nCompute returns the sha1 sum of all non whitespace characters in data excluding comments. Since it includes logic for special lines specific to the leap-second.list format its not a general purpose function and should be only used to verify the integrity of an official leap-second.list document. \n\n"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -227,6 +305,12 @@
         "references": [
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar data string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -256,6 +340,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar lines []string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -281,6 +371,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar lines []string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -310,6 +406,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar lines []string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -335,6 +437,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar lines []string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -364,6 +472,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar lines []string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -389,6 +503,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar lines []string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -418,6 +538,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar lines []string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -443,6 +569,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar filtered string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -472,6 +604,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar filtered string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -497,6 +635,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar filtered string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -526,6 +670,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar filterBlanks func(r rune) rune\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -553,6 +703,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar filterBlanks func(r rune) rune\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -578,6 +734,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar r rune\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -607,6 +769,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar r rune\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -632,6 +800,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar r rune\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -661,6 +835,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -688,6 +868,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -715,6 +901,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -740,6 +932,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -769,6 +967,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -794,6 +998,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -823,6 +1033,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -848,6 +1064,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -877,6 +1099,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar line string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -902,6 +1130,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar line string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -931,6 +1165,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar line string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -956,6 +1196,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar line string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -985,6 +1231,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar commentPos int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -1010,6 +1262,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar commentPos int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -1039,6 +1297,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar hash string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -1064,6 +1328,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar groupedHash string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -1093,6 +1363,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar groupedHash string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -1118,6 +1394,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar groupedHash string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -1147,6 +1429,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar groupedHash string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -1172,6 +1460,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14
@@ -1201,6 +1495,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -1228,6 +1528,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 14
                         },
                         "key": "symbolLanguage"
@@ -1253,6 +1559,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "```go\nvar i int\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 14

--- a/glean/glass/test/regression/tests/rust-lsif/documentSymbolIndex.out
+++ b/glean/glass/test/regression/tests/rust-lsif/documentSymbolIndex.out
@@ -9,6 +9,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nn: u64\n```"
                         }
                     },
                     "range": {
@@ -23,6 +26,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\npub fn sum_f1(n: u64) -> u64\n```"
                         }
                     },
                     "range": {
@@ -39,6 +45,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nn: u64\n```"
                         }
                     },
                     "range": {
@@ -63,6 +72,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\nfn f1_go(n: u64, acc: u64) -> u64\n```"
                         }
                     },
                     "range": {
@@ -89,6 +101,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nn: u64\n```"
                         }
                     },
                     "range": {
@@ -103,6 +118,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nacc: u64\n```"
                         }
                     },
                     "range": {
@@ -117,6 +135,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\nfn f1_go(n: u64, acc: u64) -> u64\n```"
                         }
                     },
                     "range": {
@@ -133,6 +154,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nn: u64\n```"
                         }
                     },
                     "range": {
@@ -157,6 +181,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nn: u64\n```"
                         }
                     },
                     "range": {
@@ -181,6 +208,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nn: u64\n```"
                         }
                     },
                     "range": {
@@ -205,6 +235,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nacc: u64\n```"
                         }
                     },
                     "range": {
@@ -229,6 +262,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nacc: u64\n```"
                         }
                     },
                     "range": {
@@ -253,6 +289,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\nfn f1_go(n: u64, acc: u64) -> u64\n```"
                         }
                     },
                     "range": {
@@ -279,6 +318,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nn: u64\n```"
                         }
                     },
                     "range": {
@@ -293,6 +335,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\npub fn sum_f2(n: u64) -> u64\n```"
                         }
                     },
                     "range": {
@@ -309,6 +354,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
                         }
                     },
                     "range": {
@@ -325,6 +373,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nn: u64\n```"
                         }
                     },
                     "range": {
@@ -349,6 +400,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nlet mut m: u64\n```"
                         }
                     },
                     "range": {
@@ -365,6 +419,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nlet mut m: u64\n```"
                         }
                     },
                     "range": {
@@ -391,6 +448,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
                         }
                     },
                     "range": {
@@ -417,6 +477,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
                         }
                     },
                     "range": {
@@ -441,6 +504,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nlet mut m: u64\n```"
                         }
                     },
                     "range": {
@@ -467,6 +533,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nlet mut m: u64\n```"
                         }
                     },
                     "range": {
@@ -493,6 +562,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nn: u64\n```"
                         }
                     },
                     "range": {
@@ -507,6 +579,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\npub fn sum_f3(n: u64) -> u64\n```"
                         }
                     },
                     "range": {
@@ -523,6 +598,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
                         }
                     },
                     "range": {
@@ -539,6 +617,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nn: u64\n```"
                         }
                     },
                     "range": {
@@ -563,6 +644,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nm: u64\n```"
                         }
                     },
                     "range": {
@@ -579,6 +663,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
                         }
                     },
                     "range": {
@@ -603,6 +690,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nm: u64\n```"
                         }
                     },
                     "range": {
@@ -629,6 +719,9 @@
                     "attributes": {
                         "symbolLanguage": {
                             "aInteger": 10
+                        },
+                        "symbolSignature": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
                         }
                     },
                     "range": {

--- a/glean/glass/test/regression/tests/rust-lsif/documentSymbolListX.out
+++ b/glean/glass/test/regression/tests/rust-lsif/documentSymbolListX.out
@@ -6,6 +6,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nn: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -21,6 +27,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\npub fn sum_f1(n: u64) -> u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -40,6 +52,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nn: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -55,6 +73,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nacc: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -74,6 +98,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\nfn f1_go(n: u64, acc: u64) -> u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -89,6 +119,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nn: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -108,6 +144,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\npub fn sum_f2(n: u64) -> u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -123,6 +165,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -142,6 +190,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nlet mut m: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -157,6 +211,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nn: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -176,6 +236,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\npub fn sum_f3(n: u64) -> u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -191,6 +257,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -210,6 +282,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nm: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -227,6 +305,12 @@
         "references": [
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nn: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -256,6 +340,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nn: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -281,6 +371,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nn: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -310,6 +406,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nn: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -335,6 +437,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nacc: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -364,6 +472,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nacc: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -389,6 +503,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\nfn f1_go(n: u64, acc: u64) -> u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -418,6 +538,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nbasics\n```\n\n```rust\nfn f1_go(n: u64, acc: u64) -> u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -443,6 +569,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nn: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -472,6 +604,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -497,6 +635,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -526,6 +670,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nlet mut m: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -551,6 +701,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nlet mut m: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -580,6 +736,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nlet mut m: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -605,6 +767,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nn: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10
@@ -634,6 +802,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -661,6 +835,12 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aString": "\n```rust\nlet mut acc: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 10
                         },
                         "key": "symbolLanguage"
@@ -686,6 +866,12 @@
             },
             {
                 "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "\n```rust\nm: u64\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
                     {
                         "attribute": {
                             "aInteger": 10

--- a/glean/glass/test/regression/tests/typescript/documentSymbolIndex.out
+++ b/glean/glass/test/regression/tests/typescript/documentSymbolIndex.out
@@ -31,6 +31,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import os"
                         }
                     },
                     "range": {
@@ -50,6 +53,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import path"
                         }
                     },
                     "range": {
@@ -69,6 +75,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import shell"
                         }
                     },
                     "range": {
@@ -88,6 +97,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "class Git"
                         }
                     },
                     "range": {
@@ -107,6 +119,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) Git.dir: string"
                         }
                     },
                     "range": {
@@ -126,6 +141,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) cwd: string"
                         }
                     },
                     "range": {
@@ -143,6 +161,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) Git.dir: string"
                         }
                     },
                     "range": {
@@ -170,6 +191,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const res: any"
                         }
                     },
                     "range": {
@@ -187,6 +211,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import shell"
                         }
                     },
                     "range": {
@@ -214,6 +241,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) silent: boolean"
                         }
                     },
                     "range": {
@@ -233,6 +263,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const res: any"
                         }
                     },
                     "range": {
@@ -262,6 +295,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const res: any"
                         }
                     },
                     "range": {
@@ -289,6 +325,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "interface Error"
                         }
                     },
                     "range": {
@@ -316,6 +355,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "interface Error"
                         }
                     },
                     "range": {
@@ -345,6 +387,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const res: any"
                         }
                     },
                     "range": {
@@ -374,6 +419,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const res: any"
                         }
                     },
                     "range": {
@@ -403,6 +451,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import shell"
                         }
                     },
                     "range": {
@@ -432,6 +483,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) cwd: string"
                         }
                     },
                     "range": {
@@ -449,6 +503,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) Git.dir: string"
                         }
                     },
                     "range": {
@@ -478,6 +535,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) silent: boolean"
                         }
                     },
                     "range": {
@@ -497,6 +557,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) cwd: string"
                         }
                     },
                     "range": {
@@ -514,6 +577,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) Git.dir: string"
                         }
                     },
                     "range": {
@@ -541,6 +607,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import shell"
                         }
                     },
                     "range": {
@@ -568,6 +637,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) silent: boolean"
                         }
                     },
                     "range": {
@@ -587,6 +659,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import shell"
                         }
                     },
                     "range": {
@@ -616,6 +691,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) cwd: string"
                         }
                     },
                     "range": {
@@ -633,6 +711,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) Git.dir: string"
                         }
                     },
                     "range": {
@@ -662,6 +743,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) silent: boolean"
                         }
                     },
                     "range": {
@@ -681,6 +765,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(parameter) author: string"
                         }
                     },
                     "range": {
@@ -698,6 +785,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(method) Git.commit(msg: string, date: string, author: string): void"
                         }
                     },
                     "range": {
@@ -715,6 +805,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(parameter) date: string"
                         }
                     },
                     "range": {
@@ -732,6 +825,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(parameter) msg: string"
                         }
                     },
                     "range": {
@@ -751,6 +847,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const addRes: any"
                         }
                     },
                     "range": {
@@ -768,6 +867,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) cwd: string"
                         }
                     },
                     "range": {
@@ -785,6 +887,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) Git.dir: string"
                         }
                     },
                     "range": {
@@ -812,6 +917,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import shell"
                         }
                     },
                     "range": {
@@ -839,6 +947,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) silent: boolean"
                         }
                     },
                     "range": {
@@ -858,6 +969,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const addRes: any"
                         }
                     },
                     "range": {
@@ -887,6 +1001,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const addRes: any"
                         }
                     },
                     "range": {
@@ -914,6 +1031,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "interface Error"
                         }
                     },
                     "range": {
@@ -941,6 +1061,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "interface Error"
                         }
                     },
                     "range": {
@@ -970,6 +1093,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const addRes: any"
                         }
                     },
                     "range": {
@@ -999,6 +1125,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const addRes: any"
                         }
                     },
                     "range": {
@@ -1028,6 +1157,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "class Git"
                         }
                     },
                     "range": {
@@ -1055,6 +1187,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) git: Git"
                         }
                     },
                     "range": {
@@ -1072,6 +1207,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) repoDir: string"
                         }
                     },
                     "range": {
@@ -1089,6 +1227,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "function createTempRepo(): {\n    repoDir: string;\n    git: Git;\n}"
                         }
                     },
                     "range": {
@@ -1108,6 +1249,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import fs"
                         }
                     },
                     "range": {
@@ -1135,6 +1279,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import os"
                         }
                     },
                     "range": {
@@ -1162,6 +1309,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import path"
                         }
                     },
                     "range": {
@@ -1189,6 +1339,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const repoDir: any"
                         }
                     },
                     "range": {
@@ -1208,6 +1361,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "class Git"
                         }
                     },
                     "range": {
@@ -1235,6 +1391,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const git: Git"
                         }
                     },
                     "range": {
@@ -1252,6 +1411,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "const repoDir: any"
                         }
                     },
                     "range": {
@@ -1281,6 +1443,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) git: Git"
                         }
                     },
                     "range": {
@@ -1298,6 +1463,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "(property) repoDir: string"
                         }
                     },
                     "range": {
@@ -1317,6 +1485,9 @@
                         },
                         "symbolLanguage": {
                             "aInteger": 13
+                        },
+                        "symbolSignature": {
+                            "aString": "import fs"
                         }
                     },
                     "range": {

--- a/glean/glass/test/regression/tests/typescript/documentSymbolListX.out
+++ b/glean/glass/test/regression/tests/typescript/documentSymbolListX.out
@@ -12,6 +12,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "class Git"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -32,6 +38,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "const addRes: any"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -58,6 +70,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(parameter) author: string"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -78,6 +96,12 @@
                             "aInteger": 8
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(method) Git.commit(msg: string, date: string, author: string): void"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -104,6 +128,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) cwd: string"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -124,6 +154,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(property) cwd: string"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -150,6 +186,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) cwd: string"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -170,6 +212,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(property) cwd: string"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -196,6 +244,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) cwd: string"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -216,6 +270,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(parameter) date: string"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -242,6 +302,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) Git.dir: string"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -262,6 +328,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "import fs"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -288,6 +360,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) git: Git"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -308,6 +386,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "const git: Git"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -334,6 +418,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) git: Git"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -354,6 +444,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(parameter) msg: string"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -380,6 +476,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "import os"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -400,6 +502,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "import path"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -426,6 +534,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) repoDir: string"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -446,6 +560,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "const repoDir: any"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -472,6 +592,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) repoDir: string"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -492,6 +618,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "const res: any"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -518,6 +650,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "import shell"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -538,6 +676,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(property) silent: boolean"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -564,6 +708,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) silent: boolean"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -584,6 +734,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(property) silent: boolean"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -610,6 +766,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) silent: boolean"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -630,6 +792,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(property) silent: boolean"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -679,6 +847,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "function createTempRepo(): {\n    repoDir: string;\n    git: Git;\n}"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -701,6 +875,12 @@
                             "aInteger": 7
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "class Git"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -737,6 +917,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "class Git"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -767,6 +953,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "const addRes: any"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -803,6 +995,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "const addRes: any"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -833,6 +1031,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "const addRes: any"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -869,6 +1073,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "const addRes: any"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -899,6 +1109,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(property) Git.dir: string"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -935,6 +1151,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) Git.dir: string"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -965,6 +1187,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(property) Git.dir: string"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -1001,6 +1229,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "(property) Git.dir: string"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -1031,6 +1265,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "(property) Git.dir: string"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -1067,6 +1307,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "import fs"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -1097,6 +1343,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "import os"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -1133,6 +1385,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "import path"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -1163,6 +1421,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "const repoDir: any"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -1199,6 +1463,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "const res: any"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -1229,6 +1499,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "const res: any"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -1265,6 +1541,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "const res: any"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -1295,6 +1577,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "const res: any"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -1331,6 +1619,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "import shell"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -1361,6 +1655,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "import shell"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -1397,6 +1697,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "import shell"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -1427,6 +1733,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "import shell"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -1463,6 +1775,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "import shell"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -1496,6 +1814,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "interface Error"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -1526,6 +1850,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "interface Error"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {
@@ -1562,6 +1892,12 @@
                     },
                     {
                         "attribute": {
+                            "aString": "interface Error"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
                             "aInteger": 13
                         },
                         "key": "symbolLanguage"
@@ -1592,6 +1928,12 @@
                             "aInteger": 9
                         },
                         "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "interface Error"
+                        },
+                        "key": "symbolSignature"
                     },
                     {
                         "attribute": {


### PR DESCRIPTION
- adds the symbolSignature attribute when doing documentSymbols() calls
- so hover in e.g. codehub will show Rust, Go or TypeScript (or soon Java) type signatures

Works for Rust, Go, TypeScript.

Test plan: regenerate documentSymbols output tests.