### PR TITLE
external indexer: respect indexerOutput parameter in Json case

### DIFF
--- a/glean/index/Glean/Indexer/External.hs
+++ b/glean/index/Glean/Indexer/External.hs
@@ -119,7 +119,7 @@ execExternal Ext{..} env repo IndexerParams{..} = do index; derive
 
   index = case extFlavour of
     Json -> do
-      withSystemTempDirectory "glean-json" $ \jsonBatchDir -> do
+      jsonBatchDir <- createTempDirectory indexerOutput "glean-json"
       let jsonVars = HashMap.insert "JSON_BATCH_DIR" jsonBatchDir vars
       callCommand
         (unwords (extRunScript : map (quoteArg . subst jsonVars) extArgs))


### PR DESCRIPTION
Otherwise the JSON files are written to a temporary directory that is _always_
deleted once the data has been loaded. Instead, this patches creates a dedicated
directory under whatever path is specified for `indexerOutput`, and it is then
up to the callers of (JSON-based) external indexers to decide whether all the
temporary files generated under `indexerOutput` should be kept or deleted.

(AFAIK, neither the `:index` command in `glean shell` nor the `glean index` CLI command support keeping the temp files around for now, but this will be trivial to implement if all indexers follow the convention to stick all the generated files under `indexerOutput`.)