### PR TITLE
Return typechecked key size in register 

### DIFF
--- a/glean/bytecode/def/Glean/Bytecode/Generate/Instruction.hs
+++ b/glean/bytecode/def/Glean/Bytecode/Generate/Instruction.hs
@@ -384,15 +384,4 @@ instructions =
     -- Return from a subroutine.
   , Insn "Ret" [EndBlock, Return] [] []
 
-    -- Load a word from a memory location pointed to by a register
-  , Insn "LoadWord" [] []
-      [ Arg "src" $ reg WordPtr Load
-      , Arg "dst" $ reg Word Store
-      ]
-
-    -- Store a word into a memory location pointed to by a register
-  , Insn "StoreWord" [] []
-      [ Arg "src" $ reg Word Load
-      , Arg "dst" $ reg WordPtr Load
-      ]
   ]

--- a/glean/rts/bytecode/subroutine.cpp
+++ b/glean/rts/bytecode/subroutine.cpp
@@ -315,14 +315,6 @@ struct Eval {
   FOLLY_ALWAYS_INLINE const uint64_t * FOLLY_NULLABLE execute(Ret) {
     return nullptr;
   }
-
-  FOLLY_ALWAYS_INLINE void execute(LoadWord a) {
-    *a.dst = *a.src;
-  }
-
-  FOLLY_ALWAYS_INLINE void execute(StoreWord a) {
-    *a.dst = a.src;
-  }
 };
 
 }

--- a/glean/rts/bytecode/subroutine.h
+++ b/glean/rts/bytecode/subroutine.h
@@ -120,6 +120,13 @@ struct Subroutine {
       return outputs()[i];
     }
 
+    /// Registers in which a subroutine returns its results
+    folly::Range<const uint64_t *> results() const {
+      return
+        { frame() + sub.inputs + sub.constants.size()
+        , frame() + sub.frameSize()};
+    }
+
     /// Execute the activation. If 'suspended' is true after the call, execution
     /// can be resumed by another call to 'execute'.
     void execute();

--- a/glean/rts/inventory.h
+++ b/glean/rts/inventory.h
@@ -45,7 +45,8 @@ struct Predicate {
   /// const void * - end of key/begin of value
   /// const void * - end of clause/value
   /// binary::Output * - substituted clause
-  /// uint64_t * - size of substituted key
+  ///
+  /// Returns size of substituted key in first result register
   std::shared_ptr<Subroutine> typechecker;
 
   /// Generic fact traversal. Takes these arguments:
@@ -96,9 +97,9 @@ struct Predicate {
           *rename.handlers_begin(),
           reinterpret_cast<uint64_t>(clause.data),
           reinterpret_cast<uint64_t>(clause.data + clause.key_size),
-          reinterpret_cast<uint64_t>(clause.data + clause.size()),
-          reinterpret_cast<uint64_t>(&key_size)});
+          reinterpret_cast<uint64_t>(clause.data + clause.size())});
         output = std::move(activation.output(0));
+        key_size = activation.results()[0];
     });
   }
 


### PR DESCRIPTION
We used to pass in a pointer but returning this via a register seems better and will allow us to remove the `LoadWord` and `StoreWord` insns.

WARNING: This does *not* bump the bytecode version because I believe that `LoadWord` and `StoreWord` were never used in code generated for queries and hence never serialised.