### PR TITLE
FactSet: store compressed facts

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -2006,6 +2006,7 @@ test-suite schemaevolves
     ghc-options: -main-is Schema.Evolves
     build-depends:
         glean:stubs,
+        glean:client-hs,
         glean:core,
         glean:db,
         glean:config,

--- a/glean/rts/nat.h
+++ b/glean/rts/nat.h
@@ -158,8 +158,18 @@ struct EncodedNat {
   explicit EncodedNat(uint64_t val) {
     encoded_size = storeNat(buf, val);
   }
+  
   folly::ByteRange byteRange() {
     return folly::ByteRange(buf, buf + encoded_size);
+  }
+  
+  size_t size() const {
+    return encoded_size;
+  }
+
+  size_t store(unsigned char *p) const {
+    std::memcpy(p, buf, encoded_size);
+    return encoded_size;
   }
  private:
   uint8_t buf[rts::MAX_NAT_SIZE];


### PR DESCRIPTION
PLEASE DO NOT LAND THIS!

This changes how `FactSet` stores facts internally, with the hope of significantly reducing memory usage and fragmentation. This is just one part of the upcoming `FactSet` rewrite which I'd like to get more data about. If this turns out to be beneficial in its own right we could think about landing this now but perhaps in a slightly different form.

Could you please try this out on a busy write server. It allocates memory in pages with the page size being controlled by the `GLEAN_FACTSET_PAGE_SIZE` env var. The default is 4096 but please also try with `GLEAN_FACTSET_PAGE_SIZE=1048576`.

The most likely outcome is that it segfaults because I messed up somewhere but if it doesn't, could you please see what it does to memory consumption and performance