### PR TITLE
Enable clang indexer to be used without a dependency on Thrift

### DIFF
--- a/glean/cpp/filewriter.cpp
+++ b/glean/cpp/filewriter.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "glean/cpp/filewriter.h"
+#include "glean/cpp/glean.h"
+#include "glean/cpp/sender.h"
+#include "glean/rts/serialize.h"
+
+#include <folly/FileUtil.h>
+
+namespace facebook {
+namespace glean {
+
+namespace {
+
+using namespace facebook::glean::cpp;
+using namespace facebook::glean::rts;
+
+class FileWriter : public Sender {
+public:
+  explicit FileWriter(std::string p) : path(std::move(p)) {}
+
+  void rebaseAndSend(BatchBase&, bool) override {
+    // don't do anything
+    // NOTE: we ignore the 'wait' flag for now
+  }
+
+  void flush(BatchBase& batch) override {
+    auto r = batch.serialize();
+    binary::Output out;
+    // Serialize as thrift::Batch without using fbthrift. These field
+    // numbers and types must match those in glean.thrift.
+    serialize::ThriftCompact::put(out, {
+        { 1, r.first.toThrift() },
+        { 2, static_cast<int64_t>(r.count) },
+        { 3, folly::ByteRange(r.facts.data(), r.facts.size()) },
+    });
+    folly::writeFile(folly::ByteRange(out.data(), out.size()), path.c_str());
+  }
+
+private:
+  std::string path;
+};
+
+}
+
+std::unique_ptr<Sender> fileWriter(std::string path) {
+  return std::make_unique<FileWriter>(std::move(path));
+}
+
+} // namespace glean
+} // namespace facebook

--- a/glean/cpp/filewriter.h
+++ b/glean/cpp/filewriter.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <glean/cpp/sender.h>
+
+namespace facebook {
+namespace glean {
+
+// A Sender which dumps all data into a file. This happens on the final flush,
+// rebaseAndSend is a noop. This is mostly useful for testing.
+std::unique_ptr<Sender> fileWriter(
+  std::string path
+);
+
+}
+}

--- a/glean/cpp/glean.h
+++ b/glean/cpp/glean.h
@@ -18,12 +18,12 @@
 #include <boost/variant.hpp>
 #include <folly/Format.h>
 
-#include "glean/if/gen-cpp2/glean_types.h"
 #include "glean/rts/binary.h"
 #include "glean/rts/cache.h"
 #include "glean/rts/inventory.h"
 #include "glean/rts/id.h"
 #include "glean/rts/stacked.h"
+#include "glean/rts/substitution.h"
 
 namespace facebook {
 namespace glean {
@@ -432,8 +432,9 @@ public:
     return facts.define(ty, clause);
   }
 
-  thrift::Batch serialize() const;
-  void rebase(const thrift::Subst&);
+  void rebase(const rts::Substitution&);
+
+  rts::FactSet::Serialized serialize() const;
 
   FactStats bufferStats() const {
     return FactStats{buffer.factMemory(), buffer.size()};
@@ -575,7 +576,6 @@ public:
   BatchBase& base() { return *this; }
   const BatchBase& base() const { return *this; }
 
-  using BatchBase::serialize;
   using BatchBase::rebase;
   using BatchBase::bufferStats;
   using BatchBase::CacheStats;

--- a/glean/cpp/sender.h
+++ b/glean/cpp/sender.h
@@ -41,20 +41,5 @@ struct Sender {
   virtual void flush(cpp::BatchBase& batch) = 0;
 };
 
-// A Sender which sends data synchronously via Thrift.
-std::unique_ptr<Sender> thriftSender(
-  const std::string& service,
-  const std::string& repo_name,
-  const std::string& repo_hash,
-  double min_retry_delay,
-  size_t max_errors
-);
-
-// A Sender which dumps all data into a file. This happens on the final flush,
-// rebaseAndSend is a noop. This is mostly useful for testing.
-std::unique_ptr<Sender> fileWriter(
-  std::string path
-);
-
 }
 }

--- a/glean/cpp/thriftsender.h
+++ b/glean/cpp/thriftsender.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <glean/cpp/sender.h>
+
+namespace facebook {
+namespace glean {
+
+// A Sender which sends data synchronously via Thrift.
+std::unique_ptr<Sender> thriftSender(
+  const std::string& service,
+  const std::string& repo_name,
+  const std::string& repo_hash,
+  double min_retry_delay,
+  size_t max_errors
+);
+
+} // namespace glean
+} // namespace facebook

--- a/glean/lang/clang/index.cpp
+++ b/glean/lang/clang/index.cpp
@@ -38,6 +38,10 @@
 
 #include "glean/cpp/glean.h"
 #include "glean/cpp/sender.h"
+#include "glean/cpp/filewriter.h"
+#if FACEBOOK
+#include "glean/cpp/thriftsender.h"
+#endif
 #include "glean/interprocess/cpp/counters.h"
 #include "glean/interprocess/cpp/worklist.h"
 #include "glean/lang/clang/action.h"

--- a/mk/cxx.mk
+++ b/mk/cxx.mk
@@ -74,7 +74,7 @@ CXX_SOURCES_glean_cpp_rocksdb = \
 CXX_FLAGS_glean_cpp_rocksdb = -fno-rtti -DOSS=1
 
 CXX_SOURCES_glean_cpp_client = \
-    glean/cpp/sender.cpp \
+    glean/cpp/filewriter.cpp \
     glean/cpp/glean.cpp \
     glean/interprocess/cpp/worklist.cpp \
     glean/interprocess/cpp/counters.cpp


### PR DESCRIPTION
Summary:
This should remove the last dependency on Thrift-generated C++ that
the OSS build needs. I'll clean up the OSS build in a followup diff.

Reviewed By: donsbot

Differential Revision: D43160224

