### PR TITLE
Define NDEBUG in glean.cabal for opt build

### DIFF
--- a/glean.cabal
+++ b/glean.cabal
@@ -54,7 +54,7 @@ common fb-cpp
   if arch(x86_64)
      cxx-options: -march=haswell
   if flag(opt)
-     cxx-options: -O3
+     cxx-options: -O3 -DNDEBUG
 
 common exe
   ghc-options: -threaded


### PR DESCRIPTION
This is the right thing to do and also seem to make at least query-bench
a bit faster.