### PR TITLE
Don't use Thrift serialization

### DIFF
--- a/glean/bytecode/def/Glean/Bytecode/Generate/Instruction.hs
+++ b/glean/bytecode/def/Glean/Bytecode/Generate/Instruction.hs
@@ -84,7 +84,7 @@ data Usage
 --
 -- BUMP THIS WHENEVER YOU CHANGE THE BYTECODE EVEN IF YOU JUST ADD INSTRUCTIONS
 version :: Int
-version = 7
+version = 8
 
 -- | Lowest bytecode version supported by the current engine.
 --
@@ -92,7 +92,7 @@ version = 7
 -- TO THE END OF THE LIST (in which case the new engine can still execute
 -- old bytecode)
 lowestSupportedVersion :: Int
-lowestSupportedVersion = 7
+lowestSupportedVersion = 8
 
 -- | Definitions of all bytecode instructions
 instructions :: [Insn]

--- a/glean/db/Glean/Query/Derive.hs
+++ b/glean/db/Glean/Query/Derive.hs
@@ -44,7 +44,7 @@ import Glean.Database.Storage as Storage
 import Glean.Database.Open
 import Glean.Database.Types as Database
 import Glean.Database.Writes
-import Glean.Internal.Types hiding (Predicate)
+import Glean.Internal.Types
 import qualified Glean.Query.UserQuery as UserQuery
 import Glean.Query.Typecheck (tcQueryDeps)
 import Glean.Query.Codegen.Types

--- a/glean/if/internal.thrift
+++ b/glean/if/internal.thrift
@@ -12,61 +12,6 @@ include "glean/if/glean.thrift"
 namespace cpp2 facebook.glean.thrift.internal
 namespace hs Glean
 
-struct KeyIterator {
-  // id of fact the iterator is pointing to
-  7: glean.Id fact;
-  1: i64 type;
-  // size of prefix - the value of the prefix can be obtained from the current
-  // fact's key
-  3: i64 prefix_size;
-  4: bool first;
-  // lower bound for result facts
-  5: optional glean.Id from;
-  // higher bound for result facts
-  6: optional glean.Id to;
-}
-
-struct SubroutineState {
-  1: binary code;
-  2: i64 entry;
-  3: i64 inputs;
-  4: list<i64> locals;
-  5: list<string> literals;
-}
-
-struct QueryCont {
-  1: list<KeyIterator> iters;
-  2: list<string> outputs;
-  3: SubroutineState sub;
-  // 4: deprecated, do not use
-  5: i64 pid;
-  6: optional Subroutine traverse;
-}
-
-// Types for serialising/deserialising inventories. See comments in
-// rts/inventory.h.
-
-struct Subroutine {
-  1: list<i64> code;
-  2: i64 inputs;
-  3: i64 outputs;
-  4: i64 locals;
-  5: list<i64> constants;
-  6: list<string> literals;
-}
-
-struct Predicate {
-  1: glean.Id id;
-  2: glean.PredicateRef ref;
-  // 3: deprecated
-  4: Subroutine typechecker;
-  5: Subroutine traverser;
-}
-
-struct Inventory {
-  1: list<Predicate> predicates;
-}
-
 // The Schema stored in a DB
 struct StoredSchema {
   1: string (hs.type = "ByteString") schema;

--- a/glean/rts/binary.h
+++ b/glean/rts/binary.h
@@ -380,7 +380,7 @@ struct Output {
     rts::mangleString(r, *this);
   }
 
-  folly::ByteRange bytes() & noexcept {
+  folly::ByteRange bytes() const & noexcept {
     return to<folly::ByteRange>();
   }
 

--- a/glean/rts/ffi.cpp
+++ b/glean/rts/ffi.cpp
@@ -268,8 +268,7 @@ const char *glean_query_execute_compiled(
         max_time_ms == 0 ? folly::none : folly::Optional<uint64_t>(max_time_ms),
         static_cast<Depth>(depth),
         expandPids,
-        want_stats,
-        folly::none
+        want_stats
       ).release();
   });
 }
@@ -541,8 +540,8 @@ const char *glean_subst_deserialize(
   int64_t* ids,
   Substitution **result) {
   return ffi::wrap([=] {
-    auto subst_vec = std::vector<Id>();
-    std::transform(&ids[0], &ids[count], std::back_inserter(subst_vec), Id::fromWord);
+    auto subst_vec = std::vector<Id>(count);
+    std::transform(ids, ids + count, subst_vec.begin(), Id::fromWord);
     *result = new Substitution(Id::fromWord(firstId), std::move(subst_vec));
   });
 }

--- a/glean/rts/query.h
+++ b/glean/rts/query.h
@@ -13,7 +13,6 @@
 #include "glean/rts/factset.h"
 #include "glean/rts/inventory.h"
 #include "glean/rts/ownership/derived.h"
-#include "glean/if/gen-cpp2/internal_types.h"
 
 #ifdef OSS
 #include <cpp/HsStruct.h> // @manual
@@ -57,8 +56,7 @@ std::unique_ptr<QueryResults> executeQuery(
     folly::Optional<uint64_t> maxTime,
     Depth depth,
     std::unordered_set<Pid, folly::hasher<Pid>>& expandPids,
-    bool wantStats,
-    folly::Optional<thrift::internal::QueryCont> restart);
+    bool wantStats);
 
 std::unique_ptr<QueryResults> restartQuery(
     Inventory& inventory,

--- a/glean/rts/serialize.h
+++ b/glean/rts/serialize.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "glean/rts/binary.h"
+#include "glean/rts/id.h"
+
+namespace facebook {
+namespace glean {
+namespace rts {
+
+namespace serialize {
+
+inline void put(binary::Output& o, uint64_t i) { o.nat(i); }
+inline void put(binary::Output& o, int32_t i) { o.nat(i); }
+inline void put(binary::Output& o, bool b) { o.fixed(uint8_t{b}); }
+inline void put(binary::Output& o, Id p) { put(o, p.toWord()); }
+inline void put(binary::Output& o, Pid p) { put(o, p.toWord()); }
+inline void put(binary::Output& o, const std::string &s) {
+  put(o, s.size());
+  o.put(binary::byteRange(s));
+}
+inline void put(binary::Output& o, const binary::Output &out) {
+    put(o, out.size());
+    o.put(out.bytes());
+}
+
+template <typename T>
+void put(binary::Output& o, const T* p) { put(o, *p); }
+
+// We can specify type-specific serialization by defining a static method
+//   T::put(binary::Output&, T&)
+// and then serializing a std::vector<T> or std::optional<T> will work.
+template <typename T>
+void put(binary::Output& o, const T& p) {
+    T::put(o,p);
+}
+
+template <typename T>
+void put(binary::Output& o, const folly::Range<T*>& r) {
+  put(o, r.size());
+  for (auto& i : r) {
+    put(o, i);
+  }
+}
+
+template <typename T>
+void put(binary::Output& o, const std::vector<T>& vec) {
+  put(o, folly::Range<const T*>(vec.data(), vec.size()));
+}
+
+struct AsBytes {};
+
+// put(out, vec, AsBytes{})
+//   serialize a vector of integrals as a binary blob
+template <typename T, typename = std::enable_if<std::is_integral_v<T>>>
+void put(binary::Output& o, const std::vector<T>& vec, AsBytes) {
+  put(o, vec.size());
+  o.bytes(reinterpret_cast<const uint8_t*>(vec.data()), vec.size() * sizeof(T));
+}
+
+template <typename T>
+void put(binary::Output& o, const std::optional<T>& opt) {
+  if (opt.has_value()) {
+    o.fixed(uint8_t{1});
+    put(o, *opt);
+  } else {
+    o.fixed(uint8_t{0});
+  }
+}
+
+template <typename T>
+void put(binary::Output& o, const std::shared_ptr<T>& s) {
+  if (s) {
+    o.fixed(uint8_t{1});
+    put(o, *s);
+  } else {
+    o.fixed(uint8_t{0});
+  }
+}
+
+
+inline void get(binary::Input& i, uint64_t &r) { r = i.untrustedNat(); }
+inline void get(binary::Input& i, int32_t &r) { r = i.untrustedNat(); }
+inline void get(binary::Input& i, bool &r) { r = i.byte(); }
+inline void get(binary::Input& i, Id &p) { uint64_t w; get(i, w); p = Id::fromWord(w); }
+inline void get(binary::Input& i, Pid &p) { uint64_t w; get(i, w); p = Pid::fromWord(w); }
+inline void get(binary::Input& i, std::string &s) {
+  size_t n;
+  get(i, n);
+  auto r = i.bytes(n);
+  s = binary::mkString(r);
+}
+inline void get(binary::Input& i, binary::Output& out) {
+  size_t n;
+  get(i, n);
+  out.put(i.bytes(n));
+}
+
+template <typename T>
+void get(binary::Input& i, T& p) {
+  T::get(i,p);
+}
+
+template <typename T>
+void get(binary::Input& i, std::vector<T>& vec) {
+  size_t count;
+  get(i, count);
+  vec.reserve(count);
+  vec.resize(0);
+  for (size_t n = 0; n < count; n++) {
+    T elt;
+    get(i, elt);
+    vec.push_back(std::move(elt));
+  }
+}
+
+template <typename T, typename = std::enable_if<std::is_integral_v<T>>>
+void get(binary::Input& i, std::vector<T>& vec, AsBytes) {
+  size_t count;
+  get(i, count);
+  vec.resize(count);
+  folly::ByteRange bytes = i.bytes(count * sizeof(T));
+  std::copy(bytes.begin(), bytes.end(), reinterpret_cast<uint8_t*>(vec.data()));
+}
+
+template<typename T>
+void get(binary::Input& i, std::optional<T> &opt) {
+  auto x = i.byte();
+  if (x) {
+    T y;
+    get(i, y);
+    opt = std::move(y);
+  } else {
+    opt = {};
+  }
+}
+
+template <typename T>
+void get(binary::Input& i, std::shared_ptr<T>& p) {
+  auto x = i.byte();
+  if (x) {
+    p = std::make_shared<T>();
+    get(i, *p);
+  } else {
+    p = nullptr;
+  }
+}
+
+}
+}
+}
+}

--- a/glean/test/tests/DbDeriveTest.hs
+++ b/glean/test/tests/DbDeriveTest.hs
@@ -36,7 +36,7 @@ import Glean.Database.Schema.Types
 import Glean.Database.Test
 import Glean.Database.Types
 import qualified Glean.Database.Catalog as Catalog
-import Glean.Internal.Types hiding (Predicate)
+import Glean.Internal.Types
 import Glean.Typed
 import Glean.Types as Thrift
 import Glean.Test.HUnit


### PR DESCRIPTION
Summary:
I want to eliminate the dependency on the C++ Thrift compiler, which will make open-source Glean much easier to work with. This diff eliminates our usage of Thrift serialization in glean/rts, which is the biggest roadblock to getting rid of the dependency.

Serialization is mostly done using the existing `binary::Input` and `binary::Output` types, with a little library on top (`serialize.h`) to provide standard serialization for a few types and containers like `std::vector` and `std::optional`. I didn't make it super fancy because it didn't seem worthwhile, but definitely open to suggestions for improvements.

Reviewed By: nhawkes

Differential Revision: D42844201

