### PR TITLE
quick.sh: Support for C++ tests and improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,9 @@ $(CXX_DIR)/defs.m4: force
 cxx-libraries: gen-bytecode
 	@$(MAKE) -f mk/cxx.mk --no-print-directory CXX_MODE=$(CXX_MODE) CXX_DIR=$(CXX_DIR) $@
 
+cxx-test-%: force
+	@$(MAKE) -f mk/cxx.mk --no-print-directory CXX_MODE=$(CXX_MODE) CXX_DIR=$(CXX_DIR) $@
+
 .PHONY: glean
 glean:: glean.cabal cxx-libraries
 	$(CABAL) build glean glean-server glean-hyperlink

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1816,6 +1816,16 @@ test-suite jsonwrite
         glean:if-glean-hs,
         glean:schema,
 
+test-suite BinaryTest
+    import: fb-cpp
+    type: exitcode-stdio-1.0
+    main-is: glean/rts/tests/BinaryTest.cpp
+    ghc-options: -no-hs-main
+    cxx-options: -DOSS=1
+    build-depends:
+        glean:rts
+    pkgconfig-depends: gtest_main
+
 test-suite rtstest
     import: test
     type: exitcode-stdio-1.0

--- a/mk/cxx.mk
+++ b/mk/cxx.mk
@@ -78,10 +78,17 @@ CXX_SOURCES_glean_cpp_client = \
     glean/interprocess/cpp/counters.cpp
 CXX_FLAGS_glean_cpp_client = -DOSS=1
 
+CXX_GTEST_SOURCES_BinaryTest = \
+    glean/rts/tests/BinaryTest.cpp
+CXX_GTEST_LIBS_BinaryTest = glean_cpp_rts
+CXX_GTEST_FLAGS_BinaryTest = -DOSS=1
+
 # End of C++ library definitions
 
 # Determine all C++ libraries
 CXX_LIBRARIES = $(subst CXX_SOURCES_,,$(filter CXX_SOURCES_%, $(.VARIABLES)))
+
+CXX_GTESTS = $(subst CXX_GTEST_SOURCES_,,$(filter CXX_GTEST_SOURCES_%, $(.VARIABLES)))
 
 .PHONY: cxx-libraries
 cxx-libraries:

--- a/quick.sh
+++ b/quick.sh
@@ -28,15 +28,11 @@ for arg in "$@"; do
   esac
 done
 
-TARGET=$1
-shift
+[ -n "$ACTION" ] || fatal "No action specified"
 
-if [ -z "$ACTION" ]; then
-  fatal "No action specified"
-fi
-if [ -z "$TARGET" ]; then
-  fatal "No target specified"
-fi
+TARGET=$1
+[ -n "$TARGET" ] || fatal "No target specified"
+shift
 
 make "${MAKE_ARGS[@]}" .build/current.sh glean.cabal cxx-libraries
 

--- a/quick.sh
+++ b/quick.sh
@@ -16,7 +16,7 @@ MAKE_ARGS=()
 
 for arg in "$@"; do
   case $arg in
-    build|run|test|list-bin)
+    build|run|test|list-bin|cxx-test)
       ACTION="$1"
       shift
       break
@@ -42,10 +42,18 @@ make "${MAKE_ARGS[@]}" .build/current.sh glean.cabal cxx-libraries
 
 . .build/current.sh
 
-CABAL_ARGS=()
-# Suppress "Up to date" etc. for list-bin
-if [ "$ACTION" = "list-bin" ]; then
-  CABAL_ARGS+=(-vsilent)
-fi
+case $ACTION in
+  cxx-test)
+    make "${MAKE_ARGS[@]}" "cxx-test-$TARGET"
+    ;;
 
-call_cabal "${CABAL_ARGS[@]}" "${ACTION}" "${TARGET}" -- "$@"
+  *)
+    CABAL_ARGS=()
+    # Suppress "Up to date" etc. for list-bin
+    if [ "$ACTION" = "list-bin" ]; then
+      CABAL_ARGS+=(-vsilent)
+    fi
+
+    call_cabal "${CABAL_ARGS[@]}" "${ACTION}" "${TARGET}" -- "$@"
+    ;;
+esac

--- a/quick.sh
+++ b/quick.sh
@@ -50,6 +50,6 @@ case $ACTION in
       CABAL_ARGS+=(-vsilent)
     fi
 
-    call_cabal "${CABAL_ARGS[@]}" "${ACTION}" "${TARGET}" -- "$@"
+    call_cabal "${CABAL_ARGS[@]}" "${ACTION}" -f benchmarks "${TARGET}" -- "$@"
     ;;
 esac


### PR DESCRIPTION
This adds support for running C++ tests from quick.sh similar to how C++ libraries are built. There are also minor improvements to quick.sh which I include in this PR because I'm too lazy to make dependent PRs: a fix to the error handling and we now always pass -f benchmark to Cabal because we definitely want those available during development.
This also adds BinaryTest to the Cabal find. Sadly, this is completely independent from the C++ test support - either I'll fix this eventually or we get a reasonable build system before that.

Test plan: `./quick.sh MODE=dev cxx-test BinaryTest`