### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,22 @@ FROM ghcr.io/facebookincubator/hsthrift/ci-base:latest as tools
 # remove any old stuff
 RUN rm -rf /usr/local/lib
 RUN rm -rf /usr/local/include
-RUN apt-get install -y ghc-8.10.2 cmake ninja-build libxxhash-dev wget unzip
+RUN apt-get install -y ghc-8.10.2 cmake ninja-build libxxhash-dev wget unzip rsync
 RUN cabal update
 RUN mkdir /glean-code
 WORKDIR /glean-code
 ADD https://api.github.com/repos/facebookincubator/hsthrift/compare/main...HEAD /dev/null
+ADD ./glean /glean-code/glean
+ADD ./cabal.project /glean-code/
+ADD ./Makefile  /glean-code/
+ADD ./mk /glean-code/mk
+ADD ./glean.cabal.in /glean-code/
+ADD ./LICENSE /glean-code/
+ADD ./Setup.hs /glean-code/
 ADD ./install_deps.sh /glean-code/
 RUN ./install_deps.sh
 # Nuke build artifacts to save space
 RUN rm -rf /tmp/fbcode_builder_getdeps-Z__wZGleanZGleanZhsthriftZbuildZfbcode_builder-root/
-ADD ./glean /glean-code/glean
-ADD ./cabal.project /glean-code/
-ADD ./Makefile  /glean-code/
-ADD ./glean.cabal /glean-code/
-ADD ./LICENSE /glean-code/
-ADD ./Setup.hs /glean-code/
 
 ENV LD_LIBRARY_PATH=/root/.hsthrift/lib
 ENV PKG_CONFIG_PATH=/root/.hsthrift/lib/pkgconfig

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1,4 +1,4 @@
-cabal-version:       3.8
+cabal-version:       3.4
 
 -- Copyright (c) Facebook, Inc. and its affiliates.
 


### PR DESCRIPTION
A few things in the `Dockerfile` were causing the build to fail and are fixed in this PR.
Unfortunately there is still a `make` failure. See the [last run](https://github.com/facebookincubator/Glean/actions/runs/4125955769)

In this PR
- Copy the new `glean.cabal.in` instead of the now non-existent `glean.cabal`.
- Move copying of files used by `make` to before the invocation `make`.
- Use a valid `cabal-version` as per the [documentation](https://cabal.readthedocs.io/en/3.4/file-format-changelog.html)
- Install `rsync`, which is required by `install_deps.sh`