### PR TITLE
Add FactSet benchmark

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -382,6 +382,7 @@ library core
         Glean.RTS.Bytecode.Disassemble
         Glean.RTS.Bytecode.Supply
         Glean.RTS.Constants
+        Glean.RTS.Foreign.Benchmarking
         Glean.RTS.Foreign.Bytecode
         Glean.RTS.Foreign.Define
         Glean.RTS.Foreign.FactSet

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1357,6 +1357,23 @@ executable compile-bench
         statistics,
         vector-algorithms
 
+executable factset-bench
+    import: fb-haskell, deps, exe
+    if !flag(benchmarks)
+       buildable: False
+    hs-source-dirs: glean/bench
+    main-is: FactSetBench.hs
+    ghc-options: -main-is FactSetBench
+    build-depends:
+        glean:bench-util,
+        glean:client-hs,
+        glean:client-hs-local,
+        glean:core,
+        glean:db,
+        glean:schema,
+        glean:test-lib,
+        glean:util
+
 -- -----------------------------------------------------------------------------
 -- Tests
 

--- a/glean/bench/FactSetBench.hs
+++ b/glean/bench/FactSetBench.hs
@@ -1,0 +1,218 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+{-
+
+This file implements a set of benchmarks for FactSets which can use real-world
+data. It copies all facts from a DB (selected as usual via `--db-root` and
+`--db`) and then runs the benchmarks on FactSets initialised with these facts.
+
+For best results, the DB shouldn't be too small but also shouldn't be huge
+(since all facts will be stored in RAM multiple times).
+
+For comparison, it can also run the same benchmarks on the DB it obtained the
+facts from.
+
+Run each benchmark once:
+  factset-bench --db-root=... --db=... --schema=dir
+
+Run only FactSet (but not DB) benchmarks:
+  factset-bench ... --only-factset
+
+Run specific benchmark 6 times:
+  factset-bench ... --repeat=6 redefine
+
+Run specific benchmark forever (useful for `perf` etc.):
+  factset-bench ... --forever redefine
+
+-}
+
+{-# LANGUAGE ApplicativeDo #-}
+module FactSetBench (main) where
+
+import Control.Monad
+import qualified Data.Vector.Storable as V
+import Options.Applicative
+import System.Exit (die)
+
+import Glean (Repo, parseRepo)
+import qualified Glean.Database.Config as Database (Config, options)
+import Glean.Database.Env (withDatabases)
+import Glean.Database.Open (readDatabase)
+import Glean.Impl.ConfigProvider
+import qualified Glean.RTS.Foreign.Benchmarking as B
+import qualified Glean.RTS.Foreign.FactSet as FactSet
+import qualified Glean.RTS.Foreign.Lookup as Lookup
+
+import Glean.Util.ConfigProvider
+import Util.EventBase (withEventBaseDataplane)
+import Util.Timing
+
+data Config = Config
+  { configOptions :: Database.Config
+  , configRepo :: Repo
+  , configBenchmarks :: [[Benchmark]]
+  , configRunner :: Runner
+  , configOnlyFactSet :: Bool
+  }
+
+data Ctx = Ctx
+  { ctxReport :: String -> IO ()
+  , ctxFail :: IO ()
+  , ctxDB :: Lookup.Lookup
+  , ctxFactBlock :: B.FactBlock
+  , ctxFactSet :: FactSet.FactSet
+  , ctxRunner :: Runner
+  }
+
+type Runner = (String -> IO ()) -> IO Double -> IO ()
+
+runOnce :: Runner
+runOnce report action = do
+  t <- action
+  report $ showTime t
+
+runRepeat :: Int -> Runner
+runRepeat n report action = when (n /= 0) $ do
+  ts <- replicateM n action
+  let min_time = minimum ts
+      max_time = maximum ts
+      avg_time = sum ts / fromIntegral n
+  report $ unwords
+    [ "min:", showTime min_time
+    , "avg:", showTime avg_time
+    , "max:", showTime max_time
+    ]
+
+runForever :: Runner
+runForever _ = forever
+
+time :: (Ctx -> IO Bool) -> Ctx -> IO ()
+time action ctx = ctxRunner ctx (ctxReport ctx) $ do
+  (time, _, ok) <- timeIt $ action ctx
+  when (not ok) $ ctxFail ctx
+  return time
+
+data Benchmark = Benchmark
+  { bName :: String
+  , bEnabled :: Config -> Bool
+  , bRun :: Ctx -> IO ()
+  }
+
+bench :: String -> (Ctx -> IO ()) -> [Benchmark]
+bench name f = [Benchmark name (const True) f]
+
+benchBoth
+  :: String
+  -> (forall l. Lookup.CanLookup l => l -> Ctx -> IO ())
+  -> [Benchmark]
+benchBoth name f =
+  [ Benchmark (name ++ "-db") (not . configOnlyFactSet) $ \ctx -> f (ctxDB ctx) ctx
+  , Benchmark name (const True) $ \ctx -> f (ctxFactSet ctx) ctx ]
+
+lookupB
+  :: Lookup.CanLookup l => (l -> B.FactBlock -> IO Bool) -> l -> Ctx -> IO ()
+lookupB f l = time $ f l <$> ctxFactBlock
+
+benchmarks :: [Benchmark]
+benchmarks = concat
+  [ bench "define" $ \ctx@Ctx{..} -> do
+      id <- Lookup.startingId ctxDB
+      time (const $  do
+        factset <- FactSet.new id
+        B.defineEach factset ctxFactBlock) ctx
+  
+  , bench "redefine" $ time $ B.defineEach <$> ctxFactSet <*> ctxFactBlock
+
+  , benchBoth "type" $ lookupB B.lookupEachType
+  , benchBoth "byId" $ lookupB B.lookupEachById
+  , benchBoth "byKey" $ lookupB B.lookupEachByKey
+  , benchBoth "seekToEach" $ lookupB B.seekToEach
+  -- The first seekToEach initialised things in the FactSet so lets' measure
+  -- again
+  , benchBoth "seekToEach2" $ lookupB B.seekToEach
+  , benchBoth "seekAll" $ \l ctx@Ctx{..} -> do
+      count <- FactSet.factCount ctxFactSet
+      pids <- V.fromList . map fst <$> FactSet.predicateStats ctxFactSet
+      time (const $ (count == ) <$> B.seekCount l pids) ctx
+  ]
+
+options :: ParserInfo Config
+options = info (parser <**> helper)
+  (fullDesc <> progDesc "Generate a random batch of facts")
+  where
+    parser = do
+      configOptions <- Database.options
+      configRepo <- option (maybeReader Glean.parseRepo)
+        (  long "db"
+        <> metavar "NAME/INSTANCE"
+        <> help "identifies the database"
+        )
+      configBenchmarks <- many $ argument
+        (maybeReader $ \s -> case filter (\b -> bName b == s) benchmarks of
+          [] -> Nothing
+          xs -> Just xs)
+        ( metavar "BENCHMARK"
+        <> help "selects benchmark"
+        )
+      configRunner <-
+        fmap runRepeat (option auto
+          (  long "repeat"
+          <> metavar "N"
+          <> help "repeat each benchmark N times" ))
+        <|> flag' runForever (long "forever")
+        <|> pure runOnce
+      configOnlyFactSet <- switch
+        ( long "only-factset"
+        <> help "skip DB benchmarks"
+        )
+      return Config{..}
+
+main :: IO ()
+main =
+  withConfigOptions options $ \(config@Config{..}, cfg) ->
+  withEventBaseDataplane $ \evb ->
+  withConfigProvider cfg $ \(cfgAPI :: ConfigAPI) ->
+  withDatabases evb configOptions cfgAPI $ \env ->
+  readDatabase env configRepo $ \_ db -> do
+    block <- B.createFactBlock db
+    startingId <- Lookup.startingId db
+    factset <- FactSet.new startingId
+    ok <- B.defineEach factset block
+    when (not ok) $ die "FactSet creation failed"
+
+    block_count <- B.factCount block
+    block_memory <- B.factMemory block
+    putStrLn $ unwords
+      [ "FactBlock facts:", show block_count
+      , "factmem:", showAllocs $ fromIntegral block_memory
+      ]
+    count <- FactSet.factCount factset
+    mem <- FactSet.allocatedMemory factset
+    factmem <- FactSet.factMemory factset
+    putStrLn $ unwords
+      [ "FactSet facts:", show count
+      , "mem:", showAllocs $ fromIntegral mem
+      , "factmem:", showAllocs $ fromIntegral factmem
+      ]
+
+    let bs = case configBenchmarks of
+          [] -> benchmarks
+          _ -> concat configBenchmarks
+
+        width = maximum $ map (length . bName) bs
+
+    forM_ bs $ \Benchmark{..} -> when (bEnabled config) $ bRun Ctx
+      { ctxReport = \s ->
+          putStrLn $ bName ++ replicate (width - length bName + 1) ' ' ++ s
+      , ctxFail = die $ bName ++ " failed"
+      , ctxDB = db
+      , ctxFactBlock = block
+      , ctxFactSet = factset
+      , ctxRunner = configRunner
+      }

--- a/glean/hs/Glean/RTS/Foreign/Benchmarking.hs
+++ b/glean/hs/Glean/RTS/Foreign/Benchmarking.hs
@@ -1,0 +1,163 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Glean.RTS.Foreign.Benchmarking
+  ( FactBlock
+  , createFactBlock
+  , factCount
+  , factMemory
+
+  , defineEach
+  , lookupEachType
+  , lookupEachById
+  , lookupEachByKey
+  , seekToEach
+  , seekCount
+  ) where
+
+import qualified Data.Vector.Storable as V
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign.ForeignPtr
+import Foreign.Ptr
+
+import Util.FFI
+
+import Glean.FFI
+import Glean.RTS.Foreign.Define (Define(..), CanDefine(..))
+import Glean.RTS.Foreign.Lookup (Lookup(..), CanLookup(..))
+import Glean.RTS.Types (Pid(..))
+
+newtype FactBlock = FactBlock (ForeignPtr FactBlock)
+
+instance Object FactBlock where
+  wrap = FactBlock
+  unwrap (FactBlock p) = p
+  destroy = glean_benchmarking_factblock_free
+
+createFactBlock :: CanLookup l => l -> IO FactBlock
+createFactBlock l = withLookup  l $ \look ->
+  construct $ invoke $ glean_benchmarking_factblock_create look
+
+factCount :: FactBlock -> IO Int
+factCount block =
+  fromIntegral <$> with block glean_benchmarking_factblock_fact_count
+
+factMemory :: FactBlock -> IO Int
+factMemory block =
+  fromIntegral <$> with block glean_benchmarking_factblock_fact_memory
+
+-- | Define each fact from the 'FactBlock'. Fail if the ids of the defined
+-- facts are different from their ids in the 'FactBlock'
+defineEach :: CanDefine d => d -> FactBlock -> IO Bool
+defineEach d block =
+  withDefine d $ \def ->
+  with block $ \ptr -> do
+    r <- invoke $ glean_benchmarking_define_each def ptr
+    return $ r /= 0
+
+-- | Look up the type of each fact. Fail if the types are different from those
+-- in the 'FactBlock'.
+lookupEachType :: CanLookup l => l -> FactBlock -> IO Bool
+lookupEachType l block =
+  withLookup l $ \look ->
+  with block $ \ptr -> do
+    r <- invoke $ glean_benchmarking_lookup_each_type look ptr
+    return $ r /= 0
+
+-- | Look up each fact by id. Fail if a fact doesn't exist or if its type or key
+-- are different.
+lookupEachById :: CanLookup l => l -> FactBlock -> IO Bool
+lookupEachById l block =
+  withLookup l $ \look ->
+  with block $ \ptr -> do
+    r <- invoke $ glean_benchmarking_lookup_each_by_id look ptr
+    return $ r /= 0
+
+-- | Look up each fact by key. Fail if a fact doesn't exist or if its id or type
+-- are different.
+lookupEachByKey :: CanLookup l => l -> FactBlock -> IO Bool
+lookupEachByKey l block =
+  withLookup l $ \look ->
+  with block $ \ptr -> do
+    r <- invoke $ glean_benchmarking_lookup_each_by_key look ptr
+    return $ r /= 0
+
+-- | Seek to each fact by key. Fail if a fact doesn't exist or if its id or type
+-- are different.
+seekToEach ::  CanLookup l => l -> FactBlock -> IO Bool
+seekToEach l block =
+  withLookup l $ \look ->
+  with block $ \ptr -> do
+    r <- invoke $ glean_benchmarking_seek_to_each look ptr
+    return $ r /= 0
+
+-- | For each 'Pid', iterate through all its facts via seek. Return the total
+-- number of facts iterated over.
+seekCount :: CanLookup a => a -> V.Vector Pid -> IO Int
+seekCount look pids =
+  withLookup look $ \look_ptr ->
+  V.unsafeWith pids $ \pids_ptr ->
+  fmap fromIntegral $ invoke $ glean_benchmarking_seek_count
+    look_ptr
+    pids_ptr
+    (fromIntegral $ V.length pids)
+
+foreign import ccall safe glean_benchmarking_factblock_create
+  :: Ptr Lookup
+  -> Ptr (Ptr FactBlock)
+  -> IO CString
+
+foreign import ccall unsafe "&glean_benchmarking_factblock_free"
+  glean_benchmarking_factblock_free
+  :: FunPtr (Ptr FactBlock -> IO ())
+
+foreign import ccall unsafe glean_benchmarking_factblock_fact_count
+  :: Ptr FactBlock
+  -> IO CSize
+
+foreign import ccall unsafe glean_benchmarking_factblock_fact_memory
+  :: Ptr FactBlock
+  -> IO CSize
+
+foreign import ccall safe glean_benchmarking_define_each
+  :: Define
+  -> Ptr FactBlock
+  -> Ptr CBool
+  -> IO CString
+
+foreign import ccall safe glean_benchmarking_lookup_each_type
+  :: Ptr Lookup
+  -> Ptr FactBlock
+  -> Ptr CBool
+  -> IO CString
+
+foreign import ccall safe glean_benchmarking_lookup_each_by_id
+  :: Ptr Lookup
+  -> Ptr FactBlock
+  -> Ptr CBool
+  -> IO CString
+
+foreign import ccall safe glean_benchmarking_lookup_each_by_key
+  :: Ptr Lookup
+  -> Ptr FactBlock
+  -> Ptr CBool
+  -> IO CString
+
+foreign import ccall safe glean_benchmarking_seek_to_each
+  :: Ptr Lookup
+  -> Ptr FactBlock
+  -> Ptr CBool
+  -> IO CString
+
+foreign import ccall safe glean_benchmarking_seek_count
+  :: Ptr Lookup
+  -> Ptr Pid
+  -> CSize
+  -> Ptr CSize
+  -> IO CString

--- a/glean/hs/Glean/RTS/Foreign/FactSet.hs
+++ b/glean/hs/Glean/RTS/Foreign/FactSet.hs
@@ -9,6 +9,7 @@
 module Glean.RTS.Foreign.FactSet
   ( FactSet
   , new
+  , factCount
   , factMemory
   , predicateStats
   , firstFreeId
@@ -58,6 +59,9 @@ instance CanDefine FactSet where
 
 new :: Fid -> IO FactSet
 new next_id = construct $ invoke $ glean_factset_new next_id
+
+factCount :: FactSet -> IO Int
+factCount facts = fromIntegral <$> with facts glean_factset_fact_count
 
 factMemory :: FactSet -> IO Int
 factMemory facts = fromIntegral <$> with facts glean_factset_fact_memory
@@ -131,6 +135,9 @@ foreign import ccall unsafe glean_factset_new
   :: Fid -> Ptr (Ptr FactSet) -> IO CString
 foreign import ccall unsafe "&glean_factset_free" glean_factset_free
   :: FunPtr (Ptr FactSet -> IO ())
+
+foreign import ccall unsafe glean_factset_fact_count
+  :: Ptr FactSet -> IO CSize
 
 foreign import ccall unsafe glean_factset_fact_memory
   :: Ptr FactSet -> IO CSize

--- a/glean/hs/Glean/RTS/Foreign/FactSet.hs
+++ b/glean/hs/Glean/RTS/Foreign/FactSet.hs
@@ -11,6 +11,7 @@ module Glean.RTS.Foreign.FactSet
   , new
   , factCount
   , factMemory
+  , allocatedMemory
   , predicateStats
   , firstFreeId
   , serialize
@@ -65,6 +66,10 @@ factCount facts = fromIntegral <$> with facts glean_factset_fact_count
 
 factMemory :: FactSet -> IO Int
 factMemory facts = fromIntegral <$> with facts glean_factset_fact_memory
+
+allocatedMemory :: FactSet -> IO Int
+allocatedMemory facts =
+  fromIntegral <$> with facts glean_factset_allocated_memory
 
 predicateStats :: FactSet -> IO [(Pid, Thrift.PredicateStats)]
 predicateStats facts = with facts
@@ -140,6 +145,9 @@ foreign import ccall unsafe glean_factset_fact_count
   :: Ptr FactSet -> IO CSize
 
 foreign import ccall unsafe glean_factset_fact_memory
+  :: Ptr FactSet -> IO CSize
+
+foreign import ccall unsafe glean_factset_allocated_memory
   :: Ptr FactSet -> IO CSize
 
 foreign import ccall safe glean_factset_predicateStats

--- a/glean/rts/benchmarking/factblock.cpp
+++ b/glean/rts/benchmarking/factblock.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "glean/rts/benchmarking/factblock.h"
+
+namespace facebook {
+namespace glean {
+namespace rts {
+namespace benchmarking {
+
+FactBlock FactBlock::create(FactIterator& iter) {
+  FactBlock block;
+  auto fact = iter.get();
+  if (!fact) {
+    block.starting_id = Id::fromWord(1024);
+    return block;
+  }
+
+  block.starting_id = fact.id;
+  auto expected = fact.id;
+
+  while (fact && fact.id == expected) {
+    const auto offset = block.data.size();
+    block.data.insert(
+      block.data.end(),
+      fact.clause.data,
+      fact.clause.data + fact.clause.size());
+    block.refs.push_back(
+      Ref{fact.type, offset, fact.clause.key_size, fact.clause.value_size});
+    ++expected;
+    iter.next();
+    fact = iter.get();
+  }
+
+  return block;
+}
+
+bool FactBlock::defineEach(Define& def) const {
+  auto expected = starting_id;
+  const auto buf = data.data();
+  for (const auto& ref : refs) {
+    const auto k = def.define(
+      ref.type,
+      Fact::Clause{buf + ref.offset, ref.key_size, ref.value_size});
+    if (k != expected) {
+      return false;
+    }
+    ++expected;
+  }
+  return true;
+}
+
+bool FactBlock::lookupEachType(Lookup& lookup) const {
+  for (const auto& fact : *this) {
+    const auto type = lookup.typeById(fact.id);
+    if (type != fact.type) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool FactBlock::lookupEachById(Lookup& lookup, bool compare) const {
+  bool result = true;
+  for (const auto& fact : *this) {
+    const auto found = lookup.factById(fact.id, [&](auto type, auto clause) {
+      if (type != fact.type || (!compare || clause.key() != fact.key())) {
+          result = false;
+        }
+      });
+    if (!found || !result) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool FactBlock::lookupEachByKey(Lookup& lookup) const {
+  for (const auto& fact : *this) {
+    const auto id = lookup.idByKey(fact.type, fact.key());
+    if (id != fact.id) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool FactBlock::seekToEach(Lookup& lookup) const {
+  for (const auto fact : *this) {
+    auto iter = lookup.seek(fact.type, fact.key(), 0);
+    auto ref = iter->get(FactIterator::Demand::KeyOnly);
+    if (ref.id != fact.id) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}
+}
+}
+}

--- a/glean/rts/benchmarking/factblock.h
+++ b/glean/rts/benchmarking/factblock.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "glean/rts/define.h"
+
+#include <boost/iterator/transform_iterator.hpp>
+
+namespace facebook {
+namespace glean {
+namespace rts {
+namespace benchmarking {
+
+struct FactBlock {
+  Id starting_id;
+
+  struct Ref {
+    Pid type;
+    size_t offset;
+    uint32_t key_size;
+    uint32_t value_size;
+  };
+
+  std::vector<Ref> refs;
+  std::vector<unsigned char> data;
+
+  static FactBlock create(FactIterator& iterator);
+
+  // std::unique_ptr<FactIterator> enumerate() const;
+
+  struct deref {
+    Id starting_id;
+    const Ref *refs;
+    const unsigned char *data;
+    const size_t count;
+    Fact::Ref operator()(const FactBlock::Ref& r) const {
+      assert(&r >= refs && &r < refs + count);
+      return Fact::Ref{
+        starting_id + (&r - refs),
+        r.type,
+        Fact::Clause{data + r.offset, r.key_size, r.value_size
+        }
+      };
+    }
+  };
+
+  using const_iterator =
+    boost::transform_iterator<deref, std::vector<Ref>::const_iterator>;
+
+  const_iterator iterator(std::vector<Ref>::const_iterator base) const {
+    return boost::make_transform_iterator(
+      base,
+      deref{starting_id, refs.data(), data.data(), refs.size()});
+  }
+
+  const_iterator begin() const {
+    return iterator(refs.begin());
+  }
+
+  const_iterator end() const {
+    return iterator(refs.end());
+  }
+
+  size_t size() const {
+    return refs.size();
+  }
+
+  size_t dataSize() const {
+    return data.size();
+  }
+
+  bool defineEach(Define& def) const;
+
+  bool lookupEachType(Lookup& lookup) const;
+  bool lookupEachById(Lookup& lookup, bool compare) const;
+  bool lookupEachByKey(Lookup& lookup) const;
+  bool seekToEach(Lookup& lookup) const;
+};
+
+}
+}
+}
+}

--- a/glean/rts/benchmarking/ffi.cpp
+++ b/glean/rts/benchmarking/ffi.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef OSS
+#include <cpp/memory.h> // @manual
+#include <cpp/wrap.h> // @manual
+#else
+#include <common/hs/util/cpp/memory.h>
+#include <common/hs/util/cpp/wrap.h>
+#endif
+
+#include "glean/rts/benchmarking/ffi.h"
+#include "glean/rts/benchmarking/factblock.h"
+#include "glean/rts/factset.h"
+
+using namespace facebook::hs;
+
+namespace facebook::glean::rts::benchmarking::c {
+
+const char *glean_benchmarking_factblock_create(
+    Lookup *lookup,
+    FactBlock **block) {
+  return ffi::wrap([=] {
+    *block = new FactBlock(FactBlock::create(*(lookup->enumerate())));
+  });
+}
+
+void glean_benchmarking_factblock_free(FactBlock *block) {
+  ffi::free_(block);
+}
+
+size_t glean_benchmarking_factblock_fact_count(FactBlock *block) {
+  return block->size();
+}
+
+size_t glean_benchmarking_factblock_fact_memory(FactBlock *block) {
+  return block->dataSize();
+}
+
+const char *glean_benchmarking_define_each(
+    Define *define,
+    FactBlock *block,
+    bool *result) {
+  return ffi::wrap([=] {
+    *result = block->defineEach(*define);
+  });
+}
+
+const char *glean_benchmarking_lookup_each_type(
+    Lookup *lookup,
+    FactBlock *block,
+    bool *result) {
+  return ffi::wrap([=] {
+    *result = block->lookupEachType(*lookup);
+  });
+}
+
+const char *glean_benchmarking_lookup_each_by_id(
+    Lookup *lookup,
+    FactBlock *block,
+    bool *result) {
+  return ffi::wrap([=] {
+    *result = block->lookupEachById(*lookup, true);
+  });
+}
+
+const char *glean_benchmarking_lookup_each_by_key(
+    Lookup *lookup,
+    FactBlock *block,
+    bool *result) {
+  return ffi::wrap([=] {
+    *result = block->lookupEachByKey(*lookup);
+  });
+}
+
+const char *glean_benchmarking_seek_to_each(
+    Lookup *lookup,
+    FactBlock *block,
+    bool *result) {
+  return ffi::wrap([=] {
+    *result = block->seekToEach(*lookup);
+  });
+}
+
+const char *glean_benchmarking_seek_count(
+    Lookup *lookup,
+    const int64_t* pids,
+    size_t pids_count,
+    size_t *count) {
+  return ffi::wrap([=] {
+    size_t n = 0;
+    for (size_t i = 0; i < pids_count; ++i) {
+      auto iter = lookup->seek(Pid::fromThrift(pids[i]), {}, 0);
+      while (auto ref = iter->get(FactIterator::Demand::KeyOnly)) {
+        ++n;
+        iter->next();
+      }
+    }
+    *count = n;
+  });
+}
+
+}

--- a/glean/rts/benchmarking/ffi.h
+++ b/glean/rts/benchmarking/ffi.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "glean/rts/ffi.h"
+
+#ifdef __cplusplus
+namespace facebook::glean::rts::benchmarking {
+#endif
+
+// @lint-ignore-every CLANGTIDY facebook-hte-Typedef
+typedef struct FactBlock FactBlock;
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+namespace facebook::glean::rts::benchmarking::c {
+extern "C" {
+#endif
+
+const char *glean_benchmarking_factblock_create(
+  Lookup *lookup,
+  FactBlock **block
+);
+
+void glean_benchmarking_factblock_free(
+  FactBlock *block
+);
+
+size_t glean_benchmarking_factblock_fact_count(
+  FactBlock *block
+);
+
+size_t glean_benchmarking_factblock_fact_memory(
+  FactBlock *block
+);
+
+const char *glean_benchmarking_define_each(
+  Define *define,
+  FactBlock *block,
+  bool *result
+);
+
+const char *glean_benchmarking_lookup_each_type(
+  Lookup *lookup,
+  FactBlock *block,
+  bool *result
+);
+
+const char *glean_benchmarking_lookup_each_by_id(
+  Lookup *lookup,
+  FactBlock *block,
+  bool *result
+);
+
+const char *glean_benchmarking_lookup_each_by_key(
+  Lookup *lookup,
+  FactBlock *block,
+  bool *result
+);
+
+const char *glean_benchmarking_seek_to_each(
+  Lookup *lookup,
+  FactBlock *block,
+  bool *result
+);
+
+const char *glean_benchmarking_seek_count(
+  Lookup *lookup,
+  const int64_t* pids,
+  size_t pids_count,
+  size_t *count
+);
+
+
+#ifdef __cplusplus
+}
+}
+#endif

--- a/glean/rts/densemap.h
+++ b/glean/rts/densemap.h
@@ -220,6 +220,10 @@ public:
     }
   }
 
+  size_t allocatedMemory() const noexcept {
+    return data.capacity() * sizeof(data[0]);
+  }
+
 private:
   // invariants:
   //

--- a/glean/rts/factset.cpp
+++ b/glean/rts/factset.cpp
@@ -39,6 +39,22 @@ FactSet::FactSet(FactSet&&) noexcept = default;
 FactSet& FactSet::operator=(FactSet&&) = default;
 FactSet::~FactSet() noexcept = default;
 
+size_t FactSet::allocatedMemory() const noexcept {
+  size_t n = facts.allocatedMemory() + keys.allocatedMemory();
+  for (const auto& k : keys) {
+    n += k.second.getAllocatedMemorySize();
+  }
+  return n;
+}
+
+size_t FactSet::Facts::allocatedMemory() const noexcept {
+  size_t n = facts.capacity() * sizeof(facts[0]);
+  for (const auto& fact : facts) {
+    n += fact->size();
+  }
+  return n;
+}
+
 struct FactSet::CachedPredicateStats {
   struct Data {
     /// Cached stats

--- a/glean/rts/factset.h
+++ b/glean/rts/factset.h
@@ -189,6 +189,11 @@ private:
       return fact_memory;
     }
 
+    /// Return (approximately) the total number of bytes allocated by the
+    /// FactSet. This currently does *not* include the memory allocated by seek
+    /// indices. 
+    size_t allocatedMemory() const noexcept;
+
   private:
     Id starting_id;
     std::vector<Fact::unique_ptr> facts;
@@ -243,6 +248,8 @@ public:
   size_t factMemory() const noexcept {
     return facts.factMemory();
   }
+
+  size_t allocatedMemory() const noexcept;
 
   PredicateStats predicateStats() const;
 

--- a/glean/rts/ffi.cpp
+++ b/glean/rts/ffi.cpp
@@ -469,6 +469,10 @@ size_t glean_factset_fact_memory(FactSet *facts) {
   return facts->factMemory();
 }
 
+size_t glean_factset_allocated_memory(FactSet *facts) {
+  return sizeof(FactSet) + facts->allocatedMemory();
+}
+
 const char *glean_factset_predicateStats(
     FactSet *facts,
     size_t *count,

--- a/glean/rts/ffi.cpp
+++ b/glean/rts/ffi.cpp
@@ -461,6 +461,10 @@ void glean_factset_free(FactSet *facts) {
   ffi::free_(facts);
 }
 
+size_t glean_factset_fact_count(FactSet *facts) {
+  return facts->size();
+}
+
 size_t glean_factset_fact_memory(FactSet *facts) {
   return facts->factMemory();
 }

--- a/glean/rts/ffi.h
+++ b/glean/rts/ffi.h
@@ -299,6 +299,10 @@ size_t glean_factset_fact_memory(
   FactSet *facts
 );
 
+size_t glean_factset_allocated_memory(
+  FactSet *facts
+);
+
 const char *glean_factset_predicateStats(
   FactSet *facts,
   size_t *count,

--- a/glean/rts/ffi.h
+++ b/glean/rts/ffi.h
@@ -291,6 +291,10 @@ void glean_factset_free(
   FactSet *facts
 );
 
+size_t glean_factset_fact_count(
+  FactSet *facts
+);
+
 size_t glean_factset_fact_memory(
   FactSet *facts
 );

--- a/mk/cxx.mk
+++ b/mk/cxx.mk
@@ -34,6 +34,9 @@ CXX_SOURCES_glean_cpp_if_internal = \
 
 CXX_SOURCES_glean_cpp_rts = \
     glean/rts/binary.cpp \
+    glean/rts/benchmarking/factblock.cpp \
+    glean/rts/benchmarking/ffi.cpp \
+    glean/rts/bytecode/subroutine.cpp \
     glean/rts/cache.cpp \
     glean/rts/define.cpp \
     glean/rts/error.cpp \
@@ -57,8 +60,7 @@ CXX_SOURCES_glean_cpp_rts = \
     glean/rts/substitution.cpp \
     glean/rts/thrift.cpp \
     glean/rts/timer.cpp \
-    glean/rts/validate.cpp \
-    glean/rts/bytecode/subroutine.cpp
+    glean/rts/validate.cpp
 CXX_FLAGS_glean_cpp_rts = -DOSS=1
 
 CXX_SOURCES_glean_cpp_rocksdb_stats = \


### PR DESCRIPTION
This adds a set of FactSet benchmarks which can be run on real-world data. See comments in the new FactSetBench.hs for more details. I find it very useful to track rts performance changes.

The actual benchmarks are in `rts/benchmarking`, accompanied by a `Glean.RTS.Foreign.Benchmarking` module which exposes them to Haskell. I've put these into `rts` rather than a separate library mostly because it's not clear to me that a separate library that's only used by benchmarks would be covered by CI.

Test plan: Ran it a lot on a DB obtained by indexing LLVM:

```
./quick.sh MODE=opt run glean:factset-bench --db-root=/tmp/x/db --db=llvm/14.0.6 --schema=dir
...
FactBlock facts: 5577078 factmem: 209.78 MB
FactSet facts: 5577078 mem: 570.55 MB factmem: 422.53 MB
define         1.83s
redefine       951.14ms
type-db        6.73s
type           36.85ms
byId-db        6.88s
byId           203.38ms
byKey-db       15.51s
byKey          741.72ms
seekToEach-db  29.24s
seekToEach     12.47s
seekToEach2-db 28.59s
seekToEach2    6.19s
seekAll-db     654.47ms
seekAll        611.73ms
```