### PR TITLE
fix maybe type

### DIFF
--- a/glean/glass/Glean/Glass/SymbolId/Python.hs
+++ b/glean/glass/Glean/Glass/SymbolId/Python.hs
@@ -111,7 +111,7 @@ qNameQuery nameId = vars $
   \ (lname :: Angle Py.Name)
     (pname :: Angle Py.Name)
     (psname :: Angle Py.SName)
-    (maybe_psname :: Angle (maybe Py.SName_key)) ->
+    (maybe_psname :: Angle (Maybe Py.SName_key)) ->
     tuple (lname, pname) `where_` [
         wild .= predicate @Py.NameToSName (factId nameId
           .-> predicate @Py.SName (rec $


### PR DESCRIPTION
Summary:
D36749593 (https://github.com/facebookincubator/Glean/commit/63cc7f9362c148e4c75477c1b94bbc8aa59f49b2) Broke github CI
```
glean/glass/Glean/Glass/SymbolId/Python.hs:122:46: error:
    • Couldn't match type ‘maybe’ with ‘Maybe’
      Expected type: Angle (Maybe Py.SName_key)
        Actual type: Angle (maybe Py.SName_key)
    • In the second argument of ‘(.=)’, namely ‘maybe_psname’
      In the expression: just (asPredicate psname) .= maybe_psname
      In the first argument of ‘or_’, namely
        ‘[just (asPredicate psname) .= maybe_psname,
          wild .= (predicate Py.SNameToName $ psname .-> pname)]’
    • Relevant bindings include
        maybe_psname :: Angle (maybe Py.SName_key)
          (bound at glean/glass/Glean/Glass/SymbolId/Python.hs:114:6)
    |
122 |           or_ [ just (asPredicate psname) .= maybe_psname,
    |                                              ^^^^^^^^^^^^
cabal: Failed to build lib:glass-lib from glean-0.1.0.0 (which is required by exe:glass-server from glean-0.1.0.0).
```

Differential Revision: D36935501

