### PR TITLE
Don't include key when serialising fact iterators

### DIFF
--- a/glean/if/internal.thrift
+++ b/glean/if/internal.thrift
@@ -13,8 +13,12 @@ namespace cpp2 facebook.glean.thrift.internal
 namespace hs Glean
 
 struct KeyIterator {
+  // id of fact the iterator is pointing to
+  7: optional glean.Id fact;
   1: i64 type;
-  2: string key;
+  2: optional string key;
+  // size of prefix - the value of the prefix can be obtained from the current
+  // fact's key
   3: i64 prefix_size;
   4: bool first;
   // lower bound for result facts

--- a/glean/if/internal.thrift
+++ b/glean/if/internal.thrift
@@ -14,9 +14,8 @@ namespace hs Glean
 
 struct KeyIterator {
   // id of fact the iterator is pointing to
-  7: optional glean.Id fact;
+  7: glean.Id fact;
   1: i64 type;
-  2: optional string key;
   // size of prefix - the value of the prefix can be obtained from the current
   // fact's key
   3: i64 prefix_size;


### PR DESCRIPTION
We previously started serialising fact ids in addition to keys for iterators in query continuations. This PR now stops serialising keys which should make the continuations significantly smaller.

WARNING: This is part 2 of #263. THIS IS NOT COMPATIBLE WITH SERVERS WHICH DON'T HAVE #263 so this should only be merged after all servers have been upgraded to include that change.