### PR TITLE
Serialise fact ids for prefix iterators

### DIFF
--- a/glean/if/internal.thrift
+++ b/glean/if/internal.thrift
@@ -13,8 +13,12 @@ namespace cpp2 facebook.glean.thrift.internal
 namespace hs Glean
 
 struct KeyIterator {
+  // id of fact the iterator is pointing to
+  7: optional glean.Id fact;
   1: i64 type;
-  2: string key;
+  2: optional string key;
+  // size of prefix - the value of the prefix can be obtained from the current
+  // fact's key
   3: i64 prefix_size;
   4: bool first;
   // lower bound for result facts


### PR DESCRIPTION
When we serialise iterators in query continuations, we're currently
including the key of the fact they're pointing to. This can be very
large. We want to serialise the fact id instead and then use that to
obtain the key when deserialising (via an additional `factById` query).
This commit does that in a backward and forward compatible way.

We serialise the fact id but also still serialise the key - this means
that old servers can deal with our continuations. When deserialising, we
use the fact id if present - thus, the code will still work when we stop
serialising keys altogether.

NOTE: #264 removes the actual key serialisation. I suggest merging this, updating all servers, and then merging #264.