### PR TITLE
add --omit flag to test driver to specify tests we _don't_ want to run

### DIFF
--- a/glean/test/regression/Glean/Regression/Snapshot.hs
+++ b/glean/test/regression/Glean/Regression/Snapshot.hs
@@ -217,9 +217,10 @@ testMain driver = do
 
 testAll :: TestAction -> Config -> Driver opts -> opts -> IO ()
 testAll act cfg driver opts = do
-  tests <- if null $ cfgTests cfg
+  tests' <- if null $ cfgTests cfg
     then discoverTests $ cfgRoot cfg
     else return $ cfgTests cfg
+  let tests = filter (`notElem` cfgOmitTests cfg) tests'
   let groups
         | null fromDriver = [""]
         | otherwise = fromDriver

--- a/glean/test/regression/Glean/Regression/Snapshot/Options.hs
+++ b/glean/test/regression/Glean/Regression/Snapshot/Options.hs
@@ -28,6 +28,10 @@ data Config = Config
   , cfgSchemaVersion :: Maybe Int
     -- ^ version of 'all' schema to use
   , cfgTests :: [String]
+    -- ^ specific directories of tests we want to run (ignoring other
+    --   directories)
+  , cfgOmitTests :: [String]
+    -- ^ specific directories of tests we don't want to run
   }
 
 options :: O.ParserInfo (IO Config)
@@ -51,6 +55,9 @@ optionsWith other = O.info (O.helper <*> ((,) <$> parser <*> other)) O.fullDesc
       cfgTests <- O.many $ O.strOption $
         O.long "only" <> O.metavar "DIR" <>
         O.help "Run tests from DIR only"
+      cfgOmitTests <- O.many $ O.strOption $
+        O.long "omit" <> O.metavar "DIR" <>
+        O.help "Do not run tests from DIR"
       return $ resolve Config{..}
 
     resolve cfg = do


### PR DESCRIPTION
This will be useful right away for #208 where @simonmar hinted that (some of?) the test failures might be due to discrepancies between internal and opensource environments.