### PR TITLE
Clang codemarkup tests

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1585,6 +1585,25 @@ test-suite clang-test-deriveobjcinherit
 --     if !flag(clang-tests)
 --         buildable: False
 
+test-suite clang-test-codemarkup
+    import: fb-haskell, fb-cpp, deps
+    hs-source-dirs:
+       glean/lang/clang/tests,
+       glean/lang/clang/tests/github
+    type: exitcode-stdio-1.0
+    main-is: Glean/Clang/CodeMarkup.hs
+    other-modules: Glean.Clang.Test.DerivePass
+                   Glean.Clang.Test
+                   Glean.Regression.Driver.DeriveForCodemarkup
+    ghc-options: -main-is Glean.Clang.CodeMarkup
+    build-depends:
+       glean:regression-test-lib,
+       glean:clang-derive-lib,
+       glean:indexers,
+       glean:lib
+    if !flag(clang-tests)
+        buildable: False
+
 test-suite hack-derive-test
     import: fb-haskell, fb-cpp, deps
     hs-source-dirs: glean/lang/hack/tests

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1428,6 +1428,30 @@ library regression-test-lib
         split,
         yaml
 
+library clang-derive-lib
+    import: fb-haskell, fb-cpp, deps, exe
+    hs-source-dirs: glean/lang/clang
+    build-depends:
+        ghc-compact,
+        glean:client-hs,
+        glean:client-hs-local,
+        glean:core,
+        glean:db,
+        glean:lib,
+        glean:schema,
+        glean:util,
+        vector-algorithms
+    exposed-modules:
+        Derive.Common
+        Derive.CxxDeclarationSources
+        Derive.CxxDeclarationTargets
+        Derive.CxxSame
+        Derive.CxxTargetUses
+        Derive.Env
+        Derive.Generic
+        Derive.Lib
+        Derive.Types
+
 test-suite clang-test-regression
     import: fb-haskell, fb-cpp, deps
     hs-source-dirs:
@@ -1444,6 +1468,122 @@ test-suite clang-test-regression
        glean:lib
     if !flag(clang-tests)
         buildable: False
+
+test-suite clang-test-derivebyname
+    import: fb-haskell, fb-cpp, deps
+    hs-source-dirs:
+       glean/lang/clang/tests,
+       glean/lang/clang/tests/github
+    type: exitcode-stdio-1.0
+    main-is: Glean/Clang/DeriveByName.hs
+    other-modules: Glean.Clang.Test.DerivePass
+                   Glean.Clang.Test
+                   Glean.Regression.Driver.DeriveDeclByName
+    ghc-options: -main-is Glean.Clang.DeriveByName
+    build-depends:
+       glean:regression-test-lib,
+       glean:clang-derive-lib,
+       glean:indexers,
+       glean:lib
+    if !flag(clang-tests)
+        buildable: False
+
+test-suite clang-test-derivefamilies
+    import: fb-haskell, fb-cpp, deps
+    hs-source-dirs:
+       glean/lang/clang/tests,
+       glean/lang/clang/tests/github
+    type: exitcode-stdio-1.0
+    main-is: Glean/Clang/DeriveFamilies.hs
+    other-modules: Glean.Clang.Test.DerivePass
+                   Glean.Clang.Test
+                   Glean.Regression.Driver.DeriveDeclFamilies
+    ghc-options: -main-is Glean.Clang.DeriveFamilies
+    build-depends:
+       glean:regression-test-lib,
+       glean:clang-derive-lib,
+       glean:indexers,
+       glean:lib
+    if !flag(clang-tests)
+        buildable: False
+
+test-suite clang-test-deriveattributes
+    import: fb-haskell, fb-cpp, deps
+    hs-source-dirs:
+       glean/lang/clang/tests,
+       glean/lang/clang/tests/github
+    type: exitcode-stdio-1.0
+    main-is: Glean/Clang/DeriveAttrs.hs
+    other-modules: Glean.Clang.Test.DerivePass
+                   Glean.Clang.Test
+                   Glean.Regression.Driver.DeriveFunctionDeclAttribute
+    ghc-options: -main-is Glean.Clang.DeriveAttrs
+    build-depends:
+       glean:regression-test-lib,
+       glean:clang-derive-lib,
+       glean:indexers,
+       glean:lib
+    if !flag(clang-tests)
+        buildable: False
+
+test-suite clang-test-derivefuncalls
+    import: fb-haskell, fb-cpp, deps
+    hs-source-dirs:
+       glean/lang/clang/tests,
+       glean/lang/clang/tests/github
+    type: exitcode-stdio-1.0
+    main-is: Glean/Clang/DeriveFunCalls.hs
+    other-modules: Glean.Clang.Test.DerivePass
+                   Glean.Clang.Test
+                   Glean.Regression.Driver.DeriveFunctionCalls
+    ghc-options: -main-is Glean.Clang.DeriveFunCalls
+    build-depends:
+       glean:regression-test-lib,
+       glean:clang-derive-lib,
+       glean:indexers,
+       glean:lib
+    if !flag(clang-tests)
+        buildable: False
+
+test-suite clang-test-deriveobjcinherit
+    import: fb-haskell, fb-cpp, deps
+    hs-source-dirs:
+       glean/lang/clang/tests,
+       glean/lang/clang/tests/github
+    type: exitcode-stdio-1.0
+    main-is: Glean/Clang/DeriveObjCInheritance.hs
+    other-modules: Glean.Clang.Test.DerivePass
+                   Glean.Clang.Test
+                   Glean.Regression.Driver.DeriveObjcInheritance
+    ghc-options: -main-is Glean.Clang.DeriveObjCInheritance
+    build-depends:
+       glean:regression-test-lib,
+       glean:clang-derive-lib,
+       glean:indexers,
+       glean:lib
+    if !flag(clang-tests)
+        buildable: False
+
+
+-- left on the side for now, we need a Glean.DocBlock.Test module
+-- test-suite clang-test-docblock
+--     import: fb-haskell, fb-cpp, deps
+--     hs-source-dirs:
+--        glean/lang/clang/tests,
+--        glean/lang/clang/tests/github
+--     type: exitcode-stdio-1.0
+--     main-is: Glean/Clang/DocBlock.hs
+--     other-modules: Glean.Clang.Test.DerivePass
+--                    Glean.Clang.Test
+--                    Glean.Regression.Driver.DocBlock
+--     ghc-options: -main-is Glean.Clang.DocBlock
+--     build-depends:
+--        glean:regression-test-lib,
+--        glean:clang-derive-lib,
+--        glean:indexers,
+--        glean:lib
+--     if !flag(clang-tests)
+--         buildable: False
 
 test-suite hack-derive-test
     import: fb-haskell, fb-cpp, deps

--- a/glean/lang/clang/Glean/Indexer/Cpp.hs
+++ b/glean/lang/clang/Glean/Indexer/Cpp.hs
@@ -196,9 +196,8 @@ inTreeSearchPath :: FilePath -> Maybe FilePath
 inTreeSearchPath exePath = do
   case reverse (splitDirectories  exePath) of
     -- definitely running in tree:
-    ("glean":"glean":"build":"glean":"x":_:xs) -> Just $ joinPath (reverse xs)
-    ("clang-test-regression":"clang-test-regression":"build":"clang-test-regression":"t":_:xs) -> Just $
-      joinPath (reverse xs)
+    (_:_:"build":_:ty:_:xs)
+      | ty `elem` ["x", "t"] -> Just $ joinPath (reverse xs)
     _ -> Nothing
 
 -- do a silly recursive search in the dist-newstyle under the ghc dirs

--- a/glean/lang/clang/tests/Glean/Clang/Test.hs
+++ b/glean/lang/clang/tests/Glean/Clang/Test.hs
@@ -5,8 +5,7 @@
   This source code is licensed under the BSD-style license found in the
   LICENSE file in the root directory of this source tree.
 -}
-
-module Glean.Clang.Test (driver, driverWith) where
+module Glean.Clang.Test (driver, driverWith, Options) where
 
 import qualified Data.Aeson as Aeson
 import Data.List
@@ -23,6 +22,8 @@ import Glean.Util.CxxXRef
 import Debug.Trace (trace)
 
 import qualified Data.HashMap.Strict as HM
+
+type Options = Clang
 
 driverWith :: Bool -> Driver Clang
 driverWith deriveToo =

--- a/glean/lang/clang/tests/github/Glean/Clang/CodeMarkup.hs
+++ b/glean/lang/clang/tests/github/Glean/Clang/CodeMarkup.hs
@@ -1,0 +1,12 @@
+module Glean.Clang.CodeMarkup where
+
+import System.Environment
+
+import qualified Glean.Regression.Driver.DeriveForCodemarkup as D
+
+main :: IO ()
+main = getArgs >>= \args ->
+  withArgs (args ++ ["--root", path]) D.main
+
+  where
+    path = "glean/lang/codemarkup/tests/clang"

--- a/glean/lang/clang/tests/github/Glean/Clang/DeriveAttrs.hs
+++ b/glean/lang/clang/tests/github/Glean/Clang/DeriveAttrs.hs
@@ -1,0 +1,12 @@
+module Glean.Clang.DeriveAttrs where
+
+import System.Environment
+
+import qualified Glean.Regression.Driver.DeriveFunctionDeclAttribute as D
+
+main :: IO ()
+main = getArgs >>= \args ->
+  withArgs (args ++ ["--root", path]) D.main
+
+  where
+    path = "glean/lang/clang/tests/regression_derive-attributes"

--- a/glean/lang/clang/tests/github/Glean/Clang/DeriveByName.hs
+++ b/glean/lang/clang/tests/github/Glean/Clang/DeriveByName.hs
@@ -1,0 +1,12 @@
+module Glean.Clang.DeriveByName where
+
+import System.Environment
+
+import qualified Glean.Regression.Driver.DeriveDeclByName as D
+
+main :: IO ()
+main = getArgs >>= \args ->
+  withArgs (args ++ ["--root", path]) D.main
+
+  where
+    path = "glean/lang/clang/tests/regression_derive-decl-by-name"

--- a/glean/lang/clang/tests/github/Glean/Clang/DeriveFamilies.hs
+++ b/glean/lang/clang/tests/github/Glean/Clang/DeriveFamilies.hs
@@ -1,0 +1,12 @@
+module Glean.Clang.DeriveFamilies where
+
+import System.Environment
+
+import qualified Glean.Regression.Driver.DeriveDeclFamilies as D
+
+main :: IO ()
+main = getArgs >>= \args ->
+  withArgs (args ++ ["--root", path]) D.main
+
+  where
+    path = "glean/lang/clang/tests/regression_derive-decl-families"

--- a/glean/lang/clang/tests/github/Glean/Clang/DeriveFunCalls.hs
+++ b/glean/lang/clang/tests/github/Glean/Clang/DeriveFunCalls.hs
@@ -1,0 +1,12 @@
+module Glean.Clang.DeriveFunCalls where
+
+import System.Environment
+
+import qualified Glean.Regression.Driver.DeriveFunctionCalls as D
+
+main :: IO ()
+main = getArgs >>= \args ->
+  withArgs (args ++ ["--root", path]) D.main
+
+  where
+    path = "glean/lang/clang/tests/regression_derive-function-calls"

--- a/glean/lang/clang/tests/github/Glean/Clang/DeriveObjCInheritance.hs
+++ b/glean/lang/clang/tests/github/Glean/Clang/DeriveObjCInheritance.hs
@@ -1,0 +1,12 @@
+module Glean.Clang.DeriveObjCInheritance where
+
+import System.Environment
+
+import qualified Glean.Regression.Driver.DeriveObjcInheritance as D
+
+main :: IO ()
+main = getArgs >>= \args ->
+  withArgs (args ++ ["--root", path]) D.main
+
+  where
+    path = "glean/lang/clang/tests/regression_derive-objc-inheritance"

--- a/glean/lang/clang/tests/github/Glean/Clang/DocBlock.hs
+++ b/glean/lang/clang/tests/github/Glean/Clang/DocBlock.hs
@@ -1,0 +1,12 @@
+module Glean.Clang.DocBlock where
+
+import System.Environment
+
+import qualified Glean.Regression.Driver.DocBlock as D
+
+main :: IO ()
+main = getArgs >>= \args ->
+  withArgs (args ++ ["--root", path]) D.main
+
+  where
+    path = "glean/lang/clang/tests/regression_docblock"

--- a/glean/lang/clang/tests/github/Glean/Clang/Regression.hs
+++ b/glean/lang/clang/tests/github/Glean/Clang/Regression.hs
@@ -11,7 +11,6 @@ module Glean.Clang.Regression (main) where
 import System.Environment
 
 import qualified Glean.Regression.Driver.Clang as Clang
-import Glean.Regression.Snapshot
 
 main :: IO ()
 main = getArgs >>= \args ->


### PR DESCRIPTION
(This PR is based on top of #208 and #218 and should only be imported after these two have landed.)

Current status: `Cases: 56  Tried: 56  Errors: 0  Failures: 37`

Many/most failures look like this:

```
### Failure in: 0:55:xrefs/using-decl3       
glean/test/regression/Glean/Regression/Snapshot.hs:203
ppPPEntityLocation.perf: unexpected result
1c1
< { "@generated": null, "pp1.Define.1": 380, "src.File.1": 382 }
\ No newline at end of file
---
> { "@generated": null, "pp1.Define.1": 382, "src.File.1": 384 }
\ No newline at end of file
```

with those numbers being slightly different.

<details>
  <summary>Detailed logs of all 56 tests</summary>

[tests-codemarkup.log](https://github.com/facebookincubator/Glean/files/9114076/tests-codemarkup.log)

</details>