### PR TITLE
Implement predicateStats for in-memory backend

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -392,6 +392,7 @@ library core
         Glean.RTS.Foreign.Ownership
         Glean.RTS.Foreign.Query
         Glean.RTS.Foreign.Stacked
+        Glean.RTS.Foreign.Stats
         Glean.RTS.Foreign.Subst
         Glean.RTS.Foreign.Thrift
         Glean.RTS.Foreign.Typecheck

--- a/glean/db/Glean/Database/Storage/Memory.hs
+++ b/glean/db/Glean/Database/Storage/Memory.hs
@@ -27,8 +27,7 @@ import Glean.Repo.Text
 import Glean.RTS.Foreign.FactSet (FactSet)
 import qualified Glean.RTS.Foreign.FactSet as FactSet
 import Glean.RTS.Foreign.Lookup
-import Glean.RTS.Types (lowestPid)
-import Glean.Types (PredicateStats(..), Repo)
+import Glean.Types (Repo)
 
 newtype Memory = Memory (TVar (HashMap Repo (Database Memory)))
 
@@ -68,10 +67,7 @@ instance Storage Memory where
 
   safeRemoveForcibly = delete
 
-  -- FIXME: This is a terrible hack to ensure we don't remove everything when
-  -- thinning the schema
-  predicateStats _ =
-    return $ take 10000 [(pid, PredicateStats 1 1) | pid <- [lowestPid ..]]
+  predicateStats = FactSet.predicateStats . dbFacts
 
   store db key value =
     atomically $ modifyTVar' (dbData db) $ HashMap.insert key value

--- a/glean/hs/Glean/RTS/Foreign/Stats.hs
+++ b/glean/hs/Glean/RTS/Foreign/Stats.hs
@@ -1,0 +1,35 @@
+module Glean.RTS.Foreign.Stats
+  ( marshalPredicateStats
+  ) where
+
+import Control.Monad (forM)
+import Data.Int
+import Data.Word
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign.Ptr
+import Foreign.Storable
+
+import Util.FFI
+
+import Glean.FFI
+import Glean.RTS.Types (Pid(..))
+import Glean.Types
+
+marshalPredicateStats
+  :: (Ptr CSize
+      -> Ptr (Ptr Int64)
+      -> Ptr (Ptr Word64)
+      -> Ptr (Ptr Word64)
+      -> IO CString)
+  -> IO [(Pid, PredicateStats)]
+marshalPredicateStats get = do
+  (count, pids, counts, sizes) <- invoke get
+  usingMalloced pids $
+    usingMalloced counts $
+    usingMalloced sizes $
+    forM [0 .. fromIntegral count - 1] $ \i -> do
+      pid <- peekElemOff pids i
+      count <- peekElemOff counts i
+      size <- peekElemOff sizes i
+      return (Pid pid, PredicateStats (fromIntegral count) (fromIntegral size))

--- a/glean/rocksdb/ffi.cpp
+++ b/glean/rocksdb/ffi.cpp
@@ -200,32 +200,14 @@ const char *glean_rocksdb_get_unit(Database *db, uint32_t unit_id, void **unit,
   });
 }
 
-
-const char *glean_rocksdb_database_stats(
+const char *glean_rocksdb_database_predicateStats(
     Database *db,
     size_t *count,
     int64_t **ids,
     uint64_t **counts,
     uint64_t **sizes) {
   return ffi::wrap([=] {
-    const auto stats = db->stats();
-    const auto n = stats.size();
-    auto ids_arr = ffi::malloc_array<int64_t>(n);
-    auto counts_arr = ffi::malloc_array<uint64_t>(n);
-    auto sizes_arr = ffi::malloc_array<uint64_t>(n);
-    size_t i = 0;
-    for (const auto x : stats) {
-      if (x.second.count) {
-        ids_arr[i] = x.first.toThrift();
-        counts_arr[i] = x.second.count;
-        sizes_arr[i] = x.second.memory;
-        ++i;
-      }
-    }
-    *count = i;
-    *ids = ids_arr.release();
-    *counts = counts_arr.release();
-    *sizes = sizes_arr.release();
+    rts::marshal(db->predicateStats(), count, ids, counts, sizes);
   });
 }
 

--- a/glean/rocksdb/ffi.h
+++ b/glean/rocksdb/ffi.h
@@ -140,7 +140,7 @@ const char *glean_rocksdb_get_unit(
   size_t *unit_size
 );
 
-const char *glean_rocksdb_database_stats(
+const char *glean_rocksdb_database_predicateStats(
   Database *db,
   size_t *count,
   int64_t **ids,

--- a/glean/rocksdb/rocksdb.cpp
+++ b/glean/rocksdb/rocksdb.cpp
@@ -540,9 +540,9 @@ struct DatabaseImpl final : Database {
     }
   }
 
-  PredicateStats loadStats() {
+  rts::PredicateStats loadStats() {
     container_.requireOpen();
-    PredicateStats stats;
+    rts::PredicateStats stats;
     std::unique_ptr<rocksdb::Iterator> iter(
       container_.db->NewIterator(
         rocksdb::ReadOptions(),
@@ -1023,7 +1023,7 @@ struct DatabaseImpl final : Database {
     return stats_.count(pid);
   }
 
-  PredicateStats stats() const override {
+  rts::PredicateStats predicateStats() const override {
     return stats_.get();
   }
 

--- a/glean/rocksdb/rocksdb.h
+++ b/glean/rocksdb/rocksdb.h
@@ -79,9 +79,7 @@ std::unique_ptr<Container> open(
 struct Database : rts::Lookup {
   virtual Container& container() noexcept = 0;
 
-  using PredicateStats = rts::DenseMap<Pid, rts::MemoryStats>;
-
-  virtual PredicateStats stats() const = 0;
+  virtual rts::PredicateStats predicateStats() const = 0;
 
   struct OwnershipSet {
     folly::ByteRange unit;

--- a/glean/rts/densemap.h
+++ b/glean/rts/densemap.h
@@ -42,6 +42,14 @@ public:
     return count;
   }
 
+  key_type low_bound() const {
+    return start;
+  }
+
+  key_type high_bound() const {
+    return start + data.size();
+  }
+
 private:
   template<typename Val, typename Base>
   struct Iter {
@@ -123,7 +131,6 @@ public:
     return iterator(start + data.size(), data.end(), data.end());
   }
 
-private:
   // Reserve space to cover all keys from low up to but not including high
   void reserve(key_type from, key_type upto) {
     if (data.empty()) {
@@ -147,7 +154,6 @@ private:
     }
   }
 
-public:
   mapped_type& operator[](key_type key) {
     reserve(key, key+1);
     const auto i = key - start;

--- a/glean/rts/factset.h
+++ b/glean/rts/factset.h
@@ -13,6 +13,7 @@
 #include "glean/rts/fact.h"
 #include "glean/rts/inventory.h"
 #include "glean/rts/ondemand.h"
+#include "glean/rts/stats.h"
 #include "glean/rts/store.h"
 #include "glean/rts/substitution.h"
 
@@ -166,6 +167,8 @@ public:
     return fact_memory;
   }
 
+  PredicateStats predicateStats() const;
+
  // Lookup implementation
 
   Id idByKey(Pid type, folly::ByteRange key) override;
@@ -249,6 +252,11 @@ private:
   std::vector<Fact::unique_ptr> facts;
   DenseMap<Pid, FastSetBy<const Fact *, FactByKeyOnly>> keys;
   size_t fact_memory;
+
+  /// Cached predicate stats. We create these on-demand rather than maintain
+  /// them throughout because most FactSets don't need them.
+  struct CachedPredicateStats;
+  mutable OnDemand<CachedPredicateStats> predicate_stats;
 
   /// Index for prefix seeks. It is lazily initialised and slow as we typically
   /// don't do seeks on FactSets.

--- a/glean/rts/ffi.cpp
+++ b/glean/rts/ffi.cpp
@@ -465,6 +465,17 @@ size_t glean_factset_fact_memory(FactSet *facts) {
   return facts->factMemory();
 }
 
+const char *glean_factset_predicateStats(
+    FactSet *facts,
+    size_t *count,
+    int64_t **ids,
+    uint64_t **counts,
+    uint64_t **sizes) {
+  return ffi::wrap([=] {
+    marshal(facts->predicateStats(), count, ids, counts, sizes);
+  });
+}
+
 int64_t glean_factset_first_free_id(FactSet *facts) {
   return facts->firstFreeId().toThrift();
 }

--- a/glean/rts/ffi.h
+++ b/glean/rts/ffi.h
@@ -295,6 +295,13 @@ size_t glean_factset_fact_memory(
   FactSet *facts
 );
 
+const char *glean_factset_predicateStats(
+  FactSet *facts,
+  size_t *count,
+  int64_t **ids,
+  uint64_t **counts,
+  uint64_t **sizes);
+
 Lookup *glean_factset_lookup(FactSet *facts);
 Define *glean_factset_define(FactSet *define);
 

--- a/glean/rts/stats.cpp
+++ b/glean/rts/stats.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef OSS
+#include <cpp/memory.h> // @manual
+#else
+#include <common/hs/util/cpp/memory.h>
+#endif
+
+#include "glean/rts/stats.h"
+
+using namespace facebook::hs;
+
+namespace facebook {
+namespace glean {
+namespace rts {
+
+void marshal(
+    const PredicateStats& stats,
+    size_t *count,
+    int64_t **ids,
+    uint64_t **counts,
+    uint64_t **sizes) {
+  const auto n = stats.size();
+  auto ids_arr = ffi::malloc_array<int64_t>(n);
+  auto counts_arr = ffi::malloc_array<uint64_t>(n);
+  auto sizes_arr = ffi::malloc_array<uint64_t>(n);
+  size_t i = 0;
+  for (const auto x : stats) {
+    if (x.second.count) {
+      ids_arr[i] = x.first.toThrift();
+      counts_arr[i] = x.second.count;
+      sizes_arr[i] = x.second.memory;
+      ++i;
+    }
+  }
+  *count = i;
+  *ids = ids_arr.release();
+  *counts = counts_arr.release();
+  *sizes = sizes_arr.release();
+}
+
+}
+}
+}

--- a/glean/rts/stats.h
+++ b/glean/rts/stats.h
@@ -11,6 +11,9 @@
 #include <cstdlib>
 #include <limits>
 
+#include "glean/rts/densemap.h"
+#include "glean/rts/id.h"
+
 namespace facebook {
 namespace glean {
 namespace rts {
@@ -106,8 +109,16 @@ struct MemoryStats {
   bool operator!=(const MemoryStats& other) const {
     return !(*this == other);
   }
-
 };
+
+using PredicateStats = DenseMap<Pid, MemoryStats>;
+
+void marshal(
+  const PredicateStats& stats,
+  size_t *count,
+  int64_t **ids,
+  uint64_t **counts,
+  uint64_t **sizes);
 
 }
 }

--- a/mk/cxx.mk
+++ b/mk/cxx.mk
@@ -52,6 +52,7 @@ CXX_SOURCES_glean_cpp_rts = \
     glean/rts/prim.cpp \
     glean/rts/query.cpp \
     glean/rts/sanity.cpp \
+    glean/rts/stats.cpp \
     glean/rts/string.cpp \
     glean/rts/substitution.cpp \
     glean/rts/thrift.cpp \


### PR DESCRIPTION
We want to make the in-memory backend work properly and this was a major missing piece. This adds support for computing `PredicateStats` to `FactSet` and threads it all the way through to the in-memory backend code. The stats are computed lazily and cached. There are a few knock-on effects, mostly due to moving `PredicateStats` from `rocksdb` to `rts`.