### PR TITLE
[bytecode] More precise types

### DIFF
--- a/glean/bytecode/Glean/Bytecode/Decode.hs
+++ b/glean/bytecode/Glean/Bytecode/Decode.hs
@@ -39,6 +39,9 @@ instance Decodable Word64 where
     y : ys -> (Just y, ys)
     _ -> (Nothing, xs)
 
+instance Decodable Literal where
+  decode = Literal <$> decode
+
 instance Decodable Label where
   decode = Label . fromIntegral <$> (decode :: Decode Word64)
 

--- a/glean/bytecode/Glean/Bytecode/Types.hs
+++ b/glean/bytecode/Glean/Bytecode/Types.hs
@@ -12,6 +12,7 @@ module Glean.Bytecode.Types
   , Addable
   , Register(..)
   , Label(..)
+  , Literal(..)
   , castRegister
   ) where
 
@@ -22,7 +23,7 @@ import Data.Word (Word64)
 data Ty
   = Word -- ^ 64 bit word
   | WordPtr -- ^ pointer to 64 bit word
-  | Literal -- ^ index into the (string) literal table
+  | Lit -- ^ index into the (string) literal table
   | Offset -- ^ jump offset (relative to start of next instruction)
   | DataPtr -- ^ a void pointer
   | BinaryOutputPtr -- ^ pointer to binary::Output (temporary, will be removed)
@@ -49,3 +50,6 @@ castRegister = coerce
 -- | Labels
 newtype Label = Label { fromLabel :: Int }
   deriving(Eq,Ord,Enum,Show)
+
+newtype Literal = Literal { fromLiteral :: Word64 }
+  deriving(Eq,Ord,Show)

--- a/glean/bytecode/def/Glean/Bytecode/Generate/Instruction.hs
+++ b/glean/bytecode/def/Glean/Bytecode/Generate/Instruction.hs
@@ -111,7 +111,7 @@ instructions =
   , Insn "InputShiftLit" [] []
       [ Arg "begin" $ reg DataPtr Update
       , Arg "end" $ reg DataPtr Load
-      , Arg "lit" $ Imm Literal
+      , Arg "lit" $ Imm Lit
       , Arg "match" $ reg Word Store ]
 
     -- Check that the input starts with the given byte sequence, and
@@ -191,7 +191,7 @@ instructions =
 
     -- Load the address and size of a literal
   , Insn "LoadLiteral" [] []
-      [ Arg "lit" $ Imm Literal
+      [ Arg "lit" $ Imm Lit
       , Arg "ptr" $ reg DataPtr Store
       , Arg "end" $ reg DataPtr Store ]
 
@@ -356,14 +356,14 @@ instructions =
 
     -- Raise an exception.
   , Insn "Raise" [EndBlock] []
-      [ Arg "msg" $ Imm Literal ]
+      [ Arg "msg" $ Imm Lit ]
 
     -- For debugging
   , Insn "Trace" [] []
-      [ Arg "msg" $ Imm Literal ]
+      [ Arg "msg" $ Imm Lit ]
 
   , Insn "TraceReg" [] []
-      [ Arg "msg" $ Imm Literal
+      [ Arg "msg" $ Imm Lit
       , Arg "reg" $ reg Word Load ]
 
     -- Adjust PC to point to 'cont' and suspend execution. The first argument

--- a/glean/bytecode/def/Glean/Bytecode/Generate/Instruction.hs
+++ b/glean/bytecode/def/Glean/Bytecode/Generate/Instruction.hs
@@ -11,6 +11,7 @@ module Glean.Bytecode.Generate.Instruction
   , Effect(..)
   , Arg(..)
   , ArgTy(..)
+  , ImmTy(..)
   , Usage(..)
   , instructions
   , version
@@ -50,10 +51,17 @@ data Arg = Arg
 
 -- | Argument type
 data ArgTy
-  = Imm Ty -- ^ immediate value in instruction stream
+  = Imm ImmTy -- ^ immediate value in instruction stream
   | Reg (Maybe Text) Ty Usage -- ^ register argument
   | Offsets -- ^ array of jump offsets (length + array in the insn stream)
   | Regs [Ty] -- ^ list of registers (array without length in the insn stream)
+
+-- | Type of an immediate value
+data ImmTy
+  = ImmWord
+  | ImmOffset
+  | ImmLit
+  deriving(Eq,Ord,Show)
 
 -- | Register argument of a particular type
 reg :: Ty -> Usage -> ArgTy
@@ -111,7 +119,7 @@ instructions =
   , Insn "InputShiftLit" [] []
       [ Arg "begin" $ reg DataPtr Update
       , Arg "end" $ reg DataPtr Load
-      , Arg "lit" $ Imm Lit
+      , Arg "lit" $ Imm ImmLit
       , Arg "match" $ reg Word Store ]
 
     -- Check that the input starts with the given byte sequence, and
@@ -145,12 +153,12 @@ instructions =
 
     -- Encode an immediate Nat and store it in a binary::Output.
   , Insn "OutputNatImm" [] []
-      [ Arg "src" $ Imm Word
+      [ Arg "src" $ Imm ImmWord
       , Arg "output" $ reg BinaryOutputPtr Load ]
 
     -- Encode a byte in a binary::Output
   , Insn "OutputByteImm" [] []
-      [ Arg "src" $ Imm Word
+      [ Arg "src" $ Imm ImmWord
       , Arg "output" $ reg BinaryOutputPtr Load ]
 
     -- Write a sequence of bytes to a binary::Output.
@@ -186,12 +194,12 @@ instructions =
 
     -- Write a constant into a register.
   , Insn "LoadConst" [] []
-      [ Arg "imm" $ Imm Word
+      [ Arg "imm" $ Imm ImmWord
       , Arg "dst" $ reg Word Store ]
 
     -- Load the address and size of a literal
   , Insn "LoadLiteral" [] []
-      [ Arg "lit" $ Imm Lit
+      [ Arg "lit" $ Imm ImmLit
       , Arg "ptr" $ reg DataPtr Store
       , Arg "end" $ reg DataPtr Store ]
 
@@ -202,7 +210,7 @@ instructions =
 
     -- Subtract a constant from a register.
   , Insn "SubConst" [] []
-      [ Arg "imm" $ Imm Word
+      [ Arg "imm" $ Imm ImmWord
       , Arg "dst" $ reg Word Update ]
 
     -- Subtract a register from a register.
@@ -212,7 +220,7 @@ instructions =
 
     -- Add a constant to a register.
   , Insn "AddConst" [] ["Addable a 'Word"]
-      [ Arg "imm" $ Imm Word
+      [ Arg "imm" $ Imm ImmWord
       , Arg "dst" $ polyReg "a" Word Update ]
 
     -- Add a register to another register
@@ -227,12 +235,12 @@ instructions =
       , Arg "dst" $ reg Word Store ]
 
   , Insn "LoadLabel" [] []
-      [ Arg "lbl" $ Imm Offset
+      [ Arg "lbl" $ Imm ImmOffset
       , Arg "dst" $ reg Offset Store ]
 
     -- Unconditional jump.
   , Insn "Jump" [EndBlock] []
-      [ Arg "tgt" $ Imm Offset ]
+      [ Arg "tgt" $ Imm ImmOffset ]
 
   , Insn "JumpReg" [EndBlock] []
       [ Arg "tgt" $ reg Offset Load ]
@@ -240,58 +248,58 @@ instructions =
     -- Jump if a register is 0.
   , Insn "JumpIf0" [] []
       [ Arg "reg" $ reg Word Load
-      , Arg "tgt" $ Imm Offset ]
+      , Arg "tgt" $ Imm ImmOffset ]
 
     -- Jump if a register is not 0.
   , Insn "JumpIfNot0" [] []
       [ Arg "reg" $ reg Word Load
-      , Arg "tgt" $ Imm Offset ]
+      , Arg "tgt" $ Imm ImmOffset ]
 
     -- Jump if two registers are equal.
   , Insn "JumpIfEq" [] []
       [ Arg "reg1" $ polyReg "a" Word Load
       , Arg "reg2" $ polyReg "a" Word Load
-      , Arg "tgt" $ Imm Offset ]
+      , Arg "tgt" $ Imm ImmOffset ]
 
     -- Jump if two registers are not equal.
   , Insn "JumpIfNe" [] []
       [ Arg "reg1" $ polyReg "a" Word Load
       , Arg "reg2" $ polyReg "a" Word Load
-      , Arg "tgt" $ Imm Offset ]
+      , Arg "tgt" $ Imm ImmOffset ]
 
     -- Jump if a > b.
   , Insn "JumpIfGt" [] ["Ordered a"]
       [ Arg "reg1" $ polyReg "a" Word Load
       , Arg "reg2" $ polyReg "a" Word Load
-      , Arg "tgt" $ Imm Offset ]
+      , Arg "tgt" $ Imm ImmOffset ]
 
     -- Jump if a >= b.
   , Insn "JumpIfGe" [] ["Ordered a"]
       [ Arg "reg1" $ polyReg "a" Word Load
       , Arg "reg2" $ polyReg "a" Word Load
-      , Arg "tgt" $ Imm Offset ]
+      , Arg "tgt" $ Imm ImmOffset ]
 
     -- Jump if a < b.
   , Insn "JumpIfLt" [] ["Ordered a"]
       [ Arg "reg1" $ polyReg "a" Word Load
       , Arg "reg2" $ polyReg "a" Word Load
-      , Arg "tgt" $ Imm Offset ]
+      , Arg "tgt" $ Imm ImmOffset ]
 
     -- Jump if a <= b.
   , Insn "JumpIfLe" [] ["Ordered a"]
       [ Arg "reg1" $ polyReg "a" Word Load
       , Arg "reg2" $ polyReg "a" Word Load
-      , Arg "tgt" $ Imm Offset ]
+      , Arg "tgt" $ Imm ImmOffset ]
 
     -- Decrement the value in a register and jump if it isn't 0.
   , Insn "DecrAndJumpIfNot0" [] []
       [ Arg "reg" $ reg Word Update
-      , Arg "tgt" $ Imm Offset ]
+      , Arg "tgt" $ Imm ImmOffset ]
 
     -- Decrement the value in a register and jump if it is 0.
   , Insn "DecrAndJumpIf0" [] []
       [ Arg "reg" $ reg Word Update
-      , Arg "tgt" $ Imm Offset ]
+      , Arg "tgt" $ Imm ImmOffset ]
 
   , Insn "CallFun_0_1" [] []
       [ Arg "fun" $ reg (Fun [WordPtr]) Load
@@ -356,21 +364,21 @@ instructions =
 
     -- Raise an exception.
   , Insn "Raise" [EndBlock] []
-      [ Arg "msg" $ Imm Lit ]
+      [ Arg "msg" $ Imm ImmLit ]
 
     -- For debugging
   , Insn "Trace" [] []
-      [ Arg "msg" $ Imm Lit ]
+      [ Arg "msg" $ Imm ImmLit ]
 
   , Insn "TraceReg" [] []
-      [ Arg "msg" $ Imm Lit
+      [ Arg "msg" $ Imm ImmLit
       , Arg "reg" $ reg Word Load ]
 
     -- Adjust PC to point to 'cont' and suspend execution. The first argument
     -- is a temporary, unused left-over for backwards compatibility.
   , Insn "Suspend" [EndBlock, Return] []
       [ Arg "unused" $ reg Word Load
-      , Arg "cont" $ Imm Offset
+      , Arg "cont" $ Imm ImmOffset
       ]
 
     -- Return from a subroutine.

--- a/glean/bytecode/gen/Glean/Bytecode/Generate/Cpp.hs
+++ b/glean/bytecode/gen/Glean/Bytecode/Generate/Cpp.hs
@@ -121,7 +121,7 @@ genInsnEval Insn{..} =
           <> Text.pack (show (length tys) <> ";")
       , "const uint64_t *" <> name <> ";" ]
 
-    decode (Arg name (Imm Literal)) =
+    decode (Arg name (Imm Lit)) =
       [ "args." <> name <> " = &literals[*pc++];" ]
     decode (Arg name (Imm ty)) =
       [ "args." <> name <> " = " <> cppCast ty "*pc++" <> ";" ]
@@ -149,7 +149,7 @@ genInsnEval Insn{..} =
 
 cppType :: Ty -> Text
 cppType DataPtr = "void *"
-cppType Literal = "const std::string *"
+cppType Lit = "const std::string *"
 cppType WordPtr = "uint64_t *"
 cppType BinaryOutputPtr = "binary::Output *"
 cppType (Fun _) = "SysFun"

--- a/glean/bytecode/gen/Glean/Bytecode/Generate/Cpp.hs
+++ b/glean/bytecode/gen/Glean/Bytecode/Generate/Cpp.hs
@@ -107,7 +107,7 @@ genInsnEval Insn{..} =
 
 
     declare (Arg name (Imm ty)) =
-      [ cppType ty <> " " <> name <> ";" ]
+      [ immType ty <> " " <> name <> ";" ]
     declare (Arg name (Reg _ ty Load)) =
       [ cppType ty <> " " <> name <> ";" ]
     -- just make a pointer to the register for Store and Update for now
@@ -121,10 +121,10 @@ genInsnEval Insn{..} =
           <> Text.pack (show (length tys) <> ";")
       , "const uint64_t *" <> name <> ";" ]
 
-    decode (Arg name (Imm Lit)) =
+    decode (Arg name (Imm ImmLit)) =
       [ "args." <> name <> " = &literals[*pc++];" ]
-    decode (Arg name (Imm ty)) =
-      [ "args." <> name <> " = " <> cppCast ty "*pc++" <> ";" ]
+    decode (Arg name (Imm _)) =
+      [ "args." <> name <> " = *pc++;" ]
     decode (Arg name (Reg _ ty Load)) =
       [ "args." <> name <> " = " <> cppCast ty "frame[*pc++]" <> ";" ]
     decode (Arg name (Reg _ ty _)) =
@@ -154,6 +154,11 @@ cppType WordPtr = "uint64_t *"
 cppType BinaryOutputPtr = "binary::Output *"
 cppType (Fun _) = "SysFun"
 cppType _ = "uint64_t"
+
+immType :: ImmTy -> Text
+immType ImmWord = "uint64_t"
+immType ImmOffset = "uint64_t"
+immType ImmLit = "const std::string *"
 
 -- | Generate a switch-based evaluator.
 --

--- a/glean/hs/Glean/RTS/Bytecode/Code.hs
+++ b/glean/hs/Glean/RTS/Bytecode/Code.hs
@@ -447,8 +447,8 @@ newBlock terminator = Code $ do
     }
 
 -- | Add a literal to the literal table and yield its index
-literal :: ByteString -> Code Word64
-literal lit = Code $ do
+literal :: ByteString -> Code Literal
+literal lit = Code $ Literal . fromIntegral <$> do
   m <- S.gets csLiterals
   case HashMap.lookup lit m of
     Just n -> return n


### PR DESCRIPTION
This introduces a new type for literal indices (formerly `Word64`) and a new type (only used for Haskell and C++ codegen) for immediate values. This is a bit cleaner and will help us later.