### PR TITLE
[bytecode] Support polymorphic instructions

### DIFF
--- a/glean/bytecode/Glean/Bytecode/Types.hs
+++ b/glean/bytecode/Glean/Bytecode/Types.hs
@@ -8,6 +8,8 @@
 
 module Glean.Bytecode.Types
   ( Ty(..)
+  , Ordered
+  , Addable
   , Register(..)
   , Label(..)
   , castRegister
@@ -26,6 +28,16 @@ data Ty
   | BinaryOutputPtr -- ^ pointer to binary::Output (temporary, will be removed)
   | Fun [Ty] -- ^ pointer to syscall (temporary, will be removed)
   deriving(Eq, Show)
+
+-- | Types which can be compared
+class Ordered (t :: Ty)
+instance Ordered 'Word
+instance Ordered 'DataPtr
+
+-- | Types which can be added
+class Addable (t :: Ty) (u :: Ty)
+instance Addable 'Word 'Word
+instance Addable 'DataPtr 'Word
 
 -- | Typed registers
 newtype Register (ty :: Ty) = Register { fromRegister :: Word64 }

--- a/glean/bytecode/def/Glean/Bytecode/Generate/Instruction.hs
+++ b/glean/bytecode/def/Glean/Bytecode/Generate/Instruction.hs
@@ -32,6 +32,7 @@ import Glean.Bytecode.Types
 data Insn = Insn
   { insnName :: Text
   , insnEffects :: [Effect]
+  , insnContext :: [Text]
   , insnArgs :: [Arg]
   }
 
@@ -50,9 +51,19 @@ data Arg = Arg
 -- | Argument type
 data ArgTy
   = Imm Ty -- ^ immediate value in instruction stream
-  | Reg Ty Usage -- ^ register argument
+  | Reg (Maybe Text) Ty Usage -- ^ register argument
   | Offsets -- ^ array of jump offsets (length + array in the insn stream)
   | Regs [Ty] -- ^ list of registers (array without length in the insn stream)
+
+-- | Register argument of a particular type
+reg :: Ty -> Usage -> ArgTy
+reg = Reg Nothing
+
+-- | Polymorphic register argument - `Text` is the type variable and `Ty` the
+-- type actually stored in the instruction (since we don't really need
+-- existentials there)
+polyReg :: Text -> Ty -> Usage -> ArgTy
+polyReg = Reg . Just
 
 -- | How an register is used
 data Usage
@@ -80,300 +91,300 @@ instructions :: [Insn]
 instructions =
   [
     -- Decode a Nat from memory into a register.
-    Insn "InputNat" []
-      [ Arg "begin" $ Reg DataPtr Update
-      , Arg "end" $ Reg DataPtr Load
-      , Arg "dst" $ Reg Word Store ]
+    Insn "InputNat" [] []
+      [ Arg "begin" $ reg DataPtr Update
+      , Arg "end" $ reg DataPtr Load
+      , Arg "dst" $ reg Word Store ]
 
     -- Advance begin by size bytes, and bounds-check against end
-  , Insn "InputBytes" []
-      [ Arg "begin" $ Reg DataPtr Update
-      , Arg "end" $ Reg DataPtr Load
-      , Arg "size" $ Reg Word Load ]
+  , Insn "InputBytes" [] []
+      [ Arg "begin" $ reg DataPtr Update
+      , Arg "end" $ reg DataPtr Load
+      , Arg "size" $ reg Word Load ]
 
     -- Validate and skip over an encoded UTF8 string
-  , Insn "InputSkipUntrustedString" []
-      [ Arg "begin" $ Reg DataPtr Update
-      , Arg "end" $ Reg DataPtr Load ]
+  , Insn "InputSkipUntrustedString" [] []
+      [ Arg "begin" $ reg DataPtr Update
+      , Arg "end" $ reg DataPtr Load ]
 
     -- Check that the input starts with the given literal, and then skip past it
-  , Insn "InputShiftLit" []
-      [ Arg "begin" $ Reg DataPtr Update
-      , Arg "end" $ Reg DataPtr Load
+  , Insn "InputShiftLit" [] []
+      [ Arg "begin" $ reg DataPtr Update
+      , Arg "end" $ reg DataPtr Load
       , Arg "lit" $ Imm Literal
-      , Arg "match" $ Reg Word Store ]
+      , Arg "match" $ reg Word Store ]
 
     -- Check that the input starts with the given byte sequence, and
     -- then skip past it
-  , Insn "InputShiftBytes" []
-      [ Arg "begin" $ Reg DataPtr Update
-      , Arg "end" $ Reg DataPtr Load
-      , Arg "ptr" $ Reg DataPtr Load
-      , Arg "ptrend" $ Reg DataPtr Load
-      , Arg "match" $ Reg Word Store ]
+  , Insn "InputShiftBytes" [] []
+      [ Arg "begin" $ reg DataPtr Update
+      , Arg "end" $ reg DataPtr Load
+      , Arg "ptr" $ reg DataPtr Load
+      , Arg "ptrend" $ reg DataPtr Load
+      , Arg "match" $ reg Word Store ]
 
     -- Decode a Nat from memory
-  , Insn "InputSkipNat" []
-      [ Arg "begin" $ Reg DataPtr Update
-      , Arg "end" $ Reg DataPtr Load ]
+  , Insn "InputSkipNat" [] []
+      [ Arg "begin" $ reg DataPtr Update
+      , Arg "end" $ reg DataPtr Load ]
 
     -- Skip over an encoded UTF8 string in a binary::Input. The string must be
     -- valid (this is not checked).
-  , Insn "InputSkipTrustedString" []
-      [ Arg "begin" $ Reg DataPtr Update
-      , Arg "end" $ Reg DataPtr Load ]
+  , Insn "InputSkipTrustedString" [] []
+      [ Arg "begin" $ reg DataPtr Update
+      , Arg "end" $ reg DataPtr Load ]
 
     -- Reset a binary::Output
-  , Insn "ResetOutput" []
-      [ Arg "output" $ Reg BinaryOutputPtr Load ]
+  , Insn "ResetOutput" [] []
+      [ Arg "output" $ reg BinaryOutputPtr Load ]
 
     -- Encode a Nat in a register and store it in a binary::Output.
-  , Insn "OutputNat" []
-      [ Arg "src" $ Reg Word Load
-      , Arg "output" $ Reg BinaryOutputPtr Load ]
+  , Insn "OutputNat" [] []
+      [ Arg "src" $ reg Word Load
+      , Arg "output" $ reg BinaryOutputPtr Load ]
 
     -- Encode an immediate Nat and store it in a binary::Output.
-  , Insn "OutputNatImm" []
+  , Insn "OutputNatImm" [] []
       [ Arg "src" $ Imm Word
-      , Arg "output" $ Reg BinaryOutputPtr Load ]
+      , Arg "output" $ reg BinaryOutputPtr Load ]
 
     -- Encode a byte in a binary::Output
-  , Insn "OutputByteImm" []
+  , Insn "OutputByteImm" [] []
       [ Arg "src" $ Imm Word
-      , Arg "output" $ Reg BinaryOutputPtr Load ]
+      , Arg "output" $ reg BinaryOutputPtr Load ]
 
     -- Write a sequence of bytes to a binary::Output.
-  , Insn "OutputBytes" []
-      [ Arg "ptr" $ Reg DataPtr Load
-      , Arg "end" $ Reg DataPtr Load
-      , Arg "output" $ Reg BinaryOutputPtr Load ]
+  , Insn "OutputBytes" [] []
+      [ Arg "ptr" $ reg DataPtr Load
+      , Arg "end" $ reg DataPtr Load
+      , Arg "output" $ reg BinaryOutputPtr Load ]
 
     -- String toLower
-  , Insn "OutputStringToLower" []
-      [ Arg "begin" $ Reg DataPtr Load
-      , Arg "end" $ Reg DataPtr Load
-      , Arg "dst" $ Reg BinaryOutputPtr Load ]
+  , Insn "OutputStringToLower" [] []
+      [ Arg "begin" $ reg DataPtr Load
+      , Arg "end" $ reg DataPtr Load
+      , Arg "dst" $ reg BinaryOutputPtr Load ]
 
     -- converts [RelByteSpan] to [ByteSpan]
-  , Insn "OutputRelToAbsByteSpans" []
-      [ Arg "begin" $ Reg DataPtr Load
-      , Arg "end" $ Reg DataPtr Load
-      , Arg "dst" $ Reg BinaryOutputPtr Load ]
+  , Insn "OutputRelToAbsByteSpans" [] []
+      [ Arg "begin" $ reg DataPtr Load
+      , Arg "end" $ reg DataPtr Load
+      , Arg "dst" $ reg BinaryOutputPtr Load ]
 
     -- Get the contents of a binary::Output as a pointer and
     -- length. Note that these are only valid until the next operation
     -- on the binary::Output
-  , Insn "GetOutput" []
-      [ Arg "output" $ Reg BinaryOutputPtr Load
-      , Arg "ptr" $ Reg DataPtr Store
-      , Arg "end" $ Reg DataPtr Store ]
+  , Insn "GetOutput" [] []
+      [ Arg "output" $ reg BinaryOutputPtr Load
+      , Arg "ptr" $ reg DataPtr Store
+      , Arg "end" $ reg DataPtr Store ]
 
     -- Get the number of bytes in the output
-  , Insn "GetOutputSize" []
-      [ Arg "output" $ Reg BinaryOutputPtr Load
-      , Arg "dst" $ Reg Word Store ]
+  , Insn "GetOutputSize" [] []
+      [ Arg "output" $ reg BinaryOutputPtr Load
+      , Arg "dst" $ reg Word Store ]
 
     -- Write a constant into a register.
-  , Insn "LoadConst" []
+  , Insn "LoadConst" [] []
       [ Arg "imm" $ Imm Word
-      , Arg "dst" $ Reg Word Store ]
+      , Arg "dst" $ reg Word Store ]
 
     -- Load the address and size of a literal
-  , Insn "LoadLiteral" []
+  , Insn "LoadLiteral" [] []
       [ Arg "lit" $ Imm Literal
-      , Arg "ptr" $ Reg DataPtr Store
-      , Arg "end" $ Reg DataPtr Store ]
+      , Arg "ptr" $ reg DataPtr Store
+      , Arg "end" $ reg DataPtr Store ]
 
     -- Copy a register into another one.
-  , Insn "LoadReg" []
-      [ Arg "src" $ Reg Word Load
-      , Arg "dst" $ Reg Word Store ]
+  , Insn "Move" [] []
+      [ Arg "src" $ polyReg "a" Word Load
+      , Arg "dst" $ polyReg "a" Word Store ]
 
     -- Subtract a constant from a register.
-  , Insn "SubConst" []
+  , Insn "SubConst" [] []
       [ Arg "imm" $ Imm Word
-      , Arg "dst" $ Reg Word Update ]
+      , Arg "dst" $ reg Word Update ]
 
     -- Subtract a register from a register.
-  , Insn "Sub" []
-      [ Arg "src" $ Reg Word Load
-      , Arg "dst" $ Reg Word Update ]
+  , Insn "Sub" [] ["Addable a b"]
+      [ Arg "src" $ polyReg "b" Word Load
+      , Arg "dst" $ polyReg "a" Word Update ]
 
     -- Add a constant to a register.
-  , Insn "AddConst" []
+  , Insn "AddConst" [] ["Addable a 'Word"]
       [ Arg "imm" $ Imm Word
-      , Arg "dst" $ Reg Word Update ]
+      , Arg "dst" $ polyReg "a" Word Update ]
 
     -- Add a register to another register
-  , Insn "Add" []
-      [ Arg "src" $ Reg Word Load
-      , Arg "dst" $ Reg Word Update ]
+  , Insn "Add" [] ["Addable a b"]
+      [ Arg "src" $ polyReg "b" Word Load
+      , Arg "dst" $ polyReg "a" Word Update ]
 
     -- Subtract pointers
-  , Insn "PtrDiff" []
-      [ Arg "src1" $ Reg DataPtr Load
-      , Arg "src2" $ Reg DataPtr Load
-      , Arg "dst" $ Reg Word Store ]
+  , Insn "PtrDiff" [] []
+      [ Arg "src1" $ reg DataPtr Load
+      , Arg "src2" $ reg DataPtr Load
+      , Arg "dst" $ reg Word Store ]
 
-  , Insn "LoadLabel" []
+  , Insn "LoadLabel" [] []
       [ Arg "lbl" $ Imm Offset
-      , Arg "dst" $ Reg Offset Store ]
+      , Arg "dst" $ reg Offset Store ]
 
     -- Unconditional jump.
-  , Insn "Jump" [EndBlock]
+  , Insn "Jump" [EndBlock] []
       [ Arg "tgt" $ Imm Offset ]
 
-  , Insn "JumpReg" [EndBlock]
-      [ Arg "tgt" $ Reg Offset Load ]
+  , Insn "JumpReg" [EndBlock] []
+      [ Arg "tgt" $ reg Offset Load ]
 
     -- Jump if a register is 0.
-  , Insn "JumpIf0" []
-      [ Arg "reg" $ Reg Word Load
+  , Insn "JumpIf0" [] []
+      [ Arg "reg" $ reg Word Load
       , Arg "tgt" $ Imm Offset ]
 
     -- Jump if a register is not 0.
-  , Insn "JumpIfNot0" []
-      [ Arg "reg" $ Reg Word Load
+  , Insn "JumpIfNot0" [] []
+      [ Arg "reg" $ reg Word Load
       , Arg "tgt" $ Imm Offset ]
 
     -- Jump if two registers are equal.
-  , Insn "JumpIfEq" []
-      [ Arg "reg1" $ Reg Word Load
-      , Arg "reg2" $ Reg Word Load
+  , Insn "JumpIfEq" [] []
+      [ Arg "reg1" $ polyReg "a" Word Load
+      , Arg "reg2" $ polyReg "a" Word Load
       , Arg "tgt" $ Imm Offset ]
 
     -- Jump if two registers are not equal.
-  , Insn "JumpIfNe" []
-      [ Arg "reg1" $ Reg Word Load
-      , Arg "reg2" $ Reg Word Load
+  , Insn "JumpIfNe" [] []
+      [ Arg "reg1" $ polyReg "a" Word Load
+      , Arg "reg2" $ polyReg "a" Word Load
       , Arg "tgt" $ Imm Offset ]
 
     -- Jump if a > b.
-  , Insn "JumpIfGt" []
-      [ Arg "reg1" $ Reg Word Load
-      , Arg "reg2" $ Reg Word Load
+  , Insn "JumpIfGt" [] ["Ordered a"]
+      [ Arg "reg1" $ polyReg "a" Word Load
+      , Arg "reg2" $ polyReg "a" Word Load
       , Arg "tgt" $ Imm Offset ]
 
     -- Jump if a >= b.
-  , Insn "JumpIfGe" []
-      [ Arg "reg1" $ Reg Word Load
-      , Arg "reg2" $ Reg Word Load
+  , Insn "JumpIfGe" [] ["Ordered a"]
+      [ Arg "reg1" $ polyReg "a" Word Load
+      , Arg "reg2" $ polyReg "a" Word Load
       , Arg "tgt" $ Imm Offset ]
 
     -- Jump if a < b.
-  , Insn "JumpIfLt" []
-      [ Arg "reg1" $ Reg Word Load
-      , Arg "reg2" $ Reg Word Load
+  , Insn "JumpIfLt" [] ["Ordered a"]
+      [ Arg "reg1" $ polyReg "a" Word Load
+      , Arg "reg2" $ polyReg "a" Word Load
       , Arg "tgt" $ Imm Offset ]
 
     -- Jump if a <= b.
-  , Insn "JumpIfLe" []
-      [ Arg "reg1" $ Reg Word Load
-      , Arg "reg2" $ Reg Word Load
+  , Insn "JumpIfLe" [] ["Ordered a"]
+      [ Arg "reg1" $ polyReg "a" Word Load
+      , Arg "reg2" $ polyReg "a" Word Load
       , Arg "tgt" $ Imm Offset ]
 
     -- Decrement the value in a register and jump if it isn't 0.
-  , Insn "DecrAndJumpIfNot0" []
-      [ Arg "reg" $ Reg Word Update
+  , Insn "DecrAndJumpIfNot0" [] []
+      [ Arg "reg" $ reg Word Update
       , Arg "tgt" $ Imm Offset ]
 
     -- Decrement the value in a register and jump if it is 0.
-  , Insn "DecrAndJumpIf0" []
-      [ Arg "reg" $ Reg Word Update
+  , Insn "DecrAndJumpIf0" [] []
+      [ Arg "reg" $ reg Word Update
       , Arg "tgt" $ Imm Offset ]
 
-  , Insn "CallFun_0_1" []
-      [ Arg "fun" $ Reg (Fun [WordPtr]) Load
+  , Insn "CallFun_0_1" [] []
+      [ Arg "fun" $ reg (Fun [WordPtr]) Load
       , Arg "args" $ Regs [Word] ]
 
-  , Insn "CallFun_0_2" []
-      [ Arg "fun" $ Reg (Fun [WordPtr, WordPtr]) Load
+  , Insn "CallFun_0_2" [] []
+      [ Arg "fun" $ reg (Fun [WordPtr, WordPtr]) Load
       , Arg "args" $ Regs [Word,Word] ]
 
-  , Insn "CallFun_1_1" []
-      [ Arg "fun" $ Reg (Fun [Word, WordPtr]) Load
+  , Insn "CallFun_1_1" [] []
+      [ Arg "fun" $ reg (Fun [Word, WordPtr]) Load
       , Arg "args" $ Regs [Word,Word] ]
 
-  , Insn "CallFun_1_0" []
-      [ Arg "fun" $ Reg (Fun [Word]) Load
+  , Insn "CallFun_1_0" [] []
+      [ Arg "fun" $ reg (Fun [Word]) Load
       , Arg "args" $ Regs [Word] ]
 
     -- Call an std::function which takes two 64-bit arguments and returns
     -- one 64-bit result.
-  , Insn "CallFun_2_1" []
-      [ Arg "fun" $ Reg (Fun [Word,Word,WordPtr]) Load
+  , Insn "CallFun_2_1" [] []
+      [ Arg "fun" $ reg (Fun [Word,Word,WordPtr]) Load
       , Arg "args" $ Regs [Word,Word,Word] ]
 
-  , Insn "CallFun_2_0" []
-      [ Arg "fun" $ Reg (Fun [Word,Word]) Load
+  , Insn "CallFun_2_0" [] []
+      [ Arg "fun" $ reg (Fun [Word,Word]) Load
       , Arg "args" $ Regs [Word,Word] ]
 
-  , Insn "CallFun_3_0" []
-      [ Arg "fun" $ Reg (Fun [Word,Word,Word]) Load
+  , Insn "CallFun_3_0" [] []
+      [ Arg "fun" $ reg (Fun [Word,Word,Word]) Load
       , Arg "args" $ Regs [Word,Word,Word] ]
 
-  , Insn "CallFun_4_0" []
-      [ Arg "fun" $ Reg (Fun [Word,Word,Word,Word]) Load
+  , Insn "CallFun_4_0" [] []
+      [ Arg "fun" $ reg (Fun [Word,Word,Word,Word]) Load
       , Arg "args" $ Regs [Word,Word,Word,Word] ]
 
-  , Insn "CallFun_3_1" []
-      [ Arg "fun" $ Reg (Fun [Word,Word,Word,WordPtr]) Load
+  , Insn "CallFun_3_1" [] []
+      [ Arg "fun" $ reg (Fun [Word,Word,Word,WordPtr]) Load
       , Arg "args" $ Regs [Word,Word,Word,Word] ]
 
-  , Insn "CallFun_5_0" []
-      [ Arg "fun" $ Reg (Fun [Word,Word,Word,Word,Word]) Load
+  , Insn "CallFun_5_0" [] []
+      [ Arg "fun" $ reg (Fun [Word,Word,Word,Word,Word]) Load
       , Arg "args" $ Regs [Word,Word,Word,Word,Word] ]
 
-  , Insn "CallFun_5_1" []
-      [ Arg "fun" $ Reg (Fun [Word,Word,Word,Word,Word,WordPtr]) Load
+  , Insn "CallFun_5_1" [] []
+      [ Arg "fun" $ reg (Fun [Word,Word,Word,Word,Word,WordPtr]) Load
       , Arg "args" $ Regs [Word,Word,Word,Word,Word,Word] ]
 
-  , Insn "CallFun_2_2" []
-      [ Arg "fun" $ Reg (Fun [Word,Word,WordPtr,WordPtr]) Load
+  , Insn "CallFun_2_2" [] []
+      [ Arg "fun" $ reg (Fun [Word,Word,WordPtr,WordPtr]) Load
       , Arg "args" $ Regs [Word,Word,Word,Word] ]
 
-  , Insn "CallFun_2_5" []
+  , Insn "CallFun_2_5" [] []
       [ Arg "fun"
-          $ Reg (Fun [Word,Word,WordPtr,WordPtr,WordPtr,WordPtr,WordPtr]) Load
+          $ reg (Fun [Word,Word,WordPtr,WordPtr,WordPtr,WordPtr,WordPtr]) Load
       , Arg "args" $ Regs [Word,Word,Word,Word,Word,Word,Word] ]
 
     -- Indexed jump - the register contains an index into the array of
     -- offsets. Does nothing if the index is out of range.
-  , Insn "Select" []
-      [ Arg "sel" $ Reg Word Load
+  , Insn "Select" [] []
+      [ Arg "sel" $ reg Word Load
       , Arg "tgts" Offsets ]
 
     -- Raise an exception.
-  , Insn "Raise" [EndBlock]
+  , Insn "Raise" [EndBlock] []
       [ Arg "msg" $ Imm Literal ]
 
     -- For debugging
-  , Insn "Trace" []
+  , Insn "Trace" [] []
       [ Arg "msg" $ Imm Literal ]
 
-  , Insn "TraceReg" []
+  , Insn "TraceReg" [] []
       [ Arg "msg" $ Imm Literal
-      , Arg "reg" $ Reg Word Load ]
+      , Arg "reg" $ reg Word Load ]
 
     -- Adjust PC to point to 'cont' and suspend execution. The first argument
     -- is a temporary, unused left-over for backwards compatibility.
-  , Insn "Suspend" [EndBlock, Return]
-      [ Arg "unused" $ Reg Word Load
+  , Insn "Suspend" [EndBlock, Return] []
+      [ Arg "unused" $ reg Word Load
       , Arg "cont" $ Imm Offset
       ]
 
     -- Return from a subroutine.
-  , Insn "Ret" [EndBlock, Return] []
+  , Insn "Ret" [EndBlock, Return] [] []
 
     -- Load a word from a memory location pointed to by a register
-  , Insn "LoadWord" []
-      [ Arg "src" $ Reg WordPtr Load
-      , Arg "dst" $ Reg Word Store
+  , Insn "LoadWord" [] []
+      [ Arg "src" $ reg WordPtr Load
+      , Arg "dst" $ reg Word Store
       ]
 
     -- Store a word into a memory location pointed to by a register
-  , Insn "StoreWord" []
-      [ Arg "src" $ Reg Word Load
-      , Arg "dst" $ Reg WordPtr Load
+  , Insn "StoreWord" [] []
+      [ Arg "src" $ reg Word Load
+      , Arg "dst" $ reg WordPtr Load
       ]
   ]

--- a/glean/bytecode/gen/Glean/Bytecode/Generate/Cpp.hs
+++ b/glean/bytecode/gen/Glean/Bytecode/Generate/Cpp.hs
@@ -108,10 +108,10 @@ genInsnEval Insn{..} =
 
     declare (Arg name (Imm ty)) =
       [ cppType ty <> " " <> name <> ";" ]
-    declare (Arg name (Reg ty Load)) =
+    declare (Arg name (Reg _ ty Load)) =
       [ cppType ty <> " " <> name <> ";" ]
     -- just make a pointer to the register for Store and Update for now
-    declare (Arg name (Reg ty _)) =
+    declare (Arg name (Reg _ ty _)) =
       [ cppType ty <> "* " <> name <> ";" ]
     declare (Arg name Offsets) =
       [ "uint64_t " <> name <> "_size;"
@@ -125,9 +125,9 @@ genInsnEval Insn{..} =
       [ "args." <> name <> " = &literals[*pc++];" ]
     decode (Arg name (Imm ty)) =
       [ "args." <> name <> " = " <> cppCast ty "*pc++" <> ";" ]
-    decode (Arg name (Reg ty Load)) =
+    decode (Arg name (Reg _ ty Load)) =
       [ "args." <> name <> " = " <> cppCast ty "frame[*pc++]" <> ";" ]
-    decode (Arg name (Reg ty _)) =
+    decode (Arg name (Reg _ ty _)) =
       [ "args." <> name <> " = " <> cppCastPtr ty "&frame[*pc++]" <> ";" ]
     decode (Arg name Offsets) =
       [ "args." <> name <> "_size = *pc++;"

--- a/glean/hs/Glean/RTS/Bytecode/Code.hs
+++ b/glean/hs/Glean/RTS/Bytecode/Code.hs
@@ -23,8 +23,6 @@ module Glean.RTS.Bytecode.Code
   , output
   , generate
   , castRegister
-  , move
-  , advancePtr
   , callSite
   , calledFrom
   ) where
@@ -417,13 +415,6 @@ registerSegment (Register i) = toEnum $ fromIntegral (i `shiftR` 62)
 -- | Get the index of the register within its segment
 registerIndex :: Register a -> Word64
 registerIndex (Register i) = i .&. 0x3FFFFFFFFFFFFFFF
-
--- | loadReg is fixed to Word, so make a polymorphic version
-move :: Register a -> Register a -> Code ()
-move src dst = issue $ LoadReg (castRegister src) (castRegister dst)
-
-advancePtr :: Register 'DataPtr -> Register 'Word -> Code ()
-advancePtr ptr off = issue $ Add off (castRegister ptr)
 
 -- | Start a new basic block. The previous block will be terminated by the
 -- supplied unconditional jump instruction or, if none is provided, by a jump

--- a/glean/hs/Glean/RTS/Traverse.hs
+++ b/glean/hs/Glean/RTS/Traverse.hs
@@ -37,13 +37,13 @@ traversal callback input inputend ty = go False (repType ty)
     -- If refs is False, we *must not* traverse the value unless
     -- (hasRefs ty) is True, because we might not have traversed the
     -- previous value.
-    go refs ByteRep = when refs $ addConst 1 (castRegister input)
+    go refs ByteRep = when refs $ addConst 1 input
     go refs NatRep = when refs $ inputSkipNat input inputend
     go refs StringRep = when refs $ inputSkipTrustedString input inputend
     go refs (ArrayRep elty) = when (refs || hasRefs elty) $ local $ \size -> do
       inputNat input inputend size
       case elty of
-        ByteRep -> add size (castRegister input)
+        ByteRep -> add size input
         _ -> mdo
           jumpIf0 size end
           loop <- label
@@ -56,7 +56,7 @@ traversal callback input inputend ty = go False (repType ty)
       tys
     go refs (SumRep tys)
       | all isUnit tys = when refs $ if length tys <= 127
-          then addConst 1 (castRegister input)
+          then addConst 1 input
           else inputSkipNat input inputend
       | otherwise = when (refs || any hasRefs tys) $ mdo
           local $ \sel -> do

--- a/glean/rts/bytecode/subroutine.cpp
+++ b/glean/rts/bytecode/subroutine.cpp
@@ -138,7 +138,7 @@ struct Eval {
         const_cast<char *>(a.lit->data() + a.lit->size()));
   }
 
-  FOLLY_ALWAYS_INLINE void execute(LoadReg a) {
+  FOLLY_ALWAYS_INLINE void execute(Move a) {
     *a.dst = a.src;
   }
 


### PR DESCRIPTION
Instructions like `move` (formerly `loadReg`) should be polymorphic in
the register type but we weren't able to codegen that. Now we can.

Test plan: CI