### PR TITLE
Build system improvements

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install additional tools
         run: |
           apt-get update
-          apt-get install -y libxxhash-dev wget unzip libgmock-dev
+          apt-get install -y libxxhash-dev m4 rsync wget unzip libgmock-dev
 
       - name: Make utf8 default locale
         run: |

--- a/.github/workflows/ci-clang-rocksdb.yml
+++ b/.github/workflows/ci-clang-rocksdb.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install additional tools
         run: |
           apt-get update
-          apt-get install -y libxxhash-dev wget unzip libgmock-dev
+          apt-get install -y libxxhash-dev m4 rsync wget unzip libgmock-dev
 
       - name: Make utf8 default locale
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install additional tools
         run: |
           apt-get update
-          apt install -y ninja-build libxxhash-dev wget unzip clang-11 libclang-11-dev llvm-11-dev libgmock-dev
+          apt install -y ninja-build libxxhash-dev m4 rsync wget unzip clang-11 libclang-11-dev llvm-11-dev libgmock-dev
           apt-get remove -y libfmt-dev
 
       - name: Make utf8 default locale

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ glean/schema/v[0-9]*
 glean/lang/java-lsif/tests/cases/xrefs/target
 hsthrift
 dump.lsif
+settings.mk
 .vscode
 glean.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 dist-newstyle
 gen-hs2
 gen-cpp2
+glean.cabal
 glean/hs/Glean/RTS/Bytecode/Gen
 glean/rts/bytecode/gen
 glean/lang/clang/schema.h

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 *.save[0-9]*
+.build
 dist-newstyle
 gen-hs2
 gen-cpp2

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ EXTRA_GHC_OPTS ?=
 CABAL = $(CABAL_BIN) --jobs --ghc-options='$(EXTRA_GHC_OPTS)' \
             -vnormal+nowrap --project-file=$(PWD)/cabal.project
 
+# Allow developers to locally override things
+-include settings.mk
+
 BUILD_DIR = .build
 CODEGEN_DIR = $(BUILD_DIR)/def/codegen
 CXX_DIR = $(BUILD_DIR)/def/cxx

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ EXTRA_GHC_OPTS ?=
 CABAL = $(CABAL_BIN) --jobs --ghc-options='$(EXTRA_GHC_OPTS)' \
             -vnormal+nowrap --project-file=$(PWD)/cabal.project
 
-THRIFT_COMPILE := $(shell $(CABAL) -v0 list-bin exe:thrift-compiler)
-
 CODEGEN_DIR = .build/codegen
 
 BYTECODE_GEN= \
@@ -123,6 +121,7 @@ thrift-hs:: thrift-hsthrift-hs thrift-glean-hs
 .PHONY: thrift-compiler
 thrift-compiler::
 	(cd hsthrift && make CABAL="$(CABAL)" compiler)
+	$(eval THRIFT_COMPILE := $$(shell $$(CABAL) -v0 list-bin exe:thrift-compiler))
 
 .PHONY: thrift-hsthrift-hs
 thrift-hsthrift-hs::

--- a/Makefile
+++ b/Makefile
@@ -276,3 +276,13 @@ glean-clang:: gen-schema glean glean.cabal cxx-libraries
 .PHONY: glean-hiedb
 glean-hiedb:: glean.cabal cxx-libraries
 	$(CABAL) build hiedb-indexer
+
+define bash_macros
+call_cabal() {
+	$(CABAL) "$$@"
+}
+endef
+
+$(BUILD_DIR)/current.sh: force
+	$(file >$@,$(bash_macros))
+	@:

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ all:: thrift $(BYTECODE_GEN) gen-schema thrift-schema-hs glean
 glean::
 	$(CABAL) build glean glean-server glean-hyperlink
 
+.PHONY: gen-bytecode
+gen-bytecode: $(BYTECODE_GEN)
+
 # Note we don't rsync here because we have actual dependencies
 $(BYTECODE_GEN) &: $(BYTECODE_SRCS)
 	$(CABAL) run gen-bytecode-cpp -- --install_dir=glean/rts

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ BYTECODE_SRCS= \
 
 all:: thrift $(BYTECODE_GEN) gen-schema thrift-schema-hs glean
 
+# Targets in this file invoke Cabal and hence can't be built in parallel
+.NOTPARALLEL:
+
 .PHONY: glean
 glean::
 	$(CABAL) build glean glean-server glean-hyperlink

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ CODEGEN_DIR = .build/codegen
 BYTECODE_GEN= \
 	glean/rts/bytecode/gen/evaluate.h \
 	glean/rts/bytecode/gen/instruction.h \
-	glean/hs/Glean/Bytecode/Gen/Instruction.hs \
-	glean/hs/Glean/Bytecode/Gen/Issue.hs \
-	glean/hs/Glean/Bytecode/Gen/Version.hs
+	glean/hs/Glean/RTS/Bytecode/Gen/Instruction.hs \
+	glean/hs/Glean/RTS/Bytecode/Gen/Issue.hs \
+	glean/hs/Glean/RTS/Bytecode/Gen/Version.hs
 
 BYTECODE_SRCS= \
 	$(wildcard glean/bytecode/*/Glean/Bytecode/*/*.hs) \

--- a/glean.cabal
+++ b/glean.cabal
@@ -627,8 +627,6 @@ library client-cpp
         glean/interprocess/cpp/worklist.cpp,
         glean/interprocess/cpp/counters.cpp
     cxx-options: -DOSS=1
-    if arch(x86_64)
-      cxx-options: -DGLEAN_X86_64
     include-dirs: .
     install-includes:
         glean/cpp/glean.h

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -15,6 +15,7 @@ maintainer:          Glean-team@fb.com
 copyright:           (c) Facebook, All Rights Reserved
 build-type:          Simple
 extra-source-files:  CHANGELOG.md
+CXX_EXTRA_SOURCE_FILES
 
 common fb-haskell
     default-language: Haskell2010
@@ -55,6 +56,7 @@ common fb-cpp
      cxx-options: -march=haswell
   if flag(opt)
      cxx-options: -O3
+  CXX_EXTRA_LIB_DIRS
 
 common exe
   ghc-options: -threaded
@@ -197,9 +199,7 @@ library config
         glean/config/recipes/gen-hs2
         glean/config/server/gen-hs2
         glean/config/client/gen-hs2
-    cxx-sources:
-        glean/config/recipes/gen-cpp2/recipes_types.cpp
-        glean/config/recipes/gen-cpp2/recipes_data.cpp
+    CXX_LIB_glean_cpp_config
     exposed-modules:
         Glean.Recipes.Types
         Glean.Service.Types
@@ -283,18 +283,12 @@ library if-fb303-cpp
     import: fb-haskell, fb-cpp, deps
     visibility: public
     include-dirs: .
-    cxx-sources:
-        glean/github/if/gen-cpp2/fb303_core_types.cpp
-        glean/github/if/gen-cpp2/fb303_core_data.cpp
-        glean/github/if/gen-cpp2/fb303_types.cpp
-        glean/github/if/gen-cpp2/fb303_data.cpp
+    CXX_LIB_glean_cpp_if_fb303
 
 library if-glean-cpp
     import: fb-haskell, fb-cpp, deps
     visibility: public
-    cxx-sources:
-        glean/if/gen-cpp2/glean_types.cpp
-        glean/if/gen-cpp2/glean_data.cpp
+    CXX_LIB_glean_cpp_if
     build-depends:
         glean:if-fb303-cpp,
         glean:config
@@ -302,9 +296,7 @@ library if-glean-cpp
 library if-internal-cpp
     import: fb-haskell, fb-cpp, deps
     visibility: public
-    cxx-sources:
-        glean/if/gen-cpp2/internal_types.cpp
-        glean/if/gen-cpp2/internal_data.cpp
+    CXX_LIB_glean_cpp_if_internal
     build-depends:
         glean:if-fb303-cpp,
         glean:if-glean-cpp,
@@ -314,48 +306,15 @@ library rts
     import: fb-haskell, fb-cpp, deps
     visibility: public
     include-dirs: .
-    cxx-sources:
-        glean/rts/binary.cpp
-        glean/rts/cache.cpp
-        glean/rts/define.cpp
-        glean/rts/error.cpp
-        glean/rts/fact.cpp
-        glean/rts/factset.cpp
-        glean/rts/ffi.cpp
-        glean/rts/inventory.cpp
-        glean/rts/json.cpp
-        glean/rts/lookup.cpp
-        glean/rts/nat.cpp
-        glean/rts/ownership.cpp
-        glean/rts/ownership/derived.cpp
-        glean/rts/ownership/setu32.cpp
-        glean/rts/ownership/slice.cpp
-        glean/rts/ownership/uset.cpp
-        glean/rts/prim.cpp
-        glean/rts/query.cpp
-        glean/rts/sanity.cpp
-        glean/rts/string.cpp
-        glean/rts/substitution.cpp
-        glean/rts/thrift.cpp
-        glean/rts/timer.cpp
-        glean/rts/validate.cpp
-        glean/rts/bytecode/subroutine.cpp
+    CXX_LIB_glean_cpp_rts
     pkgconfig-depends: libfolly, libunwind, libglog, icu-uc, gflags, libxxhash
-    cxx-options: -DOSS=1
     build-depends:
         glean:if-internal-cpp,
 
 library rocksdb
     import: fb-haskell, fb-cpp, deps
     visibility: private
-    cxx-sources:
-        glean/rocksdb/ffi.cpp
-        glean/rocksdb/rocksdb.cpp
-    -- -fno-rtti is needed because RocksDB is compiled with it, and we
-    -- get linker errors for references to missing typeinfo symbols if
-    -- we don't.
-    cxx-options: -fno-rtti
-    cxx-options: -DOSS=1
+    CXX_LIB_glean_cpp_rocksdb
     extra-libraries: rocksdb
     build-depends:
         glean:rocksdb-stats,
@@ -365,8 +324,7 @@ library rocksdb
 library rocksdb-stats
     import: fb-haskell, fb-cpp, deps
     visibility: private
-    cxx-sources:
-        glean/rocksdb/stats.cpp
+    CXX_LIB_glean_cpp_rocksdb_stats
     build-depends:
         glean:rts,
 
@@ -621,12 +579,7 @@ library client-hs-local
 library client-cpp
     import: fb-cpp, deps
     visibility: public
-    cxx-sources:
-        glean/cpp/sender.cpp,
-        glean/cpp/glean.cpp,
-        glean/interprocess/cpp/worklist.cpp,
-        glean/interprocess/cpp/counters.cpp
-    cxx-options: -DOSS=1
+    CXX_LIB_glean_cpp_client
     include-dirs: .
     install-includes:
         glean/cpp/glean.h

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -34,5 +34,10 @@ if test ! -d hsthrift; then
     git clone "${HSTHRIFT_REPO}"
 fi
 
+# Make sure this is available for a subsequent cabal update
+if test ! -f glean.cabal; then
+    make glean.cabal
+fi
+
 cd hsthrift
 ./new_install_deps.sh "${EXTRA_DEPS}" --threads "${THREADS}"

--- a/mk/cxx-cabal.mk
+++ b/mk/cxx-cabal.mk
@@ -1,0 +1,14 @@
+# Building C++ libraries via Cabal
+#
+# Just add cxx-sources and cxx-options for each library
+
+define CXX_DEFS_M4
+m4_divert(-1)
+m4_define(`CXX_EXTRA_SOURCE_FILES')
+m4_define(`CXX_EXTRA_LIB_DIRS')
+$(foreach lib, $(CXX_LIBRARIES),
+m4_define(`CXX_LIB_$(lib)', $(subst $() $(),
+        ,cxx-sources: $(patsubst %,%,$(CXX_SOURCES_$(lib))))$(if $(CXX_FLAGS_$(lib)),
+    cxx-options: $(CXX_FLAGS_$(lib)))))
+m4_divert(0)m4_dnl
+endef

--- a/mk/cxx-make.mk
+++ b/mk/cxx-make.mk
@@ -4,7 +4,7 @@ FOLLY_INCLUDES := $(shell pkg-config --cflags-only-I libfolly)
 ARCH := $(firstword $(subst -, ,$(shell $(CC) -dumpmachine)))
 
 # TODO: This is duplicated in glean.cabal.in
-CXXFLAGS = -I. -Ihsthrift/common/util $(FOLLY_INCLUDES) -std=c++17 
+CXXFLAGS += -I. -Ihsthrift/common/util $(FOLLY_INCLUDES) -std=c++17
 ifeq ($(ARCH), x86_64)
 CXXFLAGS += -march=haswell
 endif

--- a/mk/cxx-make.mk
+++ b/mk/cxx-make.mk
@@ -1,0 +1,70 @@
+# Building C++ libraries via make
+
+FOLLY_INCLUDES := $(shell pkg-config --cflags-only-I libfolly)
+ARCH := $(firstword $(subst -, ,$(shell $(CC) -dumpmachine)))
+
+# TODO: This is duplicated in glean.cabal.in
+CXXFLAGS = -I. -Ihsthrift/common/util $(FOLLY_INCLUDES) -std=c++17 
+ifeq ($(ARCH), x86_64)
+CXXFLAGS += -march=haswell
+endif
+
+ifndef CXX_DIR
+$(error CXX_DIR is not set)
+endif
+
+# Target directory for .a files
+CXX_LIB_DIR = $(CXX_DIR)/lib
+
+# Target directory for .o files
+CXX_OBJ_DIR = $(CXX_DIR)/obj
+
+# Actually build the libraries - the individual targets are defined via
+# define_library below
+cxx-libraries: $(CXX_LIBRARIES)
+
+# For each library xxx, we define some variables and a target xxx which builds
+# the actual library. We also track include dependencies via the usual
+# mechanism.
+#
+# Variables:
+#   CXX_OBJECTS_xxx - list of .o files
+#   CXX_LIB_xxx - path to .a file
+#
+# TODO: We compile everything with -fPIC so that it can be used in both static
+# and dynamic builds. We might want to build two versions eventually. Note that
+# we probably *don't* want to build actual shared libraries because then we'd
+# have to fiddle with LD_LIBRARY_PATH to actual run things.
+#
+define define_library
+ CXX_OBJECTS_$1 = $$(addprefix $$(CXX_OBJ_DIR)/,$$(CXX_SOURCES_$1:.cpp=.o))
+ CXX_LIB_$1 = $$(CXX_LIB_DIR)/lib$1.a
+ .PHONY: $1
+ $1:: $$(CXX_LIB_$1)
+
+ $$(CXX_LIB_$1): $$(CXX_OBJECTS_$1)
+	@mkdir -p $$(@D)
+	$$(AR) rcs $$@ $$^
+
+ $$(CXX_OBJECTS_$1): $(CXX_OBJ_DIR)/%.o: %.cpp
+	@mkdir -p $$(@D)
+	$$(CXX) -o $$@ $$(CXXFLAGS) $$(CXX_FLAGS_$1) -fPIC -MMD -MP -c $$<
+
+ -include $$(CXX_OBJECTS_$1:.o=.d)
+endef
+
+# Call define_library for each library
+$(foreach lib, $(CXX_LIBRARIES), $(eval $(call define_library,$(lib))))
+
+# Track .a files via extra-source-files - a terrible hack but seems to be the
+# only way to recompile things when the libraries change, see
+# https://github.com/haskell/cabal/issues/4746.
+define CXX_DEFS_M4
+m4_divert(-1)
+m4_define(`CXX_EXTRA_SOURCE_FILES', extra-source-files:$(foreach lib, $(CXX_LIBRARIES),
+    $(CXX_LIB_$(lib))))
+m4_define(`CXX_EXTRA_LIB_DIRS', extra-lib-dirs: $(PWD)/$(CXX_LIB_DIR)))
+$(foreach lib, $(CXX_LIBRARIES),
+m4_define(`CXX_LIB_$(lib)', extra-libraries: $(lib)))
+m4_divert(0)m4_dnl
+endef

--- a/mk/cxx.mk
+++ b/mk/cxx.mk
@@ -1,0 +1,120 @@
+#
+# C++ library definitions
+#
+# To define a C++ library glean_cpp_lib, add
+#
+# CXX_SOURCES_glean_cpp_lib = ...
+#
+# Additionaly, we support:
+#
+# CXX_FLAGS_glean_cpp_lib = ... - sets additional C++ flags for the library
+#
+
+CXX_SOURCES_glean_cpp_if_fb303 = \
+    glean/github/if/gen-cpp2/fb303_core_types.cpp \
+    glean/github/if/gen-cpp2/fb303_core_data.cpp \
+    glean/github/if/gen-cpp2/fb303_types.cpp \
+    glean/github/if/gen-cpp2/fb303_data.cpp
+
+CXX_SOURCES_glean_cpp_config = \
+    glean/config/recipes/gen-cpp2/recipes_types.cpp \
+    glean/config/recipes/gen-cpp2/recipes_data.cpp
+
+CXX_SOURCES_glean_cpp_if = \
+    glean/if/gen-cpp2/glean_types.cpp \
+    glean/if/gen-cpp2/glean_data.cpp
+
+CXX_SOURCES_glean_cpp_if_internal = \
+    glean/if/gen-cpp2/internal_types.cpp \
+    glean/if/gen-cpp2/internal_data.cpp
+
+CXX_SOURCES_glean_cpp_rts = \
+    glean/rts/binary.cpp \
+    glean/rts/cache.cpp \
+    glean/rts/define.cpp \
+    glean/rts/error.cpp \
+    glean/rts/fact.cpp \
+    glean/rts/factset.cpp \
+    glean/rts/ffi.cpp \
+    glean/rts/inventory.cpp \
+    glean/rts/json.cpp \
+    glean/rts/lookup.cpp \
+    glean/rts/nat.cpp \
+    glean/rts/ownership.cpp \
+    glean/rts/ownership/derived.cpp \
+    glean/rts/ownership/setu32.cpp \
+    glean/rts/ownership/slice.cpp \
+    glean/rts/ownership/uset.cpp \
+    glean/rts/prim.cpp \
+    glean/rts/query.cpp \
+    glean/rts/sanity.cpp \
+    glean/rts/string.cpp \
+    glean/rts/substitution.cpp \
+    glean/rts/thrift.cpp \
+    glean/rts/timer.cpp \
+    glean/rts/validate.cpp \
+    glean/rts/bytecode/subroutine.cpp
+CXX_FLAGS_glean_cpp_rts = -DOSS=1
+
+CXX_SOURCES_glean_cpp_rocksdb_stats = \
+    glean/rocksdb/stats.cpp
+
+CXX_SOURCES_glean_cpp_rocksdb = \
+    glean/rocksdb/ffi.cpp \
+    glean/rocksdb/rocksdb.cpp
+# -fno-rtti is needed because RocksDB is compiled with it, and we
+# get linker errors for references to missing typeinfo symbols if
+# we don't.
+CXX_FLAGS_glean_cpp_rocksdb = -fno-rtti -DOSS=1
+
+CXX_SOURCES_glean_cpp_client = \
+    glean/cpp/sender.cpp \
+    glean/cpp/glean.cpp \
+    glean/interprocess/cpp/worklist.cpp \
+    glean/interprocess/cpp/counters.cpp
+CXX_FLAGS_glean_cpp_client = -DOSS=1
+
+# End of C++ library definitions
+
+# Determine all C++ libraries
+CXX_LIBRARIES = $(subst CXX_SOURCES_,,$(filter CXX_SOURCES_%, $(.VARIABLES)))
+
+.PHONY: cxx-libraries
+cxx-libraries:
+
+# Include the right settings
+#
+# The included makefile is supposed to add dependencies to cxx-libraries as
+# necessary and also to define a variable CXX_DEFS_M4 whose value is a series
+# of m4 defines for the following macros:
+#
+# CXX_EXTRA_SOURCE_FILES - extra-source-files: ...
+#   Additional files to track for Cabal (typically .a files)
+#   
+# CXX_EXTRA_LIB_DIRS - extra-lib-dirs: ...
+#   Additional library directories, MUST be absolute (Cabal doesn't support
+#   relative ones)
+#
+# CXX_LIB_xxx
+#   Dependencies for library xxx - either cxx-sources and cxx-options (if
+#   compiled via Cabal) or extra-libraries (if compiled via make)
+# 
+ifeq ($(CXX_MODE),make)
+include mk/cxx-make.mk
+else
+include mk/cxx-cabal.mk
+endif
+
+# Generate defs.m4 which is used by glean.cabal.in
+.PHONY: force
+
+# Make sure we keep the timestamp if the contents hasn't changed
+$(CXX_DIR)/defs.m4: force | $(CXX_DIR)
+	$(file >$@.new,$(CXX_DEFS_M4))
+	@cmp -s $@ $@.new || mv $@.new $@
+	@rm -rf $@.new
+
+# Has to be a separate target because we can have shell commands before
+# $(file) in the rule above.
+$(CXX_DIR):
+	@mkdir -p $@

--- a/mk/mode-dev.mk
+++ b/mk/mode-dev.mk
@@ -1,0 +1,4 @@
+# dev mode - unoptimised builds
+
+CABAL_CONFIG_FLAGS = --builddir=$(PWD)/$(MODE_DIR)/dist-newbuild
+CXX_MODE=make

--- a/mk/mode-opt.mk
+++ b/mk/mode-opt.mk
@@ -1,0 +1,5 @@
+# opt mode - optimised builds + benchmarks
+
+CABAL_CONFIG_FLAGS = --builddir=$(PWD)/$(MODE_DIR)/dist-newbuild --flags=opt --flags=benchmarks
+CXX_MODE=make
+export CXXFLAGS += -O3 -DNDEBUG

--- a/quick.sh
+++ b/quick.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+set -e
+
+fatal() {
+  echo "$@" 1>&2
+  exit 1
+}
+
+MAKE_ARGS=()
+
+for arg in "$@"; do
+  case $arg in
+    build|run|test)
+      ACTION="$1"
+      shift
+      break
+      ;;
+    *)
+      MAKE_ARGS+=("${arg}")
+      shift
+      ;;
+  esac
+done
+
+TARGET=$1
+shift
+
+if [ -z "$ACTION" ]; then
+  fatal "No action specified"
+fi
+if [ -z "$TARGET" ]; then
+  fatal "No target specified"
+fi
+
+make "${MAKE_ARGS[@]}" .build/current.sh glean.cabal cxx-libraries
+
+. .build/current.sh
+
+call_cabal $ACTION $TARGET -- "$@"


### PR DESCRIPTION
Various improvements to the OSS build system. Together, they give me a workable dev environment. There should be (hopefully) no changes to the default `make` and `make test`.

Note that this now generated `glean.cabal` from `glean.cabal.in` and the C++ libs need to be specified in `mk/cxx.mk` rather  than in `glean.cabal`.