### PR TITLE
Track removal of ffi.h from fb-util

### DIFF
--- a/glean/rts/ffi.cpp
+++ b/glean/rts/ffi.cpp
@@ -7,11 +7,9 @@
  */
 
 #ifdef OSS
-#include <cpp/ffi.h> // @manual
 #include <cpp/memory.h> // @manual
 #include <cpp/wrap.h> // @manual
 #else
-#include <common/hs/util/cpp/ffi.h>
 #include <common/hs/util/cpp/memory.h>
 #include <common/hs/util/cpp/wrap.h>
 #endif


### PR DESCRIPTION
This should be landed together with https://github.com/facebookincubator/hsthrift/pull/102 which removes ffi.h from fb-util