### PR TITLE
Fix the HLS experience

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:


### PR DESCRIPTION
Without an explicit cradle, HLS will generate one dynamically and hit [two bugs](https://github.com/Avi-D-coder/implicit-hie/pull/48) in the implicit-hie library.

With the explicit Cabal cradle, HLS will interrogate `cabal repl` to find components, which sidesteps the bugs in implicit-hie