### PR TITLE
Fix cabal index state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,3 +20,5 @@ allow-newer: haskeline:base
 
 -- https://github.com/TomMD/entropy/issues/75
 constraints: entropy < 0.4.1.9
+
+index-state: 2022-12-25T00:00:00Z


### PR DESCRIPTION
To improve build reproducibility and work around an issue with hie-compat 0.3.1

Also sent a PR upstream to fix the problem with hie-compat, so we can bump the index state when needed without fear: https://github.com/haskell/haskell-language-server/pull/3456