### PR TITLE
Tentative fix to runHaxlWithWrites

### DIFF
--- a/glean/client/hs/Glean/Haxl.hs
+++ b/glean/client/hs/Glean/Haxl.hs
@@ -81,7 +81,7 @@ runHaxlWithWrites
   -> IO (a, [w])
 runHaxlWithWrites backend u h = do
   e <- initHaxlEnv backend u
-  second flattenWT <$> Haxl.runHaxlWithWrites e h
+  second (foldMap flattenWT) <$> Haxl.runHaxlWithWrites e h
 
 -- | if the Fact has a key, return it, otherwise fetch it with 'getKey'
 keyOf


### PR DESCRIPTION
This fixes the build error that all CI jobs have been failing with for a few days. Not 100% sure this is the correct fix: I'm just appending all the writes resulting from the list of `WriteTree`s together, which I guess is equivalent to creating a "mega-`WriteTree`" that merges them all together. This seemed like a reasonable implementation, do let me know if I'm wrong.

cc @simonmar