### PR TITLE
Refactor FactSet's fact table

### DIFF
--- a/glean/rts/fact.h
+++ b/glean/rts/fact.h
@@ -71,6 +71,8 @@ public:
     }
   };
 
+  static void serialize(binary::Output& output, Pid type, Clause clause);
+
   struct Ref {
     Id id = Id::invalid();
     Pid type = Pid::invalid();
@@ -90,6 +92,10 @@ public:
 
     folly::ByteRange value() const {
       return clause.value();
+    }
+
+    void serialize(binary::Output& output) const {
+      Fact::serialize(output, type, clause);
     }
   };
 
@@ -144,7 +150,6 @@ public:
     return size(key_size, value_size);
   }
 
-  static void serialize(binary::Output& output, Pid type, Clause clause);
 
   void serialize(binary::Output& output) const {
     serialize(output, type(), clause());

--- a/glean/rts/factset.cpp
+++ b/glean/rts/factset.cpp
@@ -34,7 +34,7 @@ struct FactSet::Index {
   folly::Synchronized<DenseMap<Pid, std::unique_ptr<entry_t>>> index;
 };
 
-FactSet::FactSet(Id start) : starting_id(start) {}
+FactSet::FactSet(Id start) : facts(start) {}
 FactSet::FactSet(FactSet&&) noexcept = default;
 FactSet& FactSet::operator=(FactSet&&) = default;
 FactSet::~FactSet() noexcept = default;
@@ -60,7 +60,7 @@ PredicateStats FactSet::predicateStats() const {
     wlock->stats.reserve(keys.low_bound(), keys.high_bound());
     for (const auto& fact
           : folly::range(facts.begin() + wlock->upto, facts.end())) {
-      wlock->stats[fact.type()] += MemoryStats::one(fact.clause().size());
+      wlock->stats[fact.type] += MemoryStats::one(fact.clause.size());
     }
     wlock->upto = facts.size();
     return wlock->stats;
@@ -80,20 +80,20 @@ Id FactSet::idByKey(Pid type, folly::ByteRange key) {
 }
 
 Pid FactSet::typeById(Id id) {
-  if (id >= starting_id) {
-    const auto i = distance(starting_id, id);
+  if (id >= facts.startingId()) {
+    const auto i = distance(facts.startingId(), id);
     if (i < facts.size()) {
-      return facts[i].type();
+      return facts[i].type;
     }
   }
   return Pid::invalid();
 }
 
 bool FactSet::factById(Id id, std::function<void(Pid, Fact::Clause)> f) {
-  if (id >= starting_id) {
-    const auto i = distance(starting_id, id);
+  if (id >= facts.startingId()) {
+    const auto i = distance(facts.startingId(), id);
     if (i < facts.size()) {
-      f(facts[i].type(), facts[i].clause());
+      f(facts[i].type, facts[i].clause);
       return true;
     }
   }
@@ -120,7 +120,7 @@ std::unique_ptr<FactIterator> FactSet::enumerate(Id from, Id upto) {
     }
 
     Fact::Ref get(Demand) override {
-      return pos != end ? pos->ref() : Fact::Ref::invalid();
+      return pos != end ? *pos : Fact::Ref::invalid();
     }
 
     std::optional<Id> lower_bound() override { return std::nullopt; }
@@ -150,7 +150,7 @@ std::unique_ptr<FactIterator> FactSet::enumerateBack(Id from, Id downto) {
       if (pos != end) {
         auto i = pos;
         --i;
-        return i->ref();
+        return *i;
       } else {
         return Fact::Ref::invalid();
       }
@@ -259,7 +259,7 @@ Id FactSet::define(Pid type, Fact::Clause clause, Id) {
 
 thrift::Batch FactSet::serialize() const {
   binary::Output output;
-  for (auto& fact : *this) {
+  for (auto fact : *this) {
     fact.serialize(output);
   }
 
@@ -304,12 +304,12 @@ template<typename Context>
 std::pair<binary::Output, size_t> substituteFact(
     const Inventory& inventory,
     const Predicate::Rename<Context>& substitute,
-    const Fact &fact) {
-  auto predicate = inventory.lookupPredicate(fact.type());
+    Fact::Ref fact) {
+  auto predicate = inventory.lookupPredicate(fact.type);
   CHECK_NOTNULL(predicate);
   binary::Output clause;
   uint64_t key_size;
-  predicate->substitute(substitute, fact.clause(), clause, key_size);
+  predicate->substitute(substitute, fact.clause, clause, key_size);
   return {std::move(clause), key_size};
 }
 
@@ -327,21 +327,21 @@ FactSet FactSet::rebase(
 
   const auto split = lower_bound(subst.finish());
 
-  for (auto& fact : folly::range(begin(), split)) {
+  for (auto fact : folly::range(begin(), split)) {
     auto r = substituteFact(inventory, substitute, fact);
     global.insert({
-      subst.subst(fact.id()),
-      fact.type(),
+      subst.subst(fact.id),
+      fact.type,
       Fact::Clause::from(r.first.bytes(), r.second)
     });
   }
 
   FactSet local(new_start);
   auto expected = new_start;
-  for (auto& fact : folly::range(split, end())) {
+  for (auto fact : folly::range(split, end())) {
     auto r = substituteFact(inventory, substitute, fact);
     const auto id =
-      local.define(fact.type(), Fact::Clause::from(r.first.bytes(), r.second));
+      local.define(fact.type, Fact::Clause::from(r.first.bytes(), r.second));
     CHECK(id == expected);
     ++expected;
   }

--- a/glean/rts/factset.h
+++ b/glean/rts/factset.h
@@ -109,12 +109,16 @@ template<typename T, typename By> using FastSetBy =
  */
 class FactSet final : public Define {
 private:
-  struct Facts {
-    Facts() noexcept = default;
+  class Facts final {
+  public:
+    explicit Facts(Id start) noexcept
+      : starting_id(start) {}
     Facts(Facts&& other) noexcept
-      : facts(std::move(other.facts))
+      : starting_id(other.starting_id)
+      , facts(std::move(other.facts))
       , fact_memory(other.fact_memory) {}
     Facts& operator=(Facts&& other) noexcept {
+      starting_id = other.starting_id;
       facts = std::move(other.facts);
       fact_memory = other.fact_memory;
       return *this;
@@ -128,9 +132,13 @@ private:
       return facts.size();
     }
 
+    Id startingId() const {
+      return starting_id;
+    }
+
     struct deref {
-      const Fact& operator()(const Fact::unique_ptr& p) const {
-        return *p;
+      Fact::Ref operator()(const Fact::unique_ptr& p) const {
+        return p->ref();
       }
     };
 
@@ -147,9 +155,9 @@ private:
       return boost::make_transform_iterator(facts.end(), deref());
     }
 
-    const Fact& operator[](size_t i) const {
+    Fact::Ref operator[](size_t i) const {
       assert (i < facts.size());
-      return *facts[i];
+      return facts[i]->ref();
     }
 
     void clear() {
@@ -181,6 +189,8 @@ private:
       return fact_memory;
     }
 
+  private:
+    Id starting_id;
     std::vector<Fact::unique_ptr> facts;
     size_t fact_memory = 0;
   };
@@ -217,16 +227,16 @@ public:
   /// given id (or end() if no such fact exists).
   const_iterator lower_bound(Id id) const {
     return begin() +
-      (id <= starting_id
+      (id <= facts.startingId()
         ? 0
-        : std::min(distance(starting_id, id), facts.size()));
+        : std::min(distance(facts.startingId(), id), facts.size()));
   }
 
   const_iterator upper_bound(Id id) const {
     return begin() +
-      (id < starting_id
+      (id < facts.startingId()
         ? 0
-        : std::min(distance(starting_id, id)+1, facts.size()));
+        : std::min(distance(facts.startingId(), id)+1, facts.size()));
   }
 
   /// Return the number of bytes occupied by facts.
@@ -245,11 +255,11 @@ public:
   bool factById(Id id, std::function<void(Pid, Fact::Clause)> f) override;
 
   Id startingId() const override {
-    return starting_id;
+    return facts.startingId();
   }
 
   Id firstFreeId() const override {
-    return starting_id + facts.size();
+    return facts.startingId() + facts.size();
   }
 
   Interval count(Pid pid) const override;
@@ -315,8 +325,6 @@ public:
   bool sanityCheck() const;
 
 private:
-  Id starting_id;
-
   Facts facts;
   DenseMap<Pid, FastSetBy<const Fact *, FactByKeyOnly>> keys;
 


### PR DESCRIPTION
This is one of a number of preparatory refactors before a big rewrite of `FactSet`'s implementation. We pull out the `Id`-based fact table that `FactSet` uses into a separate class whose interface is based on `Fact::Ref`, not `Fact*`. There is (hopefully) no functional change, this is a pure refactor.

These interfaces are quite volatile atm so I didn't bother adding comments as they will be further replaced shortly.

The upcoming `FactSet` implementation is not based on `Fact` (which has terrible locality and probably leads to quite a bit of fragmentation) so this is a step in the right direction.