### PR TITLE
Add a mechanism to filter available DBs

### DIFF
--- a/glean/db/Glean/Database/Config.hs
+++ b/glean/db/Glean/Database/Config.hs
@@ -156,6 +156,8 @@ data Config = Config
     -- ^ Backup backends
   , cfgEnableRecursion :: Bool
     -- ^ Enable experimental support for recursion
+  , cfgFilterAvailableDBs :: [Repo] -> IO [Repo]
+    -- ^ Filter out DBs not currently available in the server tier
   }
 
 instance Show Config where
@@ -182,6 +184,7 @@ instance Default Config where
     , cfgDatabaseLogger = Some NullGleanDatabaseLogger
     , cfgBackupBackends = HashMap.fromList [("mock", Backup.Mock.mock)]
     , cfgEnableRecursion = False
+    , cfgFilterAvailableDBs = return
     }
 
 data SchemaIndex = SchemaIndex
@@ -430,6 +433,7 @@ options = do
     , cfgServerLogger = cfgServerLogger def
     , cfgDatabaseLogger = cfgDatabaseLogger def
     , cfgBackupBackends = cfgBackupBackends def
+    , cfgFilterAvailableDBs = return
     , .. }
   where
     recipesConfigThriftSource = option (eitherReader ThriftSource.parse)

--- a/glean/db/Glean/Database/Env.hs
+++ b/glean/db/Glean/Database/Env.hs
@@ -144,6 +144,7 @@ initEnv evb envStorage envCatalog shardManager cfg
           if cfgEnableRecursion cfg
           then EnableRecursion
           else DisableRecursion
+      , envFilterAvailableDBs = cfgFilterAvailableDBs cfg
       , .. }
 
 spawnThreads :: Env -> IO ()

--- a/glean/db/Glean/Database/Types.hs
+++ b/glean/db/Glean/Database/Types.hs
@@ -264,6 +264,8 @@ data Env = forall storage. Storage storage => Env
   , envShardManager :: SomeShardManager
   , envEnableRecursion :: EnableRecursion
       -- ^ Experimental support for recursive queries. For testing only.
+  , envFilterAvailableDBs :: [Thrift.Repo] -> IO [Thrift.Repo]
+    -- ^ Filter out DBs not currently available in the server tier
   }
 
 instance Show Env where


### PR DESCRIPTION
Summary:
Currently `listDatabases` lists all the remote DBs available, assuming that they will all eventually become available in an actual query server (after restoring), and that at least some of them are available right now. This approximation has been creating problems recently because:

1. sometimes servers have an outdated remote DB list, or
2. sometimes multiple DBs get published at the same time and none of the DBs returned by `listDatabases` is available right now

This Diff adds an oracle-like mechanism to find out which DBs are available and avoid situations like 2 above.

Reviewed By: simonmar

Differential Revision: D49539095


