### PR TITLE
Support pure in-memory DB storage

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -466,6 +466,7 @@ library db
         Glean.Database.Catalog.Filter
         Glean.Database.Catalog
         Glean.Database.Catalog.Local.Files
+        Glean.Database.Catalog.Local.Memory
         Glean.Database.Catalog.Store
         Glean.Database.CompletePredicates
         Glean.Database.Config

--- a/glean/db/Glean/Database/Catalog/Local/Files.hs
+++ b/glean/db/Glean/Database/Catalog/Local/Files.hs
@@ -8,7 +8,7 @@
 
 module Glean.Database.Catalog.Local.Files
   ( Files
-  , local
+  , fileCatalog
   ) where
 
 import Control.Monad
@@ -37,8 +37,8 @@ newtype Files = Files { _filesRoot :: FilePath }
 metaPath :: FilePath -> Repo -> FilePath
 metaPath root repo = databasePath root repo </> "meta"
 
-local :: FilePath -> Files
-local = Files
+fileCatalog :: FilePath -> Files
+fileCatalog = Files
 
 instance Store Files where
   list (Files root) = do

--- a/glean/db/Glean/Database/Catalog/Local/Memory.hs
+++ b/glean/db/Glean/Database/Catalog/Local/Memory.hs
@@ -1,0 +1,45 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Glean.Database.Catalog.Local.Memory
+  ( Memory
+  , memoryCatalog
+  ) where
+
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import Data.IORef
+
+import Glean.Database.Catalog.Store
+import Glean.Database.Meta (Meta)
+import Glean.Types (Repo(..))
+
+newtype Memory = Memory (IORef (HashMap Repo Meta))
+
+memoryCatalog :: IO Memory
+memoryCatalog = Memory <$> newIORef mempty
+
+instance Store Memory where
+  list (Memory v) = readIORef v
+
+  create (Memory v) repo meta = atomicModifyIORef' v $ \xs ->
+    if repo `HashMap.member` xs
+      then (xs, False)
+      else (HashMap.insert repo meta xs, True)
+
+  delete (Memory v) repo = atomicModifyIORef' v $ \xs ->
+    if repo `HashMap.member` xs
+      then (HashMap.delete repo xs, True)
+      else (xs, False)
+
+  put (Memory v) repo meta = atomicModifyIORef' v $ \xs ->
+    if repo `HashMap.member` xs
+      then (HashMap.insert repo meta xs, True)
+      else (xs, False)
+
+  get (Memory v) repo = HashMap.lookup repo <$> readIORef v

--- a/glean/db/Glean/Database/Create.hs
+++ b/glean/db/Glean/Database/Create.hs
@@ -22,7 +22,6 @@ import qualified Data.Map as Map
 import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.Directory
 import TextShow
 
 #ifdef FACEBOOK
@@ -165,7 +164,6 @@ kickOffDatabase env@Env{..} Thrift.KickOff{..}
       when (not $ Storage.canOpenVersion Storage.ReadWrite version) $
         dbError kickOff_repo
           "can't create databases (unsupported binary version)"
-      createDirectoryIfMissing True $ databasePath envRoot kickOff_repo
       db <- atomically $ newDB kickOff_repo
       handle
         (\Catalog.EntryAlreadyExists{} ->

--- a/glean/db/Glean/Database/Delete.hs
+++ b/glean/db/Glean/Database/Delete.hs
@@ -26,7 +26,6 @@ import ServiceData.Types as Stats
 import Util.Control.Exception
 import qualified Util.Control.Exception.CallStack as CallStack
 import Util.Defer
-import Util.IO (safeRemovePathForcibly)
 import Util.Log
 
 import qualified Glean.Database.Catalog as Catalog
@@ -90,11 +89,10 @@ removeDatabase env@Env{..} repo todo = uninterruptibleMask_ $
           Open odb -> closeOpenDB env odb
             `finally` atomically (writeTVar dbState Closed)
           _ -> return ()
-        Catalog.delete envCatalog repo
         Storage.delete envStorage repo
+        Catalog.delete envCatalog repo
         atomically $ modifyTVar envDerivations $
           HashMap.filterWithKey (\(repo',_) _ -> repo' /= repo)
-        safeRemovePathForcibly $ databasePath envRoot repo
       logInfo $ inRepo repo "deleted"
 
 -- | Schedule a DB for deletion and return the 'Async' which can be used to

--- a/glean/db/Glean/Database/Env.hs
+++ b/glean/db/Glean/Database/Env.hs
@@ -18,7 +18,6 @@ import Data.Maybe
 import Data.Time
 import System.Clock (TimeSpec(..))
 import System.Timeout
-import System.IO.Temp
 
 import Data.RateLimiterMap
 import ServiceData.GlobalStats
@@ -33,6 +32,7 @@ import Glean.Database.Close
 import Glean.Database.Janitor
 import qualified Glean.Database.Stats as Stats
 import Glean.Database.Open
+import qualified Glean.Database.Storage as Storage
 import Glean.Database.Types
 import Glean.Database.Work
 import Glean.Database.Work.Heartbeat
@@ -41,11 +41,9 @@ import Glean.Database.Writes
 import qualified Glean.Recipes.Types as Recipes
 import qualified Glean.ServerConfig.Types as ServerConfig
 import Glean.Util.ConfigProvider
-import Glean.Util.Disk
 import Glean.Util.Observed as Observed
 import Glean.Util.Periodic
 import Glean.Util.ShardManager (SomeShardManager)
-import Glean.Util.Some
 import Glean.Util.ThriftSource as ThriftSource
 import Glean.Util.Time
 import qualified Glean.Util.Warden as Warden
@@ -65,35 +63,30 @@ withDatabases evb cfg cfgapi act =
     (if cfgReadOnly cfg then ThriftSource.value def else cfgRecipeConfig cfg)
     $ \recipe_config ->
   ThriftSource.withValue cfgapi (cfgServerConfig cfg) $ \server_config -> do
-    let
-      withRoot Nothing io = withSystemTempDirectory "glean" $ \tmp -> do
-        logInfo $ "Storing temporary DBs in " <> tmp
-        io tmp
-      withRoot (Just dir) io = io dir
-    withRoot (cfgRoot cfg) $ \dbRoot -> do
-      envCatalog <- do
-        Some store <- cfgCatalogStore cfg dbRoot
-        Catalog.open store
-      cfgShardManager cfg envCatalog server_config $ \shardManager ->
-        bracket
-          (initEnv
-            evb
-            dbRoot
-            envCatalog
-            shardManager
-            cfg
-            schema_source
-            recipe_config
-            server_config)
-          closeEnv
-          $ \env -> do
-              resumeWork env
-              spawnThreads env
-              act env
+  server_cfg <- Observed.get server_config
+  dataStoreCreate (cfgDataStore cfg) server_cfg $ \catalog storage -> do
+    envCatalog <- Catalog.open catalog
+    cfgShardManager cfg envCatalog server_config $ \shardManager ->
+      bracket
+        (initEnv
+          evb
+          storage
+          envCatalog
+          shardManager
+          cfg
+          schema_source
+          recipe_config
+          server_config)
+        closeEnv
+        $ \env -> do
+            resumeWork env
+            spawnThreads env
+            act env
 
 initEnv
-  :: EventBaseDataplane
-  -> FilePath
+  :: Storage.Storage storage
+  => EventBaseDataplane
+  -> storage
   -> Catalog.Catalog
   -> SomeShardManager
   -> Config
@@ -101,11 +94,10 @@ initEnv
   -> Observed Recipes.Config
   -> Observed ServerConfig.Config
   -> IO Env
-initEnv evb dbRoot envCatalog shardManager cfg
+initEnv evb envStorage envCatalog shardManager cfg
   envSchemaSource envRecipeConfig envServerConfig = do
-    server_cfg@ServerConfig.Config{..} <- Observed.get envServerConfig
+    ServerConfig.Config{..} <- Observed.get envServerConfig
 
-    Some envStorage <- cfgStorage cfg dbRoot server_cfg
     envActive <- newTVarIO mempty
     envDeleting <- newTVarIO mempty
     envStats <- Stats.new (TimeSpec 10 0)
@@ -137,7 +129,6 @@ initEnv evb dbRoot envCatalog shardManager cfg
       { envEventBase = evb
       , envServerLogger = cfgServerLogger cfg
       , envDatabaseLogger = cfgDatabaseLogger cfg
-      , envRoot = dbRoot
       , envReadOnly = cfgReadOnly cfg
       , envMockWrites = cfgMockWrites cfg
       , envTailerOpts = cfgTailerOpts cfg
@@ -151,11 +142,11 @@ initEnv evb dbRoot envCatalog shardManager cfg
       , .. }
 
 spawnThreads :: Env -> IO ()
-spawnThreads env = do
-  ServerConfig.Config{..} <- Observed.get $ envServerConfig env
+spawnThreads env@Env{..} = do
+  ServerConfig.Config{..} <- Observed.get envServerConfig
 
   case config_janitor_period of
-    Just secs -> Warden.spawn_ (envWarden env)
+    Just secs -> Warden.spawn_ envWarden
       $ doPeriodically (seconds (fromIntegral secs))
         -- a conservative timeout in case the janitor deadlocks for
         -- some reason.
@@ -167,29 +158,28 @@ spawnThreads env = do
           when (isNothing r) $ logError "janitor timeout"
     Nothing -> do
       t <- getCurrentTime
-      atomically $ writeTVar (envDatabaseJanitor env) $ Just t
+      atomically $ writeTVar envDatabaseJanitor $ Just t
 
-  Warden.spawn_ (envWarden env) $ backuper env
+  Warden.spawn_ envWarden $ backuper env
 
-  Warden.spawn_ (envWarden env) $ reapHeartbeats env
+  Warden.spawn_ envWarden $ reapHeartbeats env
 
   replicateM_ (fromIntegral config_db_writer_threads)
-    $ Warden.spawn_ (envWarden env)
-    $ writerThread
-    $ envWriteQueues env
+    $ Warden.spawn_ envWarden
+    $ writerThread envWriteQueues
 
-  when (envUpdateSchema env) $ do
-    Warden.spawnDaemon (envWarden env) "schema updater" $ do
-      void $ atomically $ takeTMVar (envSchemaUpdateSignal env)
+  when envUpdateSchema $ do
+    Warden.spawnDaemon envWarden "schema updater" $ do
+      void $ atomically $ takeTMVar envSchemaUpdateSignal
       schemaUpdated env Nothing
-    doOnUpdate (envSchemaSource env) $
-      atomically $ void $ tryPutTMVar (envSchemaUpdateSignal env) ()
+    doOnUpdate envSchemaSource $
+      atomically $ void $ tryPutTMVar envSchemaUpdateSignal ()
 
   -- Disk usage counters
-  Warden.spawn_ (envWarden env) $ doPeriodically (seconds 600) $ do
+  Warden.spawn_ envWarden $ doPeriodically (seconds 600) $ do
 
-    diskSize <- getDiskSize (envRoot env)
-    used <- getUsedDiskSpace (envRoot env)
+    diskSize <- Storage.getTotalCapacity envStorage
+    used <- Storage.getUsedCapacity envStorage
     void $ setCounter "glean.db.disk.capacity_bytes" diskSize
     void $ setCounter "glean.db.disk.used_bytes" used
     void $

--- a/glean/db/Glean/Database/Storage.hs
+++ b/glean/db/Glean/Database/Storage.hs
@@ -78,6 +78,9 @@ class CanLookup (Database s) => Storage s where
   -- | A fact database
   data Database s
 
+  -- | A short, user-readable description of the storage
+  describe :: s -> String
+
   -- | Open a database
   open :: s -> Repo -> Mode -> DBVersion -> IO (Database s)
 
@@ -86,6 +89,11 @@ class CanLookup (Database s) => Storage s where
 
   -- | Delete a database if it exists
   delete :: s -> Repo -> IO ()
+
+  -- | Unconditionally remove a database or anything that might be stored where
+  -- the database would exist. For disk-based storage, this would remove the
+  -- directory where the database would be stored.
+  safeRemoveForcibly :: s -> Repo -> IO ()
 
   -- | Obtain the 'PredicateStats' for each predicate
   predicateStats :: Database s -> IO [(Pid, PredicateStats)]
@@ -134,6 +142,22 @@ class CanLookup (Database s) => Storage s where
     -> Ownership
     -> Pid
     -> IO ComputedOwnership
+
+  -- | Determine the total capacity of the storage medium (e.g., disk size).
+  getTotalCapacity :: s -> IO Int
+
+  -- | Determine the used capacity of the storage medium (e.g., how much of the
+  -- disk is in use).
+  getUsedCapacity :: s -> IO Int
+
+  -- | Determine the free capacity of the storage medium (e.g., how much of the
+  -- disk is free).
+  getFreeCapacity :: s -> IO Int
+
+  -- | Execute the action, passing to it a path to a scratch directory which can
+  -- be used, e.g., for downloading databases. This directory is not guaranteed
+  -- to persist beyond the call and is not guaranteed to be empty.
+  withScratchRoot :: s -> (FilePath -> IO a) -> IO a
 
   -- | Backup a database. The scratch directory which can be used for storing
   -- intermediate files is guaranteed to be empty and will be deleted after

--- a/glean/db/Glean/Database/Types.hs
+++ b/glean/db/Glean/Database/Types.hs
@@ -37,7 +37,7 @@ import Glean.Database.Config
 import Glean.Database.Meta
 import Glean.Database.Schema.Types
 import Glean.Database.Stats (Stats)
-import Glean.Database.Storage (Database, Storage)
+import Glean.Database.Storage (Database, Storage, describe)
 import Glean.Database.Work.Heartbeat (Heartbeats)
 import Glean.Database.Work.Queue (WorkQueue)
 import Glean.Logger.Server (GleanServerLogger)
@@ -202,7 +202,6 @@ data Env = forall storage. Storage storage => Env
   , envServerLogger :: Some GleanServerLogger
   , envDatabaseLogger :: Some GleanDatabaseLogger
   , envLoggerRateLimit :: RateLimiterMap Text
-  , envRoot :: FilePath
   , envCatalog :: Catalog
   , envStorage :: storage
   , envSchemaSource :: Observed SchemaIndex
@@ -245,5 +244,5 @@ data Env = forall storage. Storage storage => Env
   }
 
 instance Show Env where
-  show env = unwords [ "Glean.Database.Types.Env {",
-    "envRoot: " <> envRoot env, "}" ]
+  show Env{..} = unwords [ "Glean.Database.Types.Env {",
+    "envStorage: " <> describe envStorage, "}" ]

--- a/glean/test/tests/BackupTest.hs
+++ b/glean/test/tests/BackupTest.hs
@@ -113,7 +113,7 @@ withTestEnv dbs init_server_cfg action evb cfgAPI backupdir = do
     }
   (l, events) <- recorder
   let config = def
-        { cfgRoot = Nothing
+        { cfgDataStore = tmpDataStore
         , cfgSchemaSource = schemaSourceFiles
         , cfgRecipeConfig = def
         , cfgServerConfig = server_cfg

--- a/glean/test/tests/DatabaseJanitorTest.hs
+++ b/glean/test/tests/DatabaseJanitorTest.hs
@@ -185,7 +185,7 @@ makeFakeCloudDB backupDir repo dbtime completeness stacked =
 
 dbConfig :: FilePath -> ServerTypes.Config -> Glean.Database.Config.Config
 dbConfig dbdir serverConfig = def
-  { cfgRoot = Just dbdir
+  { cfgDataStore = fileDataStore dbdir
   , cfgSchemaSource = schemaSourceFiles
   , cfgRecipeConfig = def
   , cfgServerConfig = ThriftSource.value serverConfig

--- a/glean/test/tests/Schema/Basic.hs
+++ b/glean/test/tests/Schema/Basic.hs
@@ -384,7 +384,7 @@ changeSchemaTest = TestCase $ do
 
         let
           dbConfig = def
-            { cfgRoot = Nothing
+            { cfgDataStore = tmpDataStore
             , cfgSchemaSource = ThriftSource.configWithDeserializer
                 fakeSchemaKey (processOneSchema Map.empty)
             , cfgServerConfig = ThriftSource.value def

--- a/glean/website/docs/databases.md
+++ b/glean/website/docs/databases.md
@@ -33,6 +33,7 @@ method is chosen by these command-line flags:
 * `--db-root <dir>`  Use databases stored locally in the directory `<dir>`
 * `--db-tmp` Create a temporary directory to store DBs and delete it
   when the program exits.
+* `--db-memory` Store databases in memory rather than on disk.
 
 These flags are accepted by all the Glean command-line tools,
 including `glean` and `glean-server`.

--- a/glean/website/docs/running.md
+++ b/glean/website/docs/running.md
@@ -162,8 +162,5 @@ the database is the one that was active at the time when the DB was
 created, so it is likely to be a correct description of the data in
 the database.
 
-* `--storage (rocksdb | memory)`<br />
-**Default:**: `rocksdb`<br />
-
 * `--db-mock-writes`<br />
 Allow write operations, but discard the data and don't write it to the DB.


### PR DESCRIPTION
Previously, we had `--storage memory` but it still required a `--db-root` directory for storing DB metadata which made it rather less useful. This PR removes the `--storage` flag and add `--db-memory` which is specified *instead* of `--db-root` and stores everything in memory.  The PR touches quite a few files but the main changes are:

  * Glean.Database.Config - support the new flag
  * Glean.Database.Storage - pull some operations into the `Storage` class
  * Glean.Catalog.Local.Memory - extract the in-memory Catalog.Store implementation from Glean.Database.Catalog.Test

Note that `--db-memory` doesn't support quite a few things (yet) but it is sufficient for quite a few things now.

Test Plan:
```
./quick.sh MODE=dev run glean:glean --db-memory --schema dir shell
[...]
> :index cpp-cmake ...
[...]
> src.File _
[...]
```