### PR TITLE
Refactor FactSet's index maintenance

### DIFF
--- a/glean/rts/factset.h
+++ b/glean/rts/factset.h
@@ -12,8 +12,9 @@
 #include "glean/rts/densemap.h"
 #include "glean/rts/fact.h"
 #include "glean/rts/inventory.h"
-#include "glean/rts/substitution.h"
+#include "glean/rts/ondemand.h"
 #include "glean/rts/store.h"
+#include "glean/rts/substitution.h"
 
 #include <atomic>
 #include <boost/intrusive/list.hpp>
@@ -107,14 +108,14 @@ template<typename T, typename By> using FastSetBy =
  */
 class FactSet final : public Define {
 public:
-  explicit FactSet(Id start)
-    : starting_id(start)
-    , fact_memory(0)
-    {}
-  FactSet(FactSet&&) = default;
-  FactSet& operator=(FactSet&&) = default;
+  explicit FactSet(Id start);
+  FactSet(FactSet&&);
+  FactSet& operator=(FactSet&&);
+  ~FactSet() noexcept;
+
   FactSet(const FactSet&) = delete;
   FactSet& operator=(const FactSet&) = delete;
+
 
   size_t size() const noexcept {
     return facts.size();
@@ -251,34 +252,8 @@ private:
 
   /// Index for prefix seeks. It is lazily initialised and slow as we typically
   /// don't do seeks on FactSets.
-  class Index final {
-  public:
-    Index() : impl(nullptr) {}
-    ~Index();
-    Index(Index&&) noexcept;
-    Index& operator=(Index&&);
-    Index(const Index&) = delete;
-    Index& operator=(const Index&) = delete;
-
-    void swap(Index&) noexcept;
-
-    /// Type of index maps
-    using map_t = std::map<folly::ByteRange, const Fact *>;
-
-    /// Type of index maps with synchronised access
-    using entry_t = folly::Synchronized<map_t>;
-
-    /// Get a reference to the index map for the given predicate, creating an
-    /// empty one if necessary
-    entry_t& operator[](Pid pid);
-
-  private:
-    struct Impl;
-
-    std::atomic<Impl *> impl;
-  };
-
-  Index index;
+  struct Index;
+  OnDemand<Index> index;
 };
 
 }

--- a/glean/rts/ondemand.h
+++ b/glean/rts/ondemand.h
@@ -30,7 +30,7 @@ public:
 
   OnDemand& operator=(OnDemand&& other) noexcept {
     auto p = other.ptr_.exchange(nullptr, std::memory_order_acq_rel);
-    p = ptr_.exchange(ptr_, std::memory_order_release);
+    p = ptr_.exchange(p, std::memory_order_release);
     delete p;
     return *this;
   }

--- a/glean/rts/ondemand.h
+++ b/glean/rts/ondemand.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+
+namespace facebook {
+namespace glean {
+namespace rts {
+
+/// Values which are created once when needed. OnDemand is thread safe and
+/// always returns the same value. However, it might speculatively create (and
+/// then destroy) additional values.
+template<typename T>
+class OnDemand final {
+public:
+  /// Create an empty OnDemand
+  OnDemand() noexcept : ptr_(nullptr) {}
+
+  OnDemand(OnDemand&& other) noexcept
+    : ptr_(other.ptr_.exchange(nullptr, std::memory_order_acq_rel))
+    {}
+
+  OnDemand& operator=(OnDemand&& other) noexcept {
+    auto p = other.ptr_.exchange(nullptr, std::memory_order_acq_rel);
+    p = ptr_.exchange(ptr_, std::memory_order_release);
+    delete p;
+    return *this;
+  }
+
+  ~OnDemand() noexcept {
+    delete ptr_.load(std::memory_order_relaxed);
+  }
+
+  OnDemand(const OnDemand&) = delete;
+  OnDemand& operator=(const OnDemand&) = delete;
+
+  /// Get the value, creating it if necessary.
+  T& value() {
+    auto p = ptr_.load(std::memory_order_relaxed);
+    if (p == nullptr) {
+      auto k = new T();
+      if (ptr_.compare_exchange_strong(p, k, std::memory_order_acq_rel)) {
+        p = k;
+      } else {
+        delete k;
+      }
+    }
+    return *p; 
+  }
+
+  const T& value() const {
+    return const_cast<OnDemand*>(this)->get();
+  }
+
+private:
+  mutable std::atomic<T*> ptr_;
+};
+
+}
+}
+}


### PR DESCRIPTION
This basically extracts the lifetime management of FactSet::Index into a separate, generally usable class - which we are going to reuse elsewhere later. This also makes the code easier to follow.

Test plan: CI - the index is used in various test cases