### PR TITLE
Get rid of all Thrift C++ codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ SCHEMAS= \
 	thrift \
 
 .PHONY: thrift
-thrift:: thrift-cpp thrift-compiler thrift-hs
+thrift:: thrift-hsthrift-cpp thrift-compiler thrift-hs
 
 .PHONY: thrift-hs
 thrift-hs:: thrift-hsthrift-hs thrift-glean-hs
@@ -273,23 +273,6 @@ thrift-schema-hs: thrift-compiler
 	# This depends on the schema .thrift files:
 	$(THRIFT_COMPILE) --hs glean/if/search.thrift \
 		-o $(CODEGEN_DIR)/$@/glean/if/search
-	rsync -r --checksum $(CODEGEN_DIR)/$@/ .
-
-THRIFT_CPP= \
-	glean/config/recipes/recipes.thrift \
-	glean/config/server/server_config.thrift \
-	glean/if/glean.thrift \
-	glean/github/if/fb303_core.thrift \
-	glean/github/if/fb303.thrift
-
-.PHONY: thrift-cpp
-thrift-cpp: thrift-hsthrift-cpp
-	rm -rf $(CODEGEN_DIR)/$@
-	for f in $(THRIFT_CPP); do \
-		mkdir -p $(CODEGEN_DIR)/$@/$$(dirname $$f) ;\
-		thrift1 -I . --gen mstch_cpp2 \
-			-o $(CODEGEN_DIR)/$@/$$(dirname $$f) $$f; \
-	done
 	rsync -r --checksum $(CODEGEN_DIR)/$@/ .
 
 .PHONY: thrift-hsthrift-cpp

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -202,7 +202,6 @@ library config
         glean/config/recipes/gen-hs2
         glean/config/server/gen-hs2
         glean/config/client/gen-hs2
-    CXX_LIB_glean_cpp_config
     exposed-modules:
         Glean.Recipes.Types
         Glean.Service.Types
@@ -281,20 +280,6 @@ library if-search-hs
         glean:if-glean-hs,
         glean:schema
 --        fb303
-
-library if-fb303-cpp
-    import: fb-haskell, fb-cpp, deps
-    visibility: public
-    include-dirs: .
-    CXX_LIB_glean_cpp_if_fb303
-
-library if-glean-cpp
-    import: fb-haskell, fb-cpp, deps
-    visibility: public
-    CXX_LIB_glean_cpp_if
-    build-depends:
-        glean:if-fb303-cpp,
-        glean:config
 
 library rts
     import: fb-haskell, fb-cpp, deps
@@ -590,8 +575,7 @@ library client-cpp
     install-includes:
         glean/cpp/glean.h
     build-depends:
-        glean:rts,
-        glean:if-glean-cpp
+        glean:rts
 
 library interprocess
     import: fb-haskell, deps

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -112,8 +112,6 @@ executable clang-index
         preprocessor.cpp,
     build-depends:
         glean:rts,
-        glean:config,
-        glean:if-glean-cpp,
         glean:client-cpp
     extra-libraries:
         clangFrontend,

--- a/mk/cxx.mk
+++ b/mk/cxx.mk
@@ -14,20 +14,6 @@
 #
 # CXX_FLAGS_glean_cpp_lib = ... - sets additional C++ flags for the library
 
-CXX_SOURCES_glean_cpp_if_fb303 = \
-    glean/github/if/gen-cpp2/fb303_core_types.cpp \
-    glean/github/if/gen-cpp2/fb303_core_data.cpp \
-    glean/github/if/gen-cpp2/fb303_types.cpp \
-    glean/github/if/gen-cpp2/fb303_data.cpp
-
-CXX_SOURCES_glean_cpp_config = \
-    glean/config/recipes/gen-cpp2/recipes_types.cpp \
-    glean/config/recipes/gen-cpp2/recipes_data.cpp
-
-CXX_SOURCES_glean_cpp_if = \
-    glean/if/gen-cpp2/glean_types.cpp \
-    glean/if/gen-cpp2/glean_data.cpp
-
 CXX_SOURCES_glean_cpp_rts = \
     glean/rts/binary.cpp \
     glean/rts/benchmarking/factblock.cpp \


### PR DESCRIPTION
We don't depend on any gen-cpp2 source files in the OSS build any more, so we don't need to run the thrift1 compiler. Lots of cleanup and builds should be faster.

The remaining dependency on fbthrift is the client/server interaction. We could switch that to use
`Thrift.Channel.SocketChannel` instead.