### PR TITLE
Change transformers bound to guarantee the existence of Control.Monad.Trans.Writer.CPS

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -121,7 +121,7 @@ common deps
         text ^>=1.2.3.0,
         bytestring ^>=0.10.8.2,
         vector ^>=0.12.0.1,
-        transformers ^>=0.5.5.0,
+        transformers ^>=0.5.6.2,
         network-uri ^>=2.6.1.0,
         stm ^>=2.5.0.0,
         directory ^>=1.3.1.5,


### PR DESCRIPTION
CI seems to hit the following error pretty regularly (see e.g [this run](https://github.com/facebookincubator/Glean/runs/7860367852?check_suite_focus=true)):

```
glean/db/Glean/Database/Janitor.hs:20:1: error:
    Could not find module ‘Control.Monad.Trans.Writer.CPS’
    Perhaps you meant
      Control.Monad.Trans.Writer (from transformers-0.5.5.0)
      Control.Monad.Trans.Writer.Lazy (from transformers-0.5.5.0)
      Control.Monad.Trans.Writer.Strict (from transformers-0.5.5.0)
    Use -v to see a list of the files searched for.
   |
20 | import Control.Monad.Trans.Writer.CPS
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cabal: Failed to build lib:db from glean-0.1.0.0 (which is required by exe:gen-schema from glean-0.1.0.0).
```

While I don't seem to be running into this myself, locally, for some reason, it seems to be making all CI jobs fail, recently. The fix is trivial, we just need to force cabal to pick a version of `transformers` that ships with the modules we need, which seems to have started with `0.5.6.*`. My local build uses `0.5.6.2` so that is the lower bound I'm using in this patch.

cc @simonmar 