### PR TITLE
Add Glean.Database.PredicateStats to glean:db library in cabal file

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -520,6 +520,7 @@ library db
         Glean.Database.Logger
         Glean.Database.Meta
         Glean.Database.Ownership
+        Glean.Database.PredicateStats
         Glean.Database.Repo
         Glean.Database.Schema
         Glean.Database.Schema.ComputeIds


### PR DESCRIPTION
Fixes an error in the opensource build introduced (if I'm not mistaken) in https://github.com/facebookincubator/Glean/commit/1583305efbffee80b3617787b845b04dea51fda9