### PR TITLE
Fix dep in test:backup

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1705,12 +1705,13 @@ test-suite backup
     main-is: BackupTest.hs
     ghc-options: -main-is BackupTest
     build-depends:
-        glean:stubs,
+        glean:config,
         glean:core,
         glean:db,
         glean:if-glean-hs,
+        glean:if-internal-hs,
         glean:schema,
-        glean:config,
+        glean:stubs,
         glean:util
 
 test-suite catalog


### PR DESCRIPTION
```
Preprocessing test suite 'backup' for glean-0.1.0.0..
Building test suite 'backup' for glean-0.1.0.0..
[1 of 1] Compiling BackupTest       ( glean/test/tests/BackupTest.hs, /__w/Glean/Glean/dist-newstyle/build/aarch64-linux/ghc-8.10.7/glean-0.1.0.0/t/backup/build/backup/backup-tmp/BackupTest.o )

glean/test/tests/BackupTest.hs:44:1: error:
    Could not load module ‘Glean.Internal.Types’
    It is a member of the hidden package ‘glean-0.1.0.0’.
    Perhaps you need to add ‘glean’ to the build-depends in your .cabal file.
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
44 | import Glean.Internal.Types (Completeness(Complete))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

(cherry picked from commit 6b22e32add1e4a1a3039e0cf9217ca53fa76fee2)