### PR TITLE
Delete netlify.toml

### DIFF
--- a/glean/website/netlify.toml
+++ b/glean/website/netlify.toml
@@ -1,2 +1,0 @@
-[build.environment]
-  NODE_VERSION = "16.13.0"


### PR DESCRIPTION
The new build image uses Node 16.x. However the version specified in the config isn't compatible with the Docusaurus version used (needs 16.4+), so just delete it.