### PR TITLE
[glean][typescript] Make scip indexer src.File relative to indexerRoot

### DIFF
--- a/glean/glass/test/regression/tests/typescript/documentSymbolIndex.out
+++ b/glean/glass/test/regression/tests/typescript/documentSymbolIndex.out
@@ -2,8 +2,851 @@
     "@generated",
     {
         "revision": "testhash",
-        "size": 0,
-        "symbols": {},
+        "size": 30,
+        "symbols": {
+            "1": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 1
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nmodule \"example.ts\"\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 1,
+                        "columnEnd": 2,
+                        "lineBegin": 1,
+                        "lineEnd": 1
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2F"
+                }
+            ],
+            "14": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 7
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nclass Git\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 7,
+                        "columnEnd": 10,
+                        "lineBegin": 14,
+                        "lineEnd": 14
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23"
+                }
+            ],
+            "15": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 8
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#`<constructor>`()."
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nconstructor(dir: string): Git\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 3,
+                        "columnEnd": 14,
+                        "lineBegin": 15,
+                        "lineEnd": 15
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29."
+                },
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 10
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 23,
+                        "columnEnd": 26,
+                        "lineBegin": 15,
+                        "lineEnd": 15
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29"
+                }
+            ],
+            "16": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 10
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 46,
+                        "columnEnd": 49,
+                        "lineBegin": 16,
+                        "lineEnd": 16
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 23,
+                            "columnEnd": 26,
+                            "lineBegin": 15,
+                            "lineEnd": 15
+                        },
+                        "repository": "test"
+                    }
+                },
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/cwd0:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) cwd: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 41,
+                        "columnEnd": 44,
+                        "lineBegin": 16,
+                        "lineEnd": 16
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fcwd0:"
+                },
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/silent0:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) silent: boolean\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 51,
+                        "columnEnd": 57,
+                        "lineBegin": 16,
+                        "lineEnd": 16
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent0:"
+                }
+            ],
+            "24": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 10
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 12,
+                        "columnEnd": 15,
+                        "lineBegin": 24,
+                        "lineEnd": 24
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 23,
+                            "columnEnd": 26,
+                            "lineBegin": 15,
+                            "lineEnd": 15
+                        },
+                        "repository": "test"
+                    }
+                },
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/cwd1:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) cwd: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 7,
+                        "columnEnd": 10,
+                        "lineBegin": 24,
+                        "lineEnd": 24
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fcwd1:"
+                }
+            ],
+            "25": [
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/silent1:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) silent: boolean\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 7,
+                        "columnEnd": 13,
+                        "lineBegin": 25,
+                        "lineEnd": 25
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent1:"
+                }
+            ],
+            "27": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 10
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 53,
+                        "columnEnd": 56,
+                        "lineBegin": 27,
+                        "lineEnd": 27
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 23,
+                            "columnEnd": 26,
+                            "lineBegin": 15,
+                            "lineEnd": 15
+                        },
+                        "repository": "test"
+                    }
+                },
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/cwd2:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) cwd: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 48,
+                        "columnEnd": 51,
+                        "lineBegin": 27,
+                        "lineEnd": 27
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fcwd2:"
+                },
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/silent2:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) silent: boolean\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 58,
+                        "columnEnd": 64,
+                        "lineBegin": 27,
+                        "lineEnd": 27
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent2:"
+                }
+            ],
+            "30": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 10
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 12,
+                        "columnEnd": 15,
+                        "lineBegin": 30,
+                        "lineEnd": 30
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 23,
+                            "columnEnd": 26,
+                            "lineBegin": 15,
+                            "lineEnd": 15
+                        },
+                        "repository": "test"
+                    }
+                },
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/cwd3:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) cwd: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 7,
+                        "columnEnd": 10,
+                        "lineBegin": 30,
+                        "lineEnd": 30
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fcwd3:"
+                }
+            ],
+            "31": [
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/silent3:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) silent: boolean\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 7,
+                        "columnEnd": 13,
+                        "lineBegin": 31,
+                        "lineEnd": 31
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent3:"
+                }
+            ],
+            "34": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 8
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#commit()."
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(method) commit(msg: string, date: string, author: string): void\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 3,
+                        "columnEnd": 9,
+                        "lineBegin": 34,
+                        "lineEnd": 34
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23commit%28%29."
+                },
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 10
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#commit().(author)"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(parameter) author: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 37,
+                        "columnEnd": 43,
+                        "lineBegin": 34,
+                        "lineEnd": 34
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23commit%28%29.%28author%29"
+                },
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 10
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#commit().(date)"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(parameter) date: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 23,
+                        "columnEnd": 27,
+                        "lineBegin": 34,
+                        "lineEnd": 34
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23commit%28%29.%28date%29"
+                },
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 10
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#commit().(msg)"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(parameter) msg: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 10,
+                        "columnEnd": 13,
+                        "lineBegin": 34,
+                        "lineEnd": 34
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23commit%28%29.%28msg%29"
+                }
+            ],
+            "35": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 10
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 55,
+                        "columnEnd": 58,
+                        "lineBegin": 35,
+                        "lineEnd": 35
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 23,
+                            "columnEnd": 26,
+                            "lineBegin": 15,
+                            "lineEnd": 15
+                        },
+                        "repository": "test"
+                    }
+                },
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/cwd4:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) cwd: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 45,
+                        "columnEnd": 48,
+                        "lineBegin": 35,
+                        "lineEnd": 35
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fcwd4:"
+                },
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/silent4:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) silent: boolean\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 60,
+                        "columnEnd": 66,
+                        "lineBegin": 35,
+                        "lineEnd": 35
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent4:"
+                }
+            ],
+            "46": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 7
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nclass Git\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 58,
+                        "columnEnd": 61,
+                        "lineBegin": 46,
+                        "lineEnd": 46
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 7,
+                            "columnEnd": 10,
+                            "lineBegin": 14,
+                            "lineEnd": 14
+                        },
+                        "repository": "test"
+                    }
+                },
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 8
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/createTempRepo()."
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nfunction createTempRepo(): { repoDir: string; git: Git; }\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 17,
+                        "columnEnd": 31,
+                        "lineBegin": 46,
+                        "lineEnd": 46
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FcreateTempRepo%28%29."
+                },
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/createTempRepo().typeLiteral10:git."
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) git: Git\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 53,
+                        "columnEnd": 56,
+                        "lineBegin": 46,
+                        "lineEnd": 46
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FcreateTempRepo%28%29.typeLiteral10:git."
+                },
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/createTempRepo().typeLiteral10:repoDir."
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) repoDir: string\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 36,
+                        "columnEnd": 43,
+                        "lineBegin": 46,
+                        "lineEnd": 46
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FcreateTempRepo%28%29.typeLiteral10:repoDir."
+                }
+            ],
+            "49": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 8
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/Git#`<constructor>`()."
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nconstructor(dir: string): Git\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 19,
+                        "columnEnd": 22,
+                        "lineBegin": 49,
+                        "lineEnd": 49
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 3,
+                            "columnEnd": 14,
+                            "lineBegin": 15,
+                            "lineEnd": 15
+                        },
+                        "repository": "test"
+                    }
+                }
+            ],
+            "51": [
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/git0:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) git: Git\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 20,
+                        "columnEnd": 23,
+                        "lineBegin": 51,
+                        "lineEnd": 51
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fgit0:"
+                },
+                {
+                    "attributes": {
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "`example.ts`/repoDir0:"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\n(property) repoDir: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 18,
+                        "lineBegin": 51,
+                        "lineEnd": 51
+                    },
+                    "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FrepoDir0:"
+                }
+            ]
+        },
         "truncated": false
     }
 ]

--- a/glean/glass/test/regression/tests/typescript/documentSymbolListX.out
+++ b/glean/glass/test/regression/tests/typescript/documentSymbolListX.out
@@ -1,8 +1,1238 @@
 [
     "@generated",
     {
-        "definitions": [],
-        "references": [],
+        "definitions": [
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 1
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nmodule \"example.ts\"\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 1,
+                    "columnEnd": 2,
+                    "lineBegin": 1,
+                    "lineEnd": 1
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2F"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 7
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nclass Git\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 7,
+                    "columnEnd": 10,
+                    "lineBegin": 14,
+                    "lineEnd": 14
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 8
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#`<constructor>`()."
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nconstructor(dir: string): Git\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 3,
+                    "columnEnd": 14,
+                    "lineBegin": 15,
+                    "lineEnd": 15
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29."
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 10
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 23,
+                    "columnEnd": 26,
+                    "lineBegin": 15,
+                    "lineEnd": 15
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 8
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#commit()."
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(method) commit(msg: string, date: string, author: string): void\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 3,
+                    "columnEnd": 9,
+                    "lineBegin": 34,
+                    "lineEnd": 34
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23commit%28%29."
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 10
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#commit().(author)"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(parameter) author: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 37,
+                    "columnEnd": 43,
+                    "lineBegin": 34,
+                    "lineEnd": 34
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23commit%28%29.%28author%29"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 10
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#commit().(date)"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(parameter) date: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 23,
+                    "columnEnd": 27,
+                    "lineBegin": 34,
+                    "lineEnd": 34
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23commit%28%29.%28date%29"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 10
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#commit().(msg)"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(parameter) msg: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 10,
+                    "columnEnd": 13,
+                    "lineBegin": 34,
+                    "lineEnd": 34
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23commit%28%29.%28msg%29"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 8
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/createTempRepo()."
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nfunction createTempRepo(): { repoDir: string; git: Git; }\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 17,
+                    "columnEnd": 31,
+                    "lineBegin": 46,
+                    "lineEnd": 46
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FcreateTempRepo%28%29."
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/createTempRepo().typeLiteral10:git."
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) git: Git\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 53,
+                    "columnEnd": 56,
+                    "lineBegin": 46,
+                    "lineEnd": 46
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FcreateTempRepo%28%29.typeLiteral10:git."
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/createTempRepo().typeLiteral10:repoDir."
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) repoDir: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 36,
+                    "columnEnd": 43,
+                    "lineBegin": 46,
+                    "lineEnd": 46
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FcreateTempRepo%28%29.typeLiteral10:repoDir."
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/cwd0:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) cwd: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 41,
+                    "columnEnd": 44,
+                    "lineBegin": 16,
+                    "lineEnd": 16
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fcwd0:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/cwd1:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) cwd: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 7,
+                    "columnEnd": 10,
+                    "lineBegin": 24,
+                    "lineEnd": 24
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fcwd1:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/cwd2:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) cwd: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 48,
+                    "columnEnd": 51,
+                    "lineBegin": 27,
+                    "lineEnd": 27
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fcwd2:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/cwd3:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) cwd: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 7,
+                    "columnEnd": 10,
+                    "lineBegin": 30,
+                    "lineEnd": 30
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fcwd3:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/cwd4:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) cwd: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 45,
+                    "columnEnd": 48,
+                    "lineBegin": 35,
+                    "lineEnd": 35
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fcwd4:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/git0:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) git: Git\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 20,
+                    "columnEnd": 23,
+                    "lineBegin": 51,
+                    "lineEnd": 51
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fgit0:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/repoDir0:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) repoDir: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 11,
+                    "columnEnd": 18,
+                    "lineBegin": 51,
+                    "lineEnd": 51
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FrepoDir0:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/silent0:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) silent: boolean\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 51,
+                    "columnEnd": 57,
+                    "lineBegin": 16,
+                    "lineEnd": 16
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent0:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/silent1:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) silent: boolean\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 7,
+                    "columnEnd": 13,
+                    "lineBegin": 25,
+                    "lineEnd": 25
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent1:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/silent2:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) silent: boolean\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 58,
+                    "columnEnd": 64,
+                    "lineBegin": 27,
+                    "lineEnd": 27
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent2:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/silent3:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) silent: boolean\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 7,
+                    "columnEnd": 13,
+                    "lineBegin": 31,
+                    "lineEnd": 31
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent3:"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/silent4:"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) silent: boolean\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 60,
+                    "columnEnd": 66,
+                    "lineBegin": 35,
+                    "lineEnd": 35
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent4:"
+            }
+        ],
+        "references": [
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 7
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nclass Git\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 58,
+                    "columnEnd": 61,
+                    "lineBegin": 46,
+                    "lineEnd": 46
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 7,
+                        "columnEnd": 10,
+                        "lineBegin": 14,
+                        "lineEnd": 14
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 8
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#`<constructor>`()."
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nconstructor(dir: string): Git\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 19,
+                    "columnEnd": 22,
+                    "lineBegin": 49,
+                    "lineEnd": 49
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 3,
+                        "columnEnd": 14,
+                        "lineBegin": 15,
+                        "lineEnd": 15
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 10
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 46,
+                    "columnEnd": 49,
+                    "lineBegin": 16,
+                    "lineEnd": 16
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 23,
+                        "columnEnd": 26,
+                        "lineBegin": 15,
+                        "lineEnd": 15
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 10
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 12,
+                    "columnEnd": 15,
+                    "lineBegin": 24,
+                    "lineEnd": 24
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 23,
+                        "columnEnd": 26,
+                        "lineBegin": 15,
+                        "lineEnd": 15
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 10
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 53,
+                    "columnEnd": 56,
+                    "lineBegin": 27,
+                    "lineEnd": 27
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 23,
+                        "columnEnd": 26,
+                        "lineBegin": 15,
+                        "lineEnd": 15
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 10
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 12,
+                    "columnEnd": 15,
+                    "lineBegin": 30,
+                    "lineEnd": 30
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 23,
+                        "columnEnd": 26,
+                        "lineBegin": 15,
+                        "lineEnd": 15
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 10
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "`example.ts`/Git#`<constructor>`().(dir)"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\n(property) dir: string\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 55,
+                    "columnEnd": 58,
+                    "lineBegin": 35,
+                    "lineEnd": 35
+                },
+                "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FGit%23%60%3Cconstructor%3E%60%28%29.%28dir%29",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 23,
+                        "columnEnd": 26,
+                        "lineBegin": 15,
+                        "lineEnd": 15
+                    },
+                    "repository": "test"
+                }
+            }
+        ],
         "revision": "testhash",
         "truncated": false
     }

--- a/glean/lang/typescript/Glean/Indexer/Typescript.hs
+++ b/glean/lang/typescript/Glean/Indexer/Typescript.hs
@@ -39,7 +39,8 @@ indexer = Indexer {
       params = ScipIndexerParams {
         scipBinary = scipTypescriptBinary,
         scipArgs = \outFile ->
-           [ "index", "--no-progress-bar", "--cwd", ".", "--output", outFile ],
+           [ "index", "--no-progress-bar"
+           , "--cwd", indexerRoot, "--output", outFile ],
         scipWritesLocal = False,
         scipRoot = indexerRoot,
         scipLanguage = Just SCIP.TypeScript

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityinfo.out
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityinfo.out
@@ -6,9 +6,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -33,9 +31,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -61,7 +57,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
               },
               "location": {
                 "key": {
@@ -88,7 +84,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -115,7 +111,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
+                "key": "scip-typescript npm . . `example.ts`/Git#commit()."
               },
               "location": {
                 "key": {
@@ -142,7 +138,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)"
               },
               "location": {
                 "key": {
@@ -169,7 +165,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)"
               },
               "location": {
                 "key": {
@@ -196,7 +192,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)"
               },
               "location": {
                 "key": {
@@ -223,7 +219,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo()."
               },
               "location": {
                 "key": {
@@ -250,7 +246,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
               },
               "location": {
                 "key": {
@@ -277,7 +273,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
               },
               "location": {
                 "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_entitylocation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_entitylocation.out
@@ -6,9 +6,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -25,7 +23,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`",
+        "name": "`example.ts`",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -45,9 +43,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -64,7 +60,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git",
+        "name": "`example.ts`/Git",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -85,7 +81,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
               },
               "location": {
                 "key": {
@@ -103,7 +99,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()",
+        "name": "`example.ts`/Git#`<constructor>`()",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -124,7 +120,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -142,7 +138,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir",
+        "name": "`example.ts`/Git#`<constructor>`().(dir",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -163,7 +159,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
+                "key": "scip-typescript npm . . `example.ts`/Git#commit()."
               },
               "location": {
                 "key": {
@@ -181,7 +177,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()",
+        "name": "`example.ts`/Git#commit()",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -202,7 +198,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)"
               },
               "location": {
                 "key": {
@@ -220,7 +216,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author",
+        "name": "`example.ts`/Git#commit().(author",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -241,7 +237,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)"
               },
               "location": {
                 "key": {
@@ -259,7 +255,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date",
+        "name": "`example.ts`/Git#commit().(date",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -280,7 +276,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)"
               },
               "location": {
                 "key": {
@@ -298,7 +294,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg",
+        "name": "`example.ts`/Git#commit().(msg",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -319,7 +315,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo()."
               },
               "location": {
                 "key": {
@@ -337,7 +333,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()",
+        "name": "`example.ts`/createTempRepo()",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -358,7 +354,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
               },
               "location": {
                 "key": {
@@ -376,7 +372,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git",
+        "name": "`example.ts`/createTempRepo().typeLiteral10:git",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -397,7 +393,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
               },
               "location": {
                 "key": {
@@ -415,7 +411,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir",
+        "name": "`example.ts`/createTempRepo().typeLiteral10:repoDir",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -435,9 +431,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd0:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -454,7 +448,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0",
+        "name": "`example.ts`/cwd0",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -474,9 +468,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd1:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -493,7 +485,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1",
+        "name": "`example.ts`/cwd1",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -513,9 +505,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd2:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -532,7 +522,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2",
+        "name": "`example.ts`/cwd2",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -552,9 +542,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd3:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -571,7 +559,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3",
+        "name": "`example.ts`/cwd3",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -591,9 +579,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd4:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -610,7 +596,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4",
+        "name": "`example.ts`/cwd4",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -630,9 +616,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/git0:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -649,7 +633,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0",
+        "name": "`example.ts`/git0",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -670,7 +654,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0:"
+                "key": "scip-typescript npm . . `example.ts`/repoDir0:"
               },
               "location": {
                 "key": {
@@ -688,7 +672,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0",
+        "name": "`example.ts`/repoDir0",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -709,7 +693,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0:"
+                "key": "scip-typescript npm . . `example.ts`/silent0:"
               },
               "location": {
                 "key": {
@@ -727,7 +711,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0",
+        "name": "`example.ts`/silent0",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -748,7 +732,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1:"
+                "key": "scip-typescript npm . . `example.ts`/silent1:"
               },
               "location": {
                 "key": {
@@ -766,7 +750,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1",
+        "name": "`example.ts`/silent1",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -787,7 +771,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2:"
+                "key": "scip-typescript npm . . `example.ts`/silent2:"
               },
               "location": {
                 "key": {
@@ -805,7 +789,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2",
+        "name": "`example.ts`/silent2",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -826,7 +810,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3:"
+                "key": "scip-typescript npm . . `example.ts`/silent3:"
               },
               "location": {
                 "key": {
@@ -844,7 +828,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3",
+        "name": "`example.ts`/silent3",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -865,7 +849,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4:"
+                "key": "scip-typescript npm . . `example.ts`/silent4:"
               },
               "location": {
                 "key": {
@@ -883,7 +867,7 @@
         }
       },
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4",
+        "name": "`example.ts`/silent4",
         "file": { "key": "example.ts" },
         "location": {
           "range": {

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityuses.out
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityuses.out
@@ -6,9 +6,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -41,7 +39,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
               },
               "location": {
                 "key": {
@@ -75,7 +73,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -109,7 +107,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -143,7 +141,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -177,7 +175,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -211,7 +209,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_fileentityxrefs.out
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_fileentityxrefs.out
@@ -5,7 +5,7 @@
       "file": { "key": "example.ts" },
       "xref": {
         "target": {
-          "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git",
+          "name": "`example.ts`/Git",
           "file": { "key": "example.ts" },
           "location": {
             "range": {
@@ -31,9 +31,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -56,7 +54,7 @@
       "file": { "key": "example.ts" },
       "xref": {
         "target": {
-          "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()",
+          "name": "`example.ts`/Git#`<constructor>`()",
           "file": { "key": "example.ts" },
           "location": {
             "range": {
@@ -83,7 +81,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
               },
               "location": {
                 "key": {
@@ -107,7 +105,7 @@
       "file": { "key": "example.ts" },
       "xref": {
         "target": {
-          "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir",
+          "name": "`example.ts`/Git#`<constructor>`().(dir",
           "file": { "key": "example.ts" },
           "location": {
             "range": {
@@ -134,7 +132,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -158,7 +156,7 @@
       "file": { "key": "example.ts" },
       "xref": {
         "target": {
-          "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir",
+          "name": "`example.ts`/Git#`<constructor>`().(dir",
           "file": { "key": "example.ts" },
           "location": {
             "range": {
@@ -185,7 +183,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -209,7 +207,7 @@
       "file": { "key": "example.ts" },
       "xref": {
         "target": {
-          "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir",
+          "name": "`example.ts`/Git#`<constructor>`().(dir",
           "file": { "key": "example.ts" },
           "location": {
             "range": {
@@ -236,7 +234,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -260,7 +258,7 @@
       "file": { "key": "example.ts" },
       "xref": {
         "target": {
-          "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir",
+          "name": "`example.ts`/Git#`<constructor>`().(dir",
           "file": { "key": "example.ts" },
           "location": {
             "range": {
@@ -287,7 +285,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -311,7 +309,7 @@
       "file": { "key": "example.ts" },
       "xref": {
         "target": {
-          "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir",
+          "name": "`example.ts`/Git#`<constructor>`().(dir",
           "file": { "key": "example.ts" },
           "location": {
             "range": {
@@ -338,7 +336,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_resolvelocation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_resolvelocation.out
@@ -3,7 +3,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`",
+        "name": "`example.ts`",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -19,9 +19,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -42,7 +40,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git",
+        "name": "`example.ts`/Git",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -58,9 +56,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -81,7 +77,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()",
+        "name": "`example.ts`/Git#`<constructor>`()",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -98,7 +94,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
               },
               "location": {
                 "key": {
@@ -120,7 +116,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir",
+        "name": "`example.ts`/Git#`<constructor>`().(dir",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -137,7 +133,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -159,7 +155,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()",
+        "name": "`example.ts`/Git#commit()",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -176,7 +172,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
+                "key": "scip-typescript npm . . `example.ts`/Git#commit()."
               },
               "location": {
                 "key": {
@@ -198,7 +194,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author",
+        "name": "`example.ts`/Git#commit().(author",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -215,7 +211,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)"
               },
               "location": {
                 "key": {
@@ -237,7 +233,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date",
+        "name": "`example.ts`/Git#commit().(date",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -254,7 +250,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)"
               },
               "location": {
                 "key": {
@@ -276,7 +272,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg",
+        "name": "`example.ts`/Git#commit().(msg",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -293,7 +289,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)"
               },
               "location": {
                 "key": {
@@ -315,7 +311,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()",
+        "name": "`example.ts`/createTempRepo()",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -332,7 +328,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo()."
               },
               "location": {
                 "key": {
@@ -354,7 +350,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git",
+        "name": "`example.ts`/createTempRepo().typeLiteral10:git",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -371,7 +367,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
               },
               "location": {
                 "key": {
@@ -393,7 +389,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir",
+        "name": "`example.ts`/createTempRepo().typeLiteral10:repoDir",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -410,7 +406,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
               },
               "location": {
                 "key": {
@@ -432,7 +428,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0",
+        "name": "`example.ts`/cwd0",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -448,9 +444,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd0:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -471,7 +465,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1",
+        "name": "`example.ts`/cwd1",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -487,9 +481,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd1:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -510,7 +502,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2",
+        "name": "`example.ts`/cwd2",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -526,9 +518,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd2:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -549,7 +539,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3",
+        "name": "`example.ts`/cwd3",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -565,9 +555,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd3:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -588,7 +576,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4",
+        "name": "`example.ts`/cwd4",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -604,9 +592,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd4:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -627,7 +613,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0",
+        "name": "`example.ts`/git0",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -643,9 +629,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/git0:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -666,7 +650,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0",
+        "name": "`example.ts`/repoDir0",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -683,7 +667,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0:"
+                "key": "scip-typescript npm . . `example.ts`/repoDir0:"
               },
               "location": {
                 "key": {
@@ -705,7 +689,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0",
+        "name": "`example.ts`/silent0",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -722,7 +706,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0:"
+                "key": "scip-typescript npm . . `example.ts`/silent0:"
               },
               "location": {
                 "key": {
@@ -744,7 +728,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1",
+        "name": "`example.ts`/silent1",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -761,7 +745,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1:"
+                "key": "scip-typescript npm . . `example.ts`/silent1:"
               },
               "location": {
                 "key": {
@@ -783,7 +767,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2",
+        "name": "`example.ts`/silent2",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -800,7 +784,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2:"
+                "key": "scip-typescript npm . . `example.ts`/silent2:"
               },
               "location": {
                 "key": {
@@ -822,7 +806,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3",
+        "name": "`example.ts`/silent3",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -839,7 +823,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3:"
+                "key": "scip-typescript npm . . `example.ts`/silent3:"
               },
               "location": {
                 "key": {
@@ -861,7 +845,7 @@
   {
     "key": {
       "location": {
-        "name": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4",
+        "name": "`example.ts`/silent4",
         "file": { "key": "example.ts" },
         "location": {
           "range": {
@@ -878,7 +862,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4:"
+                "key": "scip-typescript npm . . `example.ts`/silent4:"
               },
               "location": {
                 "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/definition.out
+++ b/glean/lang/typescript/tests/cases/xrefs/definition.out
@@ -2,9 +2,7 @@
   "@generated",
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -20,9 +18,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -39,7 +35,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
       },
       "location": {
         "key": {
@@ -57,7 +53,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
       },
       "location": {
         "key": {
@@ -74,9 +70,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#commit()." },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -93,7 +87,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)"
       },
       "location": {
         "key": {
@@ -111,7 +105,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)"
       },
       "location": {
         "key": {
@@ -129,7 +123,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)"
       },
       "location": {
         "key": {
@@ -147,7 +141,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo()."
       },
       "location": {
         "key": {
@@ -165,7 +159,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
       },
       "location": {
         "key": {
@@ -183,7 +177,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
       },
       "location": {
         "key": {
@@ -200,9 +194,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd0:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -218,9 +210,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd1:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -236,9 +226,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd2:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -254,9 +242,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd3:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -272,9 +258,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd4:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -290,9 +274,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/git0:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -308,9 +290,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/repoDir0:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -326,9 +306,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent0:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -344,9 +322,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent1:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -362,9 +338,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent2:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -380,9 +354,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent3:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -398,9 +370,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent4:" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },

--- a/glean/lang/typescript/tests/cases/xrefs/definitionlocation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/definitionlocation.out
@@ -11,9 +11,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -40,9 +38,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -70,7 +66,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
           },
           "location": {
             "key": {
@@ -99,7 +95,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -127,9 +123,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd0:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -156,9 +150,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/silent0:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -185,9 +177,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd1:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -214,9 +204,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/silent1:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -243,9 +231,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd2:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -272,9 +258,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/silent2:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -301,9 +285,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd3:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -330,9 +312,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/silent3:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -360,7 +340,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
+            "key": "scip-typescript npm . . `example.ts`/Git#commit()."
           },
           "location": {
             "key": {
@@ -389,7 +369,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
+            "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)"
           },
           "location": {
             "key": {
@@ -418,7 +398,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
+            "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)"
           },
           "location": {
             "key": {
@@ -447,7 +427,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
+            "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)"
           },
           "location": {
             "key": {
@@ -475,9 +455,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd4:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -504,9 +482,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/silent4:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -534,7 +510,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
+            "key": "scip-typescript npm . . `example.ts`/createTempRepo()."
           },
           "location": {
             "key": {
@@ -563,7 +539,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
+            "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
           },
           "location": {
             "key": {
@@ -592,7 +568,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
+            "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
           },
           "location": {
             "key": {
@@ -620,9 +596,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/repoDir0:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -649,9 +623,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/git0:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },

--- a/glean/lang/typescript/tests/cases/xrefs/definitionuse.out
+++ b/glean/lang/typescript/tests/cases/xrefs/definitionuse.out
@@ -4,9 +4,7 @@
     "key": {
       "target": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -22,9 +20,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -45,7 +41,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
           },
           "location": {
             "key": {
@@ -63,7 +59,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
           },
           "location": {
             "key": {
@@ -85,7 +81,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -103,7 +99,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -125,7 +121,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -143,7 +139,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -165,7 +161,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -183,7 +179,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -205,7 +201,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -223,7 +219,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -245,7 +241,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -263,7 +259,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/defn_documentation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/defn_documentation.out
@@ -4,9 +4,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -27,9 +25,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -51,7 +47,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
           },
           "location": {
             "key": {
@@ -74,7 +70,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -97,7 +93,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
+            "key": "scip-typescript npm . . `example.ts`/Git#commit()."
           },
           "location": {
             "key": {
@@ -122,7 +118,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
+            "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)"
           },
           "location": {
             "key": {
@@ -145,7 +141,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
+            "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)"
           },
           "location": {
             "key": {
@@ -168,7 +164,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
+            "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)"
           },
           "location": {
             "key": {
@@ -191,7 +187,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
+            "key": "scip-typescript npm . . `example.ts`/createTempRepo()."
           },
           "location": {
             "key": {
@@ -216,7 +212,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
+            "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
           },
           "location": {
             "key": {
@@ -239,7 +235,7 @@
       "defn": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
+            "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
           },
           "location": {
             "key": {
@@ -261,9 +257,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd0:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -284,9 +278,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd1:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -307,9 +299,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd2:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -330,9 +320,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd3:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -353,9 +341,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd4:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -376,9 +362,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/git0:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -399,9 +383,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/repoDir0:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -422,9 +404,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/silent0:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -445,9 +425,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/silent1:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -468,9 +446,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/silent2:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -491,9 +467,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/silent3:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -514,9 +488,7 @@
     "key": {
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4:"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/silent4:" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },

--- a/glean/lang/typescript/tests/cases/xrefs/documentation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/documentation.out
@@ -2,24 +2,20 @@
   "@generated",
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
       "docs": { "key": "```ts\u000amodule \"example.ts\"\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
       "docs": { "key": "```ts\u000aclass Git\u000a```" }
     }
   },
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
       },
       "docs": { "key": "```ts\u000aconstructor(dir: string): Git\u000a```" }
     }
@@ -27,16 +23,14 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
       },
       "docs": { "key": "```ts\u000a(property) dir: string\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#commit()." },
       "docs": {
         "key": "```ts\u000a(method) commit(msg: string, date: string, author: string): void\u000a```"
       }
@@ -45,7 +39,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)"
       },
       "docs": { "key": "```ts\u000a(parameter) author: string\u000a```" }
     }
@@ -53,7 +47,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)"
       },
       "docs": { "key": "```ts\u000a(parameter) date: string\u000a```" }
     }
@@ -61,7 +55,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)"
       },
       "docs": { "key": "```ts\u000a(parameter) msg: string\u000a```" }
     }
@@ -69,7 +63,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo()."
       },
       "docs": {
         "key": "```ts\u000afunction createTempRepo(): { repoDir: string; git: Git; }\u000a```"
@@ -79,7 +73,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
       },
       "docs": { "key": "```ts\u000a(property) git: Git\u000a```" }
     }
@@ -87,104 +81,80 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
       },
       "docs": { "key": "```ts\u000a(property) repoDir: string\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd0:" },
       "docs": { "key": "```ts\u000a(property) cwd: string\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd1:" },
       "docs": { "key": "```ts\u000a(property) cwd: string\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd2:" },
       "docs": { "key": "```ts\u000a(property) cwd: string\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd3:" },
       "docs": { "key": "```ts\u000a(property) cwd: string\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd4:" },
       "docs": { "key": "```ts\u000a(property) cwd: string\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/git0:" },
       "docs": { "key": "```ts\u000a(property) git: Git\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/repoDir0:" },
       "docs": { "key": "```ts\u000a(property) repoDir: any\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent0:" },
       "docs": { "key": "```ts\u000a(property) silent: boolean\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent1:" },
       "docs": { "key": "```ts\u000a(property) silent: boolean\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent2:" },
       "docs": { "key": "```ts\u000a(property) silent: boolean\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent3:" },
       "docs": { "key": "```ts\u000a(property) silent: boolean\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4:"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent4:" },
       "docs": { "key": "```ts\u000a(property) silent: boolean\u000a```" }
     }
   }

--- a/glean/lang/typescript/tests/cases/xrefs/entity.out
+++ b/glean/lang/typescript/tests/cases/xrefs/entity.out
@@ -6,9 +6,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -32,9 +30,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -59,7 +55,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
               },
               "location": {
                 "key": {
@@ -85,7 +81,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+                "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
               },
               "location": {
                 "key": {
@@ -111,7 +107,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
+                "key": "scip-typescript npm . . `example.ts`/Git#commit()."
               },
               "location": {
                 "key": {
@@ -137,7 +133,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)"
               },
               "location": {
                 "key": {
@@ -163,7 +159,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)"
               },
               "location": {
                 "key": {
@@ -189,7 +185,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
+                "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)"
               },
               "location": {
                 "key": {
@@ -215,7 +211,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo()."
               },
               "location": {
                 "key": {
@@ -241,7 +237,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
               },
               "location": {
                 "key": {
@@ -267,7 +263,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
+                "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
               },
               "location": {
                 "key": {
@@ -292,9 +288,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd0:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -318,9 +312,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd1:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -344,9 +336,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd2:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -370,9 +360,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd3:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -396,9 +384,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd4:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -422,9 +408,7 @@
         "typescript": {
           "defn": {
             "key": {
-              "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0:"
-              },
+              "symbol": { "key": "scip-typescript npm . . `example.ts`/git0:" },
               "location": {
                 "key": {
                   "file": { "key": "example.ts" },
@@ -449,7 +433,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0:"
+                "key": "scip-typescript npm . . `example.ts`/repoDir0:"
               },
               "location": {
                 "key": {
@@ -475,7 +459,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0:"
+                "key": "scip-typescript npm . . `example.ts`/silent0:"
               },
               "location": {
                 "key": {
@@ -501,7 +485,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1:"
+                "key": "scip-typescript npm . . `example.ts`/silent1:"
               },
               "location": {
                 "key": {
@@ -527,7 +511,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2:"
+                "key": "scip-typescript npm . . `example.ts`/silent2:"
               },
               "location": {
                 "key": {
@@ -553,7 +537,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3:"
+                "key": "scip-typescript npm . . `example.ts`/silent3:"
               },
               "location": {
                 "key": {
@@ -579,7 +563,7 @@
           "defn": {
             "key": {
               "symbol": {
-                "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4:"
+                "key": "scip-typescript npm . . `example.ts`/silent4:"
               },
               "location": {
                 "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/localname.out
+++ b/glean/lang/typescript/tests/cases/xrefs/localname.out
@@ -2,232 +2,156 @@
   "@generated",
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
+      "name": { "key": "`example.ts`" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
+      "name": { "key": "`example.ts`/Git" }
     }
   },
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
       },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git"
-      }
+      "name": { "key": "`example.ts`/Git#`<constructor>`()" }
     }
   },
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
       },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()"
-      }
+      "name": { "key": "`example.ts`/Git#`<constructor>`().(dir" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#commit()." },
+      "name": { "key": "`example.ts`/Git#commit()" }
     }
   },
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)"
       },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir"
-      }
+      "name": { "key": "`example.ts`/Git#commit().(author" }
     }
   },
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)"
       },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()"
-      }
+      "name": { "key": "`example.ts`/Git#commit().(date" }
     }
   },
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)"
       },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author"
-      }
+      "name": { "key": "`example.ts`/Git#commit().(msg" }
     }
   },
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo()."
       },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date"
-      }
+      "name": { "key": "`example.ts`/createTempRepo()" }
     }
   },
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
       },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg"
-      }
+      "name": { "key": "`example.ts`/createTempRepo().typeLiteral10:git" }
     }
   },
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
       },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()"
-      }
+      "name": { "key": "`example.ts`/createTempRepo().typeLiteral10:repoDir" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd0:" },
+      "name": { "key": "`example.ts`/cwd0" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd1:" },
+      "name": { "key": "`example.ts`/cwd1" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd2:" },
+      "name": { "key": "`example.ts`/cwd2" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd3:" },
+      "name": { "key": "`example.ts`/cwd3" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/cwd4:" },
+      "name": { "key": "`example.ts`/cwd4" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/git0:" },
+      "name": { "key": "`example.ts`/git0" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/repoDir0:" },
+      "name": { "key": "`example.ts`/repoDir0" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent0:" },
+      "name": { "key": "`example.ts`/silent0" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent1:" },
+      "name": { "key": "`example.ts`/silent1" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent2:" },
+      "name": { "key": "`example.ts`/silent2" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent3:" },
+      "name": { "key": "`example.ts`/silent3" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2"
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3"
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4:"
-      },
-      "name": {
-        "key": "home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4"
-      }
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/silent4:" },
+      "name": { "key": "`example.ts`/silent4" }
     }
   },
   {

--- a/glean/lang/typescript/tests/cases/xrefs/references.out
+++ b/glean/lang/typescript/tests/cases/xrefs/references.out
@@ -2,9 +2,7 @@
   "@generated",
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
       "location": {
         "key": {
           "file": { "key": "example.ts" },
@@ -21,7 +19,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
       },
       "location": {
         "key": {
@@ -39,7 +37,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
       },
       "location": {
         "key": {
@@ -57,7 +55,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
       },
       "location": {
         "key": {
@@ -75,7 +73,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
       },
       "location": {
         "key": {
@@ -93,7 +91,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
       },
       "location": {
         "key": {
@@ -111,7 +109,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
       },
       "location": {
         "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/referencetarget.out
+++ b/glean/lang/typescript/tests/cases/xrefs/referencetarget.out
@@ -4,9 +4,7 @@
     "key": {
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -22,9 +20,7 @@
       },
       "target": {
         "key": {
-          "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-          },
+          "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
           "location": {
             "key": {
               "file": { "key": "example.ts" },
@@ -45,7 +41,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
           },
           "location": {
             "key": {
@@ -63,7 +59,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
           },
           "location": {
             "key": {
@@ -85,7 +81,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -103,7 +99,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -125,7 +121,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -143,7 +139,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -165,7 +161,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -183,7 +179,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -205,7 +201,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -223,7 +219,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -245,7 +241,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {
@@ -263,7 +259,7 @@
       "target": {
         "key": {
           "symbol": {
-            "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+            "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
           },
           "location": {
             "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/symbol.out
+++ b/glean/lang/typescript/tests/cases/xrefs/symbol.out
@@ -1,74 +1,32 @@
 [
   "@generated",
+  { "key": "scip-typescript npm . . `example.ts`/" },
+  { "key": "scip-typescript npm . . `example.ts`/Git#" },
+  { "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()." },
+  { "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)" },
+  { "key": "scip-typescript npm . . `example.ts`/Git#commit()." },
+  { "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)" },
+  { "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)" },
+  { "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)" },
+  { "key": "scip-typescript npm . . `example.ts`/createTempRepo()." },
   {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
+    "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
   },
   {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
+    "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
   },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd0:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd1:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd2:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd3:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/cwd4:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/git0:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/repoDir0:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent0:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent1:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent2:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent3:"
-  },
-  {
-    "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/silent4:"
-  },
+  { "key": "scip-typescript npm . . `example.ts`/cwd0:" },
+  { "key": "scip-typescript npm . . `example.ts`/cwd1:" },
+  { "key": "scip-typescript npm . . `example.ts`/cwd2:" },
+  { "key": "scip-typescript npm . . `example.ts`/cwd3:" },
+  { "key": "scip-typescript npm . . `example.ts`/cwd4:" },
+  { "key": "scip-typescript npm . . `example.ts`/git0:" },
+  { "key": "scip-typescript npm . . `example.ts`/repoDir0:" },
+  { "key": "scip-typescript npm . . `example.ts`/silent0:" },
+  { "key": "scip-typescript npm . . `example.ts`/silent1:" },
+  { "key": "scip-typescript npm . . `example.ts`/silent2:" },
+  { "key": "scip-typescript npm . . `example.ts`/silent3:" },
+  { "key": "scip-typescript npm . . `example.ts`/silent4:" },
   {
     "key": "scip-typescript npm typescript 4.9.5 lib/`lib.es2022.error.d.ts`/Error#"
   },

--- a/glean/lang/typescript/tests/cases/xrefs/symbolkind.out
+++ b/glean/lang/typescript/tests/cases/xrefs/symbolkind.out
@@ -2,24 +2,20 @@
   "@generated",
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
       "kind": 3
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#"
-      },
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
       "kind": 4
     }
   },
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`()."
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()."
       },
       "kind": 5
     }
@@ -27,7 +23,21 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#`<constructor>`().(dir)"
+        "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`().(dir)"
+      },
+      "kind": 7
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#commit()." },
+      "kind": 5
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(author)"
       },
       "kind": 7
     }
@@ -35,7 +45,23 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit()."
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(date)"
+      },
+      "kind": 7
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-typescript npm . . `example.ts`/Git#commit().(msg)"
+      },
+      "kind": 7
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo()."
       },
       "kind": 5
     }
@@ -43,39 +69,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(author)"
-      },
-      "kind": 7
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(date)"
-      },
-      "kind": 7
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/Git#commit().(msg)"
-      },
-      "kind": 7
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo()."
-      },
-      "kind": 5
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:git."
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:git."
       },
       "kind": 12
     }
@@ -83,7 +77,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm . . home/dons/Glean/glean/lang/typescript/tests/cases/xrefs/`example.ts`/createTempRepo().typeLiteral10:repoDir."
+        "key": "scip-typescript npm . . `example.ts`/createTempRepo().typeLiteral10:repoDir."
       },
       "kind": 12
     }


### PR DESCRIPTION
fixes tests in different environments, as they were previously absolute paths.

Test Plan:
> cabal test glean-snapshot-typescript
> cabal test glass-regression-typescript