### PR TITLE
UX improvements to glean-clang indexer wrapper

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -1076,30 +1076,6 @@ executable glean-hyperlink
         wai,
         warp
 
-library clang-derive-lib
-    import: fb-haskell, fb-cpp, deps
-    hs-source-dirs: glean/lang/clang
-    exposed-modules:
-        Derive.Env
-        Derive.Lib
-        Derive.Types
-    other-modules:
-        Derive.Common
-        Derive.CxxDeclarationSources
-        Derive.CxxDeclarationTargets
-        Derive.CxxSame
-        Derive.CxxTargetUses
-        Derive.Generic
-    build-depends:
-        glean:client-hs,
-        glean:client-hs-local,
-        glean:core,
-        glean:lib,
-        glean:schema,
-        glean:util,
-        ghc-compact,
-        vector-algorithms,
-
 library hack-derive-lib
     import: fb-haskell, fb-cpp, deps
     hs-source-dirs: glean/lang/hack
@@ -1429,22 +1405,6 @@ library regression-test-lib
         glean:util,
         split,
         yaml
-
--- library clang-derive-test
---      import: fb-haskell, fb-cpp, deps
---      hs-source-dirs: glean/lang/clang/tests
---      exposed-modules:
--- Missing Glean.Clang.Test
---         Glean.Clang.Test.DerivePass
---         Glean.Regression.Driver.DeriveFunctionCalls
---         Glean.Regression.Driver.DeriveDeclFamilies
---         Glean.Regression.Driver.DeriveObjcInheritance
---         Glean.Regression.Driver.DeriveDeclByName
---         Glean.Regression.Driver.DocBlock
---         Glean.Regression.Driver.Clang
---      build-depends:
---         glean:regression-test-lib,
---         glean:clang-derive-lib,
 
 test-suite hack-derive-test
     import: fb-haskell, fb-cpp, deps

--- a/glean/lang/clang/exe/Glean/CMake.hs
+++ b/glean/lang/clang/exe/Glean/CMake.hs
@@ -64,11 +64,8 @@ generateBuildCommands indexOpts buildDir = do
            , buildDir
            ]
 
-runIndexer ::
-  CppIndexerOpts ->
-  -- | path to (temporary) cmake build dir
-  FilePath ->
-  IndexM ()
+-- | buildDir is path to (temporary) cmake build dir
+runIndexer :: CppIndexerOpts -> FilePath -> IndexM ()
 runIndexer indexOpts buildDir = withClangIndex $ \exe -> do
   liftIO $ putStrLn $ "Indexing with: " ++ unwords (exe : args)
   (ex, out, err) <- liftIO $ readProcessWithExitCode exe args ""
@@ -97,6 +94,7 @@ runIndexer indexOpts buildDir = withClangIndex $ \exe -> do
       , cfgInventory indexOpts
       ]
 
+withClangIndex :: (FilePath -> IndexM ()) -> IndexM ()
 withClangIndex f = do
   -- check $PATH
   mPath <- liftIO $ findExecutable clangIndexExe

--- a/glean/lang/clang/exe/Glean/Clang.hs
+++ b/glean/lang/clang/exe/Glean/Clang.hs
@@ -35,7 +35,9 @@ options = info (helper <*> parser) fullDesc
       <*> strOption
             ( long "inventory"
            <> short 'i'
-           <> help "Path to the schema inventory file"
+           <> help ("Path to the schema inventory file. Extract from glean with "
+            <> " `glean write-serialized-inventory --repo $repo $out`"
+           )
            <> metavar "FILE"
             )
       <*> strOption
@@ -50,6 +52,10 @@ options = info (helper <*> parser) fullDesc
            <> help "Extra arguments to pass to clang (in addition to the ones dictated by CMake)"
            <> value ""
            <> showDefault
+            )
+      <*> switch
+            ( long "verbose"
+            <> help "Enable verbose logging from subprocesses"
             )
 
 main :: IO ()

--- a/glean/lang/clang/exe/Glean/Clang.hs
+++ b/glean/lang/clang/exe/Glean/Clang.hs
@@ -54,9 +54,9 @@ options = info (helper <*> parser) fullDesc
 
 main :: IO ()
 main = execParser options >>= go
-
-  where go opts = do
-          r <- runExceptT (indexCMake opts)
-          case r of
-            Left e  -> error $ "Indexing error: " ++ show e
-            Right _ -> putStrLn "Indexing OK."
+  where
+    go opts = do
+      r <- runExceptT (indexCMake opts)
+      case r of
+        Left e  -> error $ "Indexing error: " ++ show e
+        Right _ -> putStrLn "Indexing OK."

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -13,7 +13,6 @@ author:              Facebook, Inc.
 maintainer:          Glean-team@fb.com
 copyright:           (c) Facebook, All Rights Reserved
 build-type:          Custom
-extra-source-files:  CHANGELOG.md
 
 -- These bits of code live in their own package because we want the custom setup
 -- to detect LLVM/clang, but this is not compatible with glean.cabal's use of

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -28,65 +28,34 @@ build-type:          Custom
 -- include/library directories, necessary for 'glean-clang-index' C++ program
 -- which uses the clang/llvm libraries.
 custom-setup
-  setup-depends: base
-               , Cabal >= 3.6
-               , containers
+  setup-depends:
+    base,
+    Cabal >= 3.6,
+    containers
 
 flag opt
      default: False
 
--- copied from the main cabal file, probably a lot of superfluous deps here
 common deps
     build-depends:
-        fb-util,
-        thrift-cpp-channel,
-        thrift-lib,
-        HUnit,
-        safe,
-        scientific,
-        text-show,
-        uuid,
-        extra,
-        aeson,
-        data-default,
-        temporary,
-        clock,
-        STMonadTrans,
-        utf8-string,
-        optparse-applicative,
-        ansi-terminal,
-        json,
-        regex-base,
-        regex-pcre,
-        base >=4.11.1 && <4.15,
         array ^>=0.5.2.0,
         async ^>=2.2.1,
-        attoparsec ^>=0.13.2.3,
-        unordered-containers ^>=0.2.9.0,
+        base >=4.11.1 && <4.15,
         containers,
-        contravariant ^>=1.5,
-        text ^>=1.2.3.0,
-        bytestring ^>=0.10.8.2,
-        vector ^>=0.12.0.1,
-        transformers ^>=0.5.5.0,
-        network-uri ^>=2.6.1.0,
-        stm ^>=2.5.0.0,
-        directory ^>=1.3.1.5,
-        filepath ^>=1.4.2,
-        exceptions ^>=0.10.0,
-        mtl ^>=2.2.2,
-        unix ^>=2.7.2.2,
-        process ^>=1.6.3.0,
-        prettyprinter >=1.2.1 && <1.7,
-        time >=1.8.0.2 && <1.12,
-        binary ^>=0.8.5.1,
+        data-default,
         deepseq ^>=1.4.3.0,
-        hashable >=1.2.7.0 && <1.4,
-        tar ^>=0.5.1.0,
-        ghc-prim >=0.5.2.0 && <0.7,
-        parsec ^>=3.1.13.0,
-        haxl >= 2.1.2.0 && < 2.4,
-        hinotify ^>= 0.4.1
+        directory ^>=1.3.1.5,
+        fb-util,
+        filepath ^>=1.4.2,
+        optparse-applicative,
+        process ^>=1.6.3.0,
+        stm ^>=2.5.0.0,
+        temporary,
+        text ^>=1.2.3.0,
+        thrift-cpp-channel,
+        thrift-lib,
+        unordered-containers ^>=0.2.9.0,
+        vector ^>=0.12.0.1,
 
 common exe
   ghc-options: -threaded
@@ -169,29 +138,30 @@ executable glean-clang-index
         glean:if-glean-cpp,
         glean:if-internal-cpp,
         glean:client-cpp
-    extra-libraries: clangFrontend,
-                     clangSerialization,
-                     clangDriver,
-                     clangParse,
-                     clangSema,
-                     clangAnalysis,
-                     clangAST,
-                     clangASTMatchers,
-                     clangEdit,
-                     clangFrontendTool,
-                     clangIndex,
-                     clangToolingCore,
-                     clangTooling,
-                     clangFormat,
-                     clangLex,
-                     clangBasic,
-                     LLVM,
-                     folly,
-                     glog,
-                     pthread,
-                     fmt,
-                     gflags,
-                     atomic
+    extra-libraries:
+        clangFrontend,
+        clangSerialization,
+        clangDriver,
+        clangParse,
+        clangSema,
+        clangAnalysis,
+        clangAST,
+        clangASTMatchers,
+        clangEdit,
+        clangFrontendTool,
+        clangIndex,
+        clangToolingCore,
+        clangTooling,
+        clangFormat,
+        clangLex,
+        clangBasic,
+        LLVM,
+        folly,
+        glog,
+        pthread,
+        fmt,
+        gflags,
+        atomic
     cxx-options: -fexceptions -DOSS=1 -std=c++17
     if arch(x86_64)
       cxx-options: -DGLEAN_X86_64 -march=haswell

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -88,8 +88,9 @@ common fb-haskell
         TypeFamilies
         TypeSynonymInstances
         NondecreasingIndentation
-  if flag(opt)
-     ghc-options: -O2
+    ghc-options: -Wall -Wno-orphans -Wno-name-shadowing
+    if flag(opt)
+      ghc-options: -O2
 
 common fb-cpp
   cxx-options: -DOSS=1 -std=c++17


### PR DESCRIPTION
- make cabal stop complaining about changelog
- remove unnecessary dependencies
- use either glean-clang-index in $PATH, or if not found, look in wrapper's build dir under dist/
- use async logger to track status of glean-clang-index subprocess, showing output as needed (video in group)