### PR TITLE
Fix ----verbose argument name

### DIFF
--- a/glean/tools/gleancli/GleanCLI.hs
+++ b/glean/tools/gleancli/GleanCLI.hs
@@ -292,7 +292,7 @@ instance Plugin ListCommand where
       listFormat <- shellFormatOpt
       listVerbosity <- flag DbSummarise DbDescribe (
         short 'v' <>
-        long "--verbose" <>
+        long "verbose" <>
         help "include more details in tty/plain formats"
         )
       return List{..}


### PR DESCRIPTION
`long` already adds the `--`, so don't include it in the name. Otherwise, users have to write `glean list ----verbose`.