### PR TITLE
Clang codemarkup tests (#220)

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1600,6 +1600,25 @@ test-suite clang-test-deriveobjcinherit
 --     if !flag(clang-tests)
 --         buildable: False
 
+test-suite clang-test-codemarkup
+    import: fb-haskell, fb-cpp, deps
+    hs-source-dirs:
+       glean/lang/clang/tests,
+       glean/lang/clang/tests/github
+    type: exitcode-stdio-1.0
+    main-is: Glean/Clang/CodeMarkup.hs
+    other-modules: Glean.Clang.Test.DerivePass
+                   Glean.Clang.Test
+                   Glean.Regression.Driver.DeriveForCodemarkup
+    ghc-options: -main-is Glean.Clang.CodeMarkup
+    build-depends:
+       glean:regression-test-lib,
+       glean:clang-derive-lib,
+       glean:indexers,
+       glean:lib
+    if !flag(clang-tests)
+        buildable: False
+
 test-suite hack-derive-test
     import: fb-haskell, fb-cpp, deps
     hs-source-dirs: glean/lang/hack/tests

--- a/glean/lang/clang/tests/github/Glean/Clang/CodeMarkup.hs
+++ b/glean/lang/clang/tests/github/Glean/Clang/CodeMarkup.hs
@@ -1,0 +1,18 @@
+module Glean.Clang.CodeMarkup where
+
+import System.Environment
+
+import qualified Glean.Regression.Driver.DeriveForCodemarkup as D
+
+main :: IO ()
+main = getArgs >>= \args ->
+  withArgs (args ++ extraArgs) D.main
+  where
+    extraArgs = [
+      "--root", path,
+      "--omit", "declarations/typeAlias1"
+        -- Bug fixed upstream in LLVM:
+        --  https://github.com/llvm/llvm-project/commit/d9c979ef33ff83b49ba14c2eecdf499bae4565f4
+        -- TODO: re-enable when using a fixed LLVM
+      ]
+    path = "glean/lang/codemarkup/tests/clang"


### PR DESCRIPTION
Summary:
(This PR is based on top of https://github.com/facebookincubator/Glean/issues/208 and https://github.com/facebookincubator/Glean/issues/218 and should only be imported after these two have landed.)

Current status: `Cases: 56  Tried: 56  Errors: 0  Failures: 37`

Many/most failures look like this:

```
### Failure in: 0:55:xrefs/using-decl3
glean/test/regression/Glean/Regression/Snapshot.hs:203
ppPPEntityLocation.perf: unexpected result
1c1
< { "generated": null, "pp1.Define.1": 380, "src.File.1": 382 }
\ No newline at end of file
 ---
> { "generated": null, "pp1.Define.1": 382, "src.File.1": 384 }
\ No newline at end of file
```

with those numbers being slightly different.

<details>
  <summary>Detailed logs of all 56 tests</summary>

[tests-codemarkup.log](https://github.com/facebookincubator/Glean/files/9114076/tests-codemarkup.log)

</details>

Pull Request resolved: https://github.com/facebookincubator/Glean/pull/220

Reviewed By: donsbot, lazamar

Differential Revision: D38738633

