### PR TITLE
This fixes the compilation of clang-index on cabal 3.8

### DIFF
--- a/glean/lang/clang/Setup.hs
+++ b/glean/lang/clang/Setup.hs
@@ -173,6 +173,7 @@ main = do
           newHsc buildInfo localBuildInfo componentLocalBuildInfo =
               PreProcessor {
                   platformIndependent = platformIndependent (origHsc buildInfo),
+                  ppOrdering = \_ _ ms -> pure ms,
                   runPreProcessor = \inFiles outFiles verbosity -> do
                       llvmConfig <- getLLVMConfig (configFlags localBuildInfo)
                       llvmCFlags <- do


### PR DESCRIPTION
not sure how this wasn't a problem earlier