### PR TITLE
Disable clang tests on arm64

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -100,4 +100,4 @@ jobs:
         run: make glean-clang
     # disable tests for languages we don't have indexer installed
       - name: Run tests
-        run: cabal test glean:tests -f-hack-tests
+        run: cabal test glean:tests -f-hack-tests -f-clang-tests


### PR DESCRIPTION
We don't have bandwidth to chase up these anomalies, and we do use a slightly different clang toolchain here. We really just want to check things build for now