### PR TITLE
Get Haxl from git, for compatibility with yet-unreleased changes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,10 +13,17 @@ packages:
     glean.cabal
     glean/lang/clang/glean-clang.cabal
 
+-- we need a haxl with
+-- https://github.com/facebook/Haxl/commit/260a97b757a6239df153b69b127ded5c47efa13c
+source-repository-package
+  type: git
+  location: https://github.com/facebook/Haxl.git
+  tag: ef52a522fb851be8ed0a38bcd370d29310d5bba0
+
 tests: True
 
 -- necessary to use a haskeline <0.8 with GHCs that ship with base >= 4.14
-allow-newer: haskeline:base
+allow-newer: haskeline:base, thrift-haxl:haxl
 
 -- https://github.com/TomMD/entropy/issues/75
 constraints: entropy < 0.4.1.9

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -141,7 +141,7 @@ common deps
         tar ^>=0.5.1.0,
         ghc-prim >=0.5.2.0 && <0.7,
         parsec ^>=3.1.13.0,
-        haxl >= 2.1.2.0 && < 2.4,
+        haxl >= 2.5 && < 2.6,
         hinotify ^>= 0.4.1
 
 common hsc2hs-cpp
@@ -1097,10 +1097,12 @@ executable hack-derive
     main-is: Derive.hs
     ghc-options: -main-is Derive
     build-depends:
+        aeson-pretty,
         glean:client-hs,
         glean:hack-derive-lib,
+        glean:schema,
         glean:stubs,
-        glean:util,
+        glean:util
 
 -- Haskell indexer via hiedb
 executable hiedb-indexer


### PR DESCRIPTION
See the comment in `cabal.project` for the changes in question which are assumed to be there by Glean's code, and we probably don't want to maintain the two codepaths, picking one or the other depending on the version of Haxl we're building against through CPP...