### PR TITLE
[oss] Use HTTP transport, drop fbthrift dependency

### DIFF
--- a/.github/workflows/ci-clang-rocksdb.yml
+++ b/.github/workflows/ci-clang-rocksdb.yml
@@ -82,7 +82,7 @@ jobs:
 
     # no hhvm builds yet for jammy/ubuntu 22.00, so we skip the hack indexer
 
-      - name: Fetch hsthrift and build folly, fizz, wangle, fbthrift
+      - name: Fetch hsthrift and build folly
         run: ./install_deps.sh --use-system-libs
       - name: Nuke build artifacts
         run: rm -rf /tmp/fbcode_builder_getdeps-Z__wZGleanZGleanZhsthriftZbuildZfbcode_builder-root/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           ./coursier bootstrap --standalone -o lsif-java com.sourcegraph:lsif-java_2.13:0.8.0-RC1 --main-class com.sourcegraph.lsif_java.LsifJava
           mkdir -p "$HOME"/.hsthrift/bin && cp lsif-java "$HOME"/.hsthrift/bin
 
-      - name: Fetch hsthrift and build folly, fizz, wangle, fbthrift, rocksdb
+      - name: Fetch hsthrift and build folly, rocksdb
         run: ./install_deps.sh
       - name: Nuke build artifacts
         run: rm -rf /tmp/fbcode_builder_getdeps-Z__wZGleanZGleanZhsthriftZbuildZfbcode_builder-root/

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ SCHEMAS= \
 	thrift \
 
 .PHONY: thrift
-thrift:: thrift-hsthrift-cpp thrift-compiler thrift-hs
+thrift:: thrift-compiler thrift-hs
 
 .PHONY: thrift-hs
 thrift-hs:: thrift-hsthrift-hs thrift-glean-hs
@@ -283,10 +283,6 @@ thrift-schema-hs: thrift-compiler
 	$(THRIFT_COMPILE) --hs glean/if/search.thrift \
 		-o $(CODEGEN_DIR)/$@/glean/if/search
 	rsync -r --checksum $(CODEGEN_DIR)/$@/ .
-
-.PHONY: thrift-hsthrift-cpp
-thrift-hsthrift-cpp::
-	(cd hsthrift && make CABAL="$(CABAL)" thrift-cpp)
 
 # full build up to glass lib
 .PHONY: glass-lib

--- a/cabal.project
+++ b/cabal.project
@@ -4,12 +4,11 @@ packages:
     hsthrift/common/util/fb-util.cabal
     hsthrift/common/github/fb-stubs.cabal
     hsthrift/common/mangle/mangle.cabal
-    hsthrift/cpp-channel/thrift-cpp-channel.cabal
     hsthrift/lib/thrift-lib.cabal
-    hsthrift/server/thrift-server.cabal
     hsthrift/compiler/thrift-compiler.cabal
     hsthrift/haxl/thrift-haxl.cabal
     hsthrift/tests/thrift-tests.cabal
+    hsthrift/http/thrift-http.cabal
     glean.cabal
     glean/lang/clang/glean-clang.cabal
 
@@ -22,3 +21,9 @@ allow-newer: haskeline:base
 constraints: entropy < 0.4.1.9
 
 index-state: 2022-12-25T00:00:00Z
+
+package glean
+    flags: -fbthrift
+
+package thrift-tests
+    flags: -fbthrift

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -92,10 +92,13 @@ flag rust-tests
 flag java-lsif-tests
      default: False
 
+-- use fbthrift as the the server/client transport, or HTTP?
+flag fbthrift
+     default: False
+
 common deps
     build-depends:
         fb-util,
-        thrift-cpp-channel,
         thrift-lib,
         HUnit,
         safe,
@@ -150,8 +153,22 @@ common deps
 common hsc2hs-cpp
     hsc2hs-options: --cc=g++ --lflag=-lstdc++ --cflag=-D__HSC2HS__=1 --cflag=-std=c++17
 
+common thrift-server
+    if flag(fbthrift)
+       ghc-options: -DFBTHRIFT
+       build-depends: thrift-server
+    else
+       build-depends: thrift-http
+
+common thrift-client
+    if flag(fbthrift)
+       ghc-options: -DFBTHRIFT
+       build-depends: thrift-cpp-channel
+    else
+       build-depends: thrift-http
+
 library stubs
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, thrift-server
     visibility: public
     hs-source-dirs: glean/github
     exposed-modules:
@@ -171,7 +188,6 @@ library stubs
         glean:if-glean-hs,
         glean:if-index-hs,
         mangle,
-        thrift-server,
         template-haskell
 
 library tailer
@@ -298,6 +314,8 @@ library rts
     visibility: public
     include-dirs: .
     CXX_LIB_glean_cpp_rts
+    -- __atomic_is_lock_free missing with clang
+    extra-libraries: atomic
     pkgconfig-depends: libfolly, libunwind, libglog, icu-uc, gflags, libxxhash
 
 library rocksdb
@@ -318,7 +336,7 @@ library rocksdb-stats
         glean:rts,
 
 library util
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, thrift-client
     visibility: public
     hs-source-dirs: glean/util
     exposed-modules:
@@ -893,7 +911,7 @@ library handler
         glean:config,
 
 executable glean-server
-    import: fb-haskell, fb-cpp, deps, exe
+    import: fb-haskell, fb-cpp, deps, exe, thrift-server
     hs-source-dirs: glean/server
     main-is: Glean/Server.hs
     ghc-options: -main-is Glean.Server
@@ -914,8 +932,7 @@ executable glean-server
         glean:db,
         glean:util,
         haskeline >=0.7.3 && <0.8,
-        json,
-        thrift-server
+        json
 
 library shell-lib
     import: fb-haskell, fb-cpp, deps
@@ -947,7 +964,7 @@ library shell-lib
         split
 
 library indexers
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, thrift-server
     hs-source-dirs:
         glean/lang/clang
         glean/lang/flow
@@ -987,8 +1004,7 @@ library indexers
         glean:lsif,
         glean:scip,
         glean:stubs,
-        glean:util,
-        thrift-server
+        glean:util
 
 library cli-types
     import: fb-haskell, fb-cpp, deps
@@ -1187,7 +1203,7 @@ library if-glass-hs
 
 -- Glass core library
 library glass-lib
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, thrift-server
     visibility: public
     default-extensions: CPP
     hs-source-dirs: glean/glass
@@ -1266,9 +1282,8 @@ library glass-lib
         glean:schema,
         glean:stubs,
         glean:util,
-        thrift-server,
         uri-encode,
-        split,
+        split
 
 executable glass-server
     import: fb-haskell, fb-cpp, deps, exe
@@ -1301,6 +1316,7 @@ executable glass-democlient
     build-depends:
         glean:if-glass-hs,
         glean:stubs,
+        glean:util,
 
 -- -----------------------------------------------------------------------------
 -- Benchmarks

--- a/glean/github/Facebook/Service.hs
+++ b/glean/github/Facebook/Service.hs
@@ -6,6 +6,7 @@
   LICENSE file in the root directory of this source tree.
 -}
 
+{-# LANGUAGE CPP #-}
 module Facebook.Service
   ( runFacebookService
   , withBackgroundFacebookService
@@ -23,7 +24,11 @@ import System.Posix.Signals
 import Fb303Core.Types
 import Facebook.Fb303
 import Thrift.Processor
+#ifdef FBTHRIFT
 import Thrift.Server.CppServer
+#else
+import Thrift.Server.HTTP
+#endif
 
 -- | Runs a facebook service on a CPPServer
 -- Handles fb303 statuses as well as shutting down on process signals

--- a/glean/glass/Glean/Glass/Main.hs
+++ b/glean/glass/Glean/Glass/Main.hs
@@ -16,7 +16,11 @@ module Glean.Glass.Main
 
 import Facebook.Service ( runFacebookService )
 import Facebook.Fb303 ( fb303Handler, withFb303 )
-import qualified Thrift.Server.Types as Thrift
+#ifdef FBTHRIFT
+import qualified Thrift.Server.CppServer as Thrift
+#else
+import qualified Thrift.Server.HTTP as Thrift
+#endif
 import Util.EventBase ( withEventBaseDataplane )
 import Util.Log.Text ( logInfo )
 import Util.Text ( textShow )

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -53,7 +53,6 @@ common deps
         stm ^>=2.5.0.0,
         temporary,
         text ^>=1.2.3.0,
-        thrift-cpp-channel,
         thrift-lib,
         unordered-containers ^>=0.2.9.0,
         vector ^>=0.12.0.1,

--- a/glean/lang/clang/index.cpp
+++ b/glean/lang/clang/index.cpp
@@ -35,8 +35,6 @@
 #include <folly/init/Init.h>
 #endif
 
-#include "thrift/lib/cpp/transport/TTransportException.h"
-
 #include "glean/cpp/glean.h"
 #include "glean/cpp/sender.h"
 #include "glean/cpp/filewriter.h"

--- a/glean/util/Glean/Impl/ThriftService.hs
+++ b/glean/util/Glean/Impl/ThriftService.hs
@@ -6,21 +6,23 @@
   LICENSE file in the root directory of this source tree.
 -}
 
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE CPP, StandaloneDeriving #-}
 module Glean.Impl.ThriftService
   ( ThriftService
   ) where
 
-import qualified Data.ByteString.UTF8 as UTF8
 import Data.Maybe
 import qualified Data.Text.Encoding as Text
-import Network.Socket
-
-import Thrift.Channel.HeaderChannel
-import Thrift.Protocol.Id
 
 import Glean.Util.Service
 import Glean.Util.ThriftService
+
+#ifdef FBTHRIFT
+
+import qualified Data.ByteString.UTF8 as UTF8
+import Network.Socket
+
+import Thrift.Channel.HeaderChannel
 
 -- | A basic 'ThriftService' supporting connections to a specific host/port
 newtype ThriftService p = ThriftService
@@ -67,3 +69,41 @@ instance IsThriftService ThriftService where
     return
       [ (Text.decodeUtf8 (headerHost headerConfig), headerPort headerConfig)
       ]
+
+#else /* !FBTHRIFT */
+
+import Thrift.Channel.HTTP
+import Thrift.Protocol.Id
+
+-- | A basic 'ThriftService' supporting connections to a specific host/port
+newtype ThriftService p = ThriftService
+  { httpConfig :: HTTPConfig p
+  }
+
+deriving instance Show (ThriftService p)
+
+instance IsThriftService ThriftService where
+  mkThriftService (HostPort h p) ThriftServiceOptions{..} = ThriftService
+    { httpConfig = httpConfig
+    }
+    where
+    httpConfig = HTTPConfig
+      { httpHost = Text.encodeUtf8 h
+      , httpPort = fromIntegral p
+      , httpProtocolId = compactProtocolId
+      , httpResponseTimeout =
+          Just $ round (fromMaybe 30 processingTimeout * 1000000)
+      }
+  mkThriftService _ _ = error "basic-thriftservice does not support Tier"
+
+  thriftServiceWithDbShard t _ = t  -- shards are irrelevant if we have host/port
+
+  runThrift _evb ThriftService{..} action =
+    withHTTPChannel httpConfig action
+
+  getSelection _evb ThriftService{..} _ =
+    return
+      [ (Text.decodeUtf8 (httpHost httpConfig), httpPort httpConfig)
+      ]
+
+#endif

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -40,4 +40,4 @@ if test ! -f glean.cabal; then
 fi
 
 cd hsthrift
-./new_install_deps.sh "${EXTRA_DEPS}" --threads "${THREADS}"
+./new_install_deps.sh --no-fbthrift "${EXTRA_DEPS}" --threads "${THREADS}"


### PR DESCRIPTION
Changes earlier removed the dependency on fbthrift serialization in the C++ parts of Glean (mainly glean/rts). The only remaining dependency on fbthrift is for the transport layer between server and client.

I've added a simple HTTP transport layer for Thrift (see https://github.com/facebookincubator/hsthrift/pull/111). This PR moves the OSS build of Glean to use the HTTP transport, and drops the fbthrift dependency by default. It's still available via flags if we need it in the future.