### PR TITLE
More typesafe insn decoding

### DIFF
--- a/glean/bytecode/gen/Glean/Bytecode/Generate/Cpp.hs
+++ b/glean/bytecode/gen/Glean/Bytecode/Generate/Cpp.hs
@@ -137,7 +137,7 @@ genInsnEval Insn{..} =
       , "pc += args." <> name <> "_arity;" ]
 
 cppType :: Ty -> Text
-cppType DataPtr = "unsigned char *"
+cppType DataPtr = "const unsigned char *"
 cppType Lit = "const std::string *"
 cppType WordPtr = "uint64_t *"
 cppType BinaryOutputPtr = "binary::Output *"

--- a/glean/rts/binary.cpp
+++ b/glean/rts/binary.cpp
@@ -59,7 +59,7 @@ folly::fbstring Output::moveToFbString() {
     // fbstring requires the data to be NUL-terminated. The terminator isn't
     // included in the size.
     *alloc(1) = 0;
-    const auto d = data();
+    const auto d = mutableData();
     const auto s = size();
     const auto c = large.cap;
     markEmpty();

--- a/glean/rts/binary.h
+++ b/glean/rts/binary.h
@@ -325,15 +325,12 @@ struct Output {
     return (isSmall() ? large.size & 0xFF : large.size) >> TAG_BITS;
   }
 
+  /// Return a pointer to the underlying memory. This is guaranteed to never
+  /// be null, not even for empty buffers.
   const unsigned char* data() const noexcept {
     return isSmall() ? small+1 : large.data;
   }
 
-  /// Return a pointer to the underlying memory. This is guaranteed to never
-  /// be null, not even for empty buffers.
-  unsigned char* data() noexcept {
-    return isSmall() ? small+1 : large.data;
-  }
 
   size_t capacity() const noexcept {
     return isSmall() ? SMALL_CAP : large.cap;
@@ -460,6 +457,10 @@ struct Output {
     small[0] = 0;
   }
 
+  unsigned char* mutableData() noexcept {
+    return isSmall() ? small+1 : large.data;
+  }
+
   /// Return a pointer to enough space for n bytes. This reserves memory but
   /// doesn't increase the size - this can be done via 'use' afterwards.
   unsigned char *alloc(size_t n) {
@@ -470,7 +471,7 @@ struct Output {
       // results in slightly better code.
       folly::assume((small[0] & LARGE_BIT) != 0);
     }
-    return data() + size();
+    return mutableData() + size();
   }
 
   /// Grow the buffer by at least `n` bytes. This changes capacity but not size.

--- a/glean/rts/bytecode/subroutine.cpp
+++ b/glean/rts/bytecode/subroutine.cpp
@@ -30,67 +30,54 @@ struct Eval {
 
   FOLLY_ALWAYS_INLINE void execute(InputNat a) {
     binary::Input input { *a.begin, a.end };
-    *a.dst = input.packed<uint64_t>();
-    *a.begin = reinterpret_cast<void *>(
-        const_cast<unsigned char*>(input.data()));
+    a.dst << input.packed<uint64_t>();
+    a.begin << const_cast<unsigned char*>(input.data());
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputBytes a) {
     binary::Input input { *a.begin, a.end };
     input.bytes(a.size);
-    *a.begin = reinterpret_cast<void *>(
-        const_cast<unsigned char*>(input.data()));
+    a.begin << const_cast<unsigned char*>(input.data());
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputSkipUntrustedString a) {
     binary::Input input { *a.begin, a.end };
     input.skipUntrustedString();
-    *a.begin = reinterpret_cast<void *>(
-        const_cast<unsigned char*>(input.data()));
+    a.begin << const_cast<unsigned char*>(input.data());
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputShiftLit a) {
     binary::Input input { *a.begin, a.end };
-    *a.match = input.shift(binary::byteRange(*a.lit));
-    *a.begin = reinterpret_cast<void *>(
-        const_cast<unsigned char*>(input.data()));
+    a.match << input.shift(binary::byteRange(*a.lit));
+    a.begin << const_cast<unsigned char*>(input.data());
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputShiftBytes a) {
     binary::Input input { *a.begin, a.end };
-    *a.match = input.shift(
-        folly::ByteRange(reinterpret_cast<const unsigned char*>(a.ptr),
-                         reinterpret_cast<const unsigned char*>(a.ptrend)));
-    *a.begin = reinterpret_cast<void *>(
-        const_cast<unsigned char*>(input.data()));
+    a.match << input.shift(folly::ByteRange(a.ptr, a.ptrend));
+    a.begin << const_cast<unsigned char*>(input.data());
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputSkipNat a) {
     binary::Input input { *a.begin, a.end };
     input.packed<uint64_t>();
-    *a.begin = reinterpret_cast<void *>(
-        const_cast<unsigned char*>(input.data()));
+    a.begin << const_cast<unsigned char*>(input.data());
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputSkipTrustedString a) {
     binary::Input input { *a.begin, a.end };
     input.skipTrustedString();
-    *a.begin = reinterpret_cast<void *>(
-        const_cast<unsigned char*>(input.data()));
+    a.begin << const_cast<unsigned char*>(input.data());
   }
 
   FOLLY_ALWAYS_INLINE void execute(OutputStringToLower a) {
-    folly::ByteRange input {
-      reinterpret_cast<const unsigned char*>(a.begin),
-      reinterpret_cast<const unsigned char*>(a.end) };
+    folly::ByteRange input { a.begin, a.end };
     toLowerTrustedString(input, *a.dst);
   }
 
 
   FOLLY_ALWAYS_INLINE void execute(OutputRelToAbsByteSpans a) {
-    folly::ByteRange input {
-      reinterpret_cast<const uint8_t*>(a.begin),
-      reinterpret_cast<const uint8_t*>(a.end) };
+    folly::ByteRange input { a.begin, a.end }; 
     relToAbsByteSpans(input, *a.dst);
   }
 
@@ -118,53 +105,52 @@ struct Eval {
   }
 
   FOLLY_ALWAYS_INLINE void execute(GetOutput a) {
-    *a.ptr = reinterpret_cast<void *>(
-        const_cast<unsigned char*>(a.output->bytes().data()));
-    *a.end = reinterpret_cast<void *>(
-        const_cast<unsigned char*>(a.output->bytes().end()));
+    a.ptr << const_cast<unsigned char*>(a.output->bytes().data());
+    a.end << const_cast<unsigned char*>(a.output->bytes().end());
   }
 
   FOLLY_ALWAYS_INLINE void execute(GetOutputSize a) {
-    *a.dst = a.output->size();
+    a.dst << a.output->size();
   }
 
   FOLLY_ALWAYS_INLINE void execute(LoadConst a) {
-    *a.dst = a.imm;
+    a.dst << a.imm;
   }
 
   FOLLY_ALWAYS_INLINE void execute(LoadLiteral a) {
-    *a.ptr = reinterpret_cast<uint64_t *>(const_cast<char *>(a.lit->data()));
-    *a.end = reinterpret_cast<uint64_t *>(
-        const_cast<char *>(a.lit->data() + a.lit->size()));
+    a.ptr << reinterpret_cast<unsigned char *>(
+      const_cast<char *>(a.lit->data()));
+    a.end << reinterpret_cast<unsigned char *>(
+      const_cast<char *>(a.lit->data() + a.lit->size()));
   }
 
   FOLLY_ALWAYS_INLINE void execute(Move a) {
-    *a.dst = a.src;
+    a.dst << a.src;
   }
 
   FOLLY_ALWAYS_INLINE void execute(SubConst a) {
-    *a.dst -= a.imm;
+    a.dst << *a.dst - a.imm;
   }
 
   FOLLY_ALWAYS_INLINE void execute(AddConst a) {
-    *a.dst += a.imm;
+    a.dst << *a.dst + a.imm;
   }
 
   FOLLY_ALWAYS_INLINE void execute(Sub a) {
-    *a.dst -= a.src;
+    a.dst << *a.dst - a.src;
   }
 
   FOLLY_ALWAYS_INLINE void execute(Add a) {
-    *a.dst += a.src;
+    a.dst << *a.dst + a.src;
   }
 
   FOLLY_ALWAYS_INLINE void execute(PtrDiff a) {
-    *a.dst = reinterpret_cast<uint64_t>(a.src2) -
+    a.dst << reinterpret_cast<uint64_t>(a.src2) -
       reinterpret_cast<uint64_t>(a.src1);
   }
 
   FOLLY_ALWAYS_INLINE void execute(LoadLabel a) {
-    *a.dst = static_cast<uint64_t>(pc - code + std::ptrdiff_t(a.lbl));
+    a.dst << static_cast<uint64_t>(pc - code + std::ptrdiff_t(a.lbl));
       // turn relative into absolute offset
   }
 
@@ -225,14 +211,14 @@ struct Eval {
   }
 
   FOLLY_ALWAYS_INLINE void execute(DecrAndJumpIfNot0 a) {
-    --*a.reg;
+    a.reg << *a.reg - 1;
     if (*a.reg != 0) {
       pc += std::ptrdiff_t(a.tgt);
     }
   }
 
   FOLLY_ALWAYS_INLINE void execute(DecrAndJumpIf0 a) {
-    --*a.reg;
+    a.reg << *a.reg - 1;
     if (*a.reg == 0) {
       pc += std::ptrdiff_t(a.tgt);
     }

--- a/glean/rts/bytecode/subroutine.cpp
+++ b/glean/rts/bytecode/subroutine.cpp
@@ -31,54 +31,51 @@ struct Eval {
   FOLLY_ALWAYS_INLINE void execute(InputNat a) {
     binary::Input input { *a.begin, a.end };
     a.dst << input.packed<uint64_t>();
-    a.begin << const_cast<unsigned char*>(input.data());
+    a.begin << input.data();
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputBytes a) {
     binary::Input input { *a.begin, a.end };
     input.bytes(a.size);
-    a.begin << const_cast<unsigned char*>(input.data());
+    a.begin << input.data();
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputSkipUntrustedString a) {
     binary::Input input { *a.begin, a.end };
     input.skipUntrustedString();
-    a.begin << const_cast<unsigned char*>(input.data());
+    a.begin << input.data();
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputShiftLit a) {
     binary::Input input { *a.begin, a.end };
     a.match << input.shift(binary::byteRange(*a.lit));
-    a.begin << const_cast<unsigned char*>(input.data());
+    a.begin << input.data();
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputShiftBytes a) {
     binary::Input input { *a.begin, a.end };
     a.match << input.shift(folly::ByteRange(a.ptr, a.ptrend));
-    a.begin << const_cast<unsigned char*>(input.data());
+    a.begin << input.data();
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputSkipNat a) {
     binary::Input input { *a.begin, a.end };
     input.packed<uint64_t>();
-    a.begin << const_cast<unsigned char*>(input.data());
+    a.begin << input.data();
   }
 
   FOLLY_ALWAYS_INLINE void execute(InputSkipTrustedString a) {
     binary::Input input { *a.begin, a.end };
     input.skipTrustedString();
-    a.begin << const_cast<unsigned char*>(input.data());
+    a.begin << input.data();
   }
 
   FOLLY_ALWAYS_INLINE void execute(OutputStringToLower a) {
-    folly::ByteRange input { a.begin, a.end };
-    toLowerTrustedString(input, *a.dst);
+    toLowerTrustedString({a.begin, a.end}, *a.dst);
   }
 
-
   FOLLY_ALWAYS_INLINE void execute(OutputRelToAbsByteSpans a) {
-    folly::ByteRange input { a.begin, a.end }; 
-    relToAbsByteSpans(input, *a.dst);
+    relToAbsByteSpans({a.begin, a.end}, *a.dst);
   }
 
   FOLLY_ALWAYS_INLINE void execute(ResetOutput a) {
@@ -98,15 +95,12 @@ struct Eval {
   }
 
   FOLLY_ALWAYS_INLINE void execute(OutputBytes a) {
-    a.output->bytes(
-        reinterpret_cast<const void *>(a.ptr),
-        reinterpret_cast<uintptr_t>(a.end) -
-        reinterpret_cast<uintptr_t>(a.ptr));
+    a.output->bytes(a.ptr, a.end - a.ptr);
   }
 
   FOLLY_ALWAYS_INLINE void execute(GetOutput a) {
-    a.ptr << const_cast<unsigned char*>(a.output->bytes().data());
-    a.end << const_cast<unsigned char*>(a.output->bytes().end());
+    a.ptr << a.output->bytes().data();
+    a.end << a.output->bytes().end();
   }
 
   FOLLY_ALWAYS_INLINE void execute(GetOutputSize a) {
@@ -118,10 +112,9 @@ struct Eval {
   }
 
   FOLLY_ALWAYS_INLINE void execute(LoadLiteral a) {
-    a.ptr << reinterpret_cast<unsigned char *>(
-      const_cast<char *>(a.lit->data()));
-    a.end << reinterpret_cast<unsigned char *>(
-      const_cast<char *>(a.lit->data() + a.lit->size()));
+    a.ptr << reinterpret_cast<const unsigned char *>(a.lit->data());
+    a.end <<
+      reinterpret_cast<const unsigned char *>(a.lit->data() + a.lit->size());
   }
 
   FOLLY_ALWAYS_INLINE void execute(Move a) {
@@ -145,8 +138,7 @@ struct Eval {
   }
 
   FOLLY_ALWAYS_INLINE void execute(PtrDiff a) {
-    a.dst << reinterpret_cast<uint64_t>(a.src2) -
-      reinterpret_cast<uint64_t>(a.src1);
+    a.dst << a.src2 - a.src1;
   }
 
   FOLLY_ALWAYS_INLINE void execute(LoadLabel a) {
@@ -159,7 +151,7 @@ struct Eval {
   }
 
   FOLLY_ALWAYS_INLINE void execute(JumpReg a) {
-    pc = reinterpret_cast<const uint64_t*>(code + a.tgt);
+    pc = code + a.tgt;
   }
 
   FOLLY_ALWAYS_INLINE void execute(JumpIf0 a) {

--- a/glean/rts/bytecode/syscall.h
+++ b/glean/rts/bytecode/syscall.h
@@ -73,11 +73,11 @@ private:
   }
 
   // data pointers
-  static void fromWord(unsigned char *&x, uint64_t w) {
-    x = reinterpret_cast<unsigned char *>(w);
+  static void fromWord(const unsigned char *&x, uint64_t w) {
+    x = reinterpret_cast<const unsigned char *>(w);
   }
 
-  static uint64_t toWord(unsigned char *x) {
+  static uint64_t toWord(const unsigned char *x) {
     return reinterpret_cast<uint64_t>(x);
   }
 
@@ -86,21 +86,16 @@ private:
     x = reinterpret_cast<binary::Output *>(w);
   }
 
+  static void fromWord(const binary::Output *&x, uint64_t w) {
+    x = reinterpret_cast<binary::Output *>(w);
+  }
+
   static uint64_t toWord(binary::Output *x) {
     return reinterpret_cast<uint64_t>(x);
   }
 
-  // Also support const data and output pointers
-  template<typename U>
-  static void fromWord(const U *&x, uint64_t w) {
-    U *y;
-    fromWord(y,w);
-    x = y;
-  }
-
-  template<typename U>
-  static uint64_t toWord(const U *x) {
-    return toWord(const_cast<U *>(x));
+  static uint64_t toWord(const binary::Output *x) {
+    return reinterpret_cast<uint64_t>(x);
   }
 
   // SysFun


### PR DESCRIPTION
This reuses the `Reg` machinery for register references when decoding instructions rather than (highly unsafely) casting pointers. We also change the generated C++ to use const pointers for DataPtr since we never actually mutate data once it's written into a buffer. This allows us to remove all `reinterpret_cast`s and `const_cast`s from the bytecode interpreter. We also remove mutable access to `binary::Output` data.