### PR TITLE
list only available shards

### DIFF
--- a/glean/db/Glean/Database/Config.hs
+++ b/glean/db/Glean/Database/Config.hs
@@ -156,6 +156,8 @@ data Config = Config
     -- ^ Backup backends
   , cfgEnableRecursion :: Bool
     -- ^ Enable experimental support for recursion
+  , cfgFilterAvailableDBs :: [Repo] -> IO [Repo]
+    -- ^ Filter out DBs not currently available in the server tier
   }
 
 instance Show Config where
@@ -182,6 +184,7 @@ instance Default Config where
     , cfgDatabaseLogger = Some NullGleanDatabaseLogger
     , cfgBackupBackends = HashMap.fromList [("mock", Backup.Mock.mock)]
     , cfgEnableRecursion = False
+    , cfgFilterAvailableDBs = return
     }
 
 data SchemaIndex = SchemaIndex
@@ -430,6 +433,7 @@ options = do
     , cfgServerLogger = cfgServerLogger def
     , cfgDatabaseLogger = cfgDatabaseLogger def
     , cfgBackupBackends = cfgBackupBackends def
+    , cfgFilterAvailableDBs = return
     , .. }
   where
     recipesConfigThriftSource = option (eitherReader ThriftSource.parse)

--- a/glean/db/Glean/Database/Env.hs
+++ b/glean/db/Glean/Database/Env.hs
@@ -6,7 +6,6 @@
   LICENSE file in the root directory of this source tree.
 -}
 
-{-# LANGUAGE CPP #-}
 module Glean.Database.Env ( withDatabases ) where
 
 import Control.Concurrent

--- a/glean/db/Glean/Database/Env.hs
+++ b/glean/db/Glean/Database/Env.hs
@@ -106,6 +106,7 @@ initEnv evb envStorage envCatalog shardManager cfg
     envDatabaseJanitor <- newTVarIO Nothing
     envDatabaseJanitorPublishedCounters <- newTVarIO mempty
     envCachedRestorableDBs <- newTVarIO Nothing
+    envCachedAvailableDBs <- newTVarIO mempty
 
     envLoggerRateLimit <-
       newRateLimiterMap (fromIntegral config_logging_rate_limit) 600
@@ -144,6 +145,7 @@ initEnv evb envStorage envCatalog shardManager cfg
           if cfgEnableRecursion cfg
           then EnableRecursion
           else DisableRecursion
+      , envFilterAvailableDBs = cfgFilterAvailableDBs cfg
       , .. }
 
 spawnThreads :: Env -> IO ()

--- a/glean/db/Glean/Database/Janitor.hs
+++ b/glean/db/Glean/Database/Janitor.hs
@@ -14,7 +14,6 @@ module Glean.Database.Janitor
   -- for testing
   , mergeLocalAndRemote
   , computeRetentionSet
-  , RetentionSet(..)
   , dbIndex
   , DbIndex(..)
   ) where
@@ -24,6 +23,9 @@ import Control.Concurrent (getNumCapabilities)
 import Control.Exception.Safe
 import Control.Monad.Extra
 import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.State.Strict (StateT, runStateT)
+import qualified Control.Monad.Trans.State.Strict as State
 import Control.Monad.Trans.Writer.CPS
 import Data.ByteString (ByteString)
 import Data.Foldable as Foldable
@@ -168,14 +170,25 @@ runWithShards env myShards sm = do
 
   dbToShard <- computeShardMapping sm
 
+  cachedAvailableDBs <- readTVarIO (envCachedAvailableDBs env)
   let
+    isAvailable db
+      | HashSet.member db cachedAvailableDBs = return True
+      | otherwise = not . null <$> envFilterAvailableDBs env [db]
+
     allDBsByAge :: [Item]
     allDBsByAge = mergeLocalAndRemote backups localAndRestoring
 
     index@DbIndex{byRepo, byRepoName, dependencies} = dbIndex allDBsByAge
-    RetentionSet{retentionSetRemote, retentionSetLocalAndRemote = keep} =
-      computeRetentionSet config_retention t backups index
 
+  (keep, cachedAvailable) <-
+    computeRetentionSet config_retention t isAvailable index `runStateT` mempty
+
+  atomically $ writeTVar
+    (envCachedAvailableDBs env)
+    (HashMap.keysSet $ HashMap.filter id cachedAvailable)
+
+  let
     keepAnnotatedWithShard =
       [ (item, guard (shard `Set.member` myShards) >> pure shard)
       | item <- keep
@@ -186,11 +199,6 @@ runWithShards env myShards sm = do
 
     keepInThisNode =
       mapMaybe (\(item, shard) -> (item,) <$> shard) keepAnnotatedWithShard
-
-    retentionSlackInThisNode =
-      [ item
-      | (item@Item{itemRepo}, _) <- keepInThisNode
-      , not $ HashSet.member itemRepo retentionSetRemote ]
 
     delete =
       [ repo | Item repo Local _ _ <- allDBsByAge
@@ -258,10 +266,13 @@ runWithShards env myShards sm = do
   -- so that the backup thread can't jump in early and pick one
   atomically $ sequence_ restores
 
-  atomically $ Catalog.resetElsewhere (envCatalog env) $
-    [ item
-      -- Nothing means the db is not in any of the shards assigned to this node
-    | (item, Nothing) <- keepAnnotatedWithShard]
+  let elsewhereDBs =
+        [ item
+          -- Nothing means it is not in any of the shards assigned to this node
+        | (item, Nothing) <- keepAnnotatedWithShard
+        ]
+
+  atomically $ Catalog.resetElsewhere (envCatalog env) elsewhereDBs
 
   deleting <- readTVarIO (envDeleting env)
 
@@ -296,16 +307,6 @@ runWithShards env myShards sm = do
       whenM (liftIO $ atomically $ isDatabaseClosed env $ itemRepo item) $
         preOpenDB (itemRepo item)
 
-    -- see "Retention set slack" note
-    let totalSlack = sum
-            [ fromIntegral b
-            | Item{ itemMeta = Meta {
-                  metaCompleteness =
-                    Complete DatabaseComplete{databaseComplete_bytes = Just b}
-                  }
-                } <- retentionSlackInThisNode
-            ]
-    publishCounter "glean.db.slack.bytes" totalSlack
     forM_ byRepoName $ \(repoNm, dbsByAge) -> do
       let prefix = "glean.db." <> Text.encodeUtf8 repoNm
       let repoKeep =
@@ -350,20 +351,6 @@ runWithShards env myShards sm = do
           publishCounter (prefix <> ".age") (ageFrom dbStart)
           publishCounter (prefix <> ".span") (ageFrom dbCreated)
 
-      -- see "Retention set slack" note
-      let leaked = sum
-            [ fromIntegral b
-            | Item{
-                itemRepo,
-                itemMeta = Meta {
-                  metaCompleteness =
-                    Complete DatabaseComplete{databaseComplete_bytes = Just b}
-                  }
-                } <- retentionSlackInThisNode
-            , repo_name itemRepo == repoNm
-            ]
-      unless (leaked == 0) $ publishCounter (prefix <> ".slack.bytes") leaked
-
     -- Report shard stats for dynamic sharding assignment
     mapM_ (\(n,v) -> publishCounter (Text.encodeUtf8 n) v) $
       countersForShardSizes sm $
@@ -382,7 +369,8 @@ mergeLocalAndRemote :: [(Repo, Meta)] -> [Item] -> [Item]
 mergeLocalAndRemote backups localAndRestoring =
   sortOn (metaCreated . itemMeta) $
       localAndRestoring ++
-        [ Item repo Cloud meta ItemMissing -- DBs we could restore
+        [ Item repo Cloud meta ItemMissing
+          -- DBs we could restore
         | (repo, meta) <- backups
         , repo `notElem` map itemRepo localAndRestoring  ]
 
@@ -418,110 +406,58 @@ dbIndex items = DbIndex{..}
       [ pruned_base update `Map.lookup` byRepo ]
     stacked Nothing = []
 
-{- NOTE Retention set slack
-
-  The slack is the difference between the remote and local+remote
-  retention sets. It is only justified  when no other shard is
-  serving DB instances for a given DB name. This happens very rarely
-  with hash-based sharding, and constitutes a resource leak that we track.
-
-  Example using sharding per DB name:
-
-  Remote Retention Set: [DB1(I1, I2), DB2(I1,I2), DB3(I1)]
-  Shard 1: DB1(I1,I2)
-  Shard 2: DB2(I1,I2)
-  Shard 3: DB3(I1)
-
-  --> Event: DB1(I3) gets published
-
-  Retention Set: [DB1(I2, I3), DB2(I1,I2), DB3(I1)]
-  Shard 1: DB1(I2, *I3*) --I3 is getting restored
-  Shard 2: DB2(I1,I2)
-  Shard 3: DB3(I1)
-
-  --> Event: DB1(I4) gets published
-  Retention Set: [DB1(I3, I4), DB2(I1,I2), DB3(I1)]
-  Shard 1: DB1(*I3*, *I4*) --I3 and I4 are getting restored
-           -- in this case the local retention set will include DB1(I2)
-           -- to continue serving DB1 until I3 and I4 are restored
-  Shard 2: DB2(I1,I2)
-  Shard 3: DB3(I1)
-
-  A different sharding policy for the same event sequence could render:
-
-  Remote Retention Set: [DB1(I1, I2), DB2(I1,I2), DB3(I1)]
-  Shard 1: DB1(I1,I2)
-  Shard 2: DB2(I1,I2)
-  Shard 3: DB3(I1)
-
-  --> Event: DB1(I3) gets published
-  --> Event: DB1(I4) gets published
-  --> Event: DB1(I3) gets restored
-  --> Event: DB1(I4) gets restored
-
-  Retention Set: [DB1(I2, I3), DB2(I1,I2), DB3(I1)]
-  Shard 1: DB1(I2)
-           -- DB1(I2) is still in the local retention set after DB1(I3)
-           -- has been restored, which constitutes a leak.
-  Shard 2: DB1(I4), DB2(I1,I2)
-  Shard 3: DB1(I3), DB3(I1)
-  --
- -}
-
-data RetentionSet = RetentionSet
-  { retentionSetRemote :: HashSet.HashSet Repo
-  -- ^ The retention set ignoring local DBs
-  , retentionSetLocalAndRemote :: [Item]
-  -- ^ The retention set that applies to this server
-  }
 -- | The final set of DBs we want usable on disk.
 --  This is the set of 'keepRoots' DB extended with all the stacked dependencies
 computeRetentionSet
-  :: ServerConfig.DatabaseRetentionPolicy
+  :: Monad m
+  => ServerConfig.DatabaseRetentionPolicy
   -> UTCTime
-  -> [(Repo, Meta)] -- ^ Remote backups
+  -> (Repo -> m Bool)
   -> DbIndex
-  -> RetentionSet
-computeRetentionSet config_retention time backups DbIndex{..} = RetentionSet{..}
-  where
-    retentionSetRemote =
-      HashSet.fromList $ map itemRepo $ retentionSet backupItemsByRepoName
-    retentionSetLocalAndRemote = retentionSet byRepoName
-    retentionSet dbsByRepoName =
-      transitiveClosureBy itemRepo (catMaybes . dependencies) $
-        concatMap
-          (\(repoNm, dbs) ->
-            dbRetentionForRepo (repoRetention config_retention repoNm) time
-              dbs
-          )
-          dbsByRepoName
-    backupItemsByRepoName = Map.toList $ Map.fromListWith (<>)
-      [ (repo_name itemRepo, pure Item{..})
-      | let itemLocality = Cloud
-      , let itemStatus = ItemComplete
-      , (itemRepo, itemMeta) <- backups
-      ]
+  -> StateT (HashMap.HashMap Repo Bool) m [Item]
+computeRetentionSet config_retention time isAvailableM DbIndex{..} =
+  transitiveClosureBy itemRepo (catMaybes . dependencies) <$>
+    concatMapM
+      (\(repoNm, dbs) ->
+        dbRetentionForRepo
+          (repoRetention config_retention repoNm)
+          time
+          isAvailableM
+          dbs
+      )
+      byRepoName
 
 -- | The target set of DBs we want usable on the disk. This is a set of
 -- DBs that satisfies the policy.
 dbRetentionForRepo
-  :: ServerConfig.Retention
+  :: Monad m
+  => ServerConfig.Retention
   -> UTCTime
+  -> (Repo -> m Bool)
   -> NonEmpty Item
-  -> [Item]
-dbRetentionForRepo ServerConfig.Retention{..} t dbs = keep
-  where
+  -> StateT (HashMap.HashMap Repo Bool) m [Item]
+dbRetentionForRepo ServerConfig.Retention{..} t isAvailableM dbs = do
+  let
+    itemAvailable Item{itemRepo} = do
+      st <- State.get
+      case HashMap.lookup itemRepo st of
+        Just isAvailable -> return isAvailable
+        Nothing -> do
+          isAvailable <- lift $ isAvailableM itemRepo
+          State.put $! HashMap.insert itemRepo isAvailable st
+          return isAvailable
+
     -- retention policy parameters
     retainAtLeast = fromIntegral $ fromMaybe 0 retention_retain_at_least
     retainAtMost = fmap fromIntegral retention_retain_at_most
     deleteIfOlder = fmap fromIntegral retention_delete_if_older
     deleteIncompleteIfOlder =
       fmap fromIntegral retention_delete_incomplete_if_older
-    remoteBumpsLocalAfter =
-      fmap fromIntegral retention_remote_db_bumps_local_db_after
 
     f &&& g = \x -> f x && g x
     f ||| g = \x -> f x || g x
+    f &&&> g = \x -> if not(f x) then return False else g x
+    f |||> g = \x -> if f x then return True else g x
 
     ifSet (Just a) f = f a
     ifSet Nothing _ = const False
@@ -531,9 +467,11 @@ dbRetentionForRepo ServerConfig.Retention{..} t dbs = keep
     isComplete Item{..} =
       completenessStatus itemMeta == Thrift.DatabaseStatus_Complete
     isOlderThan secs Item{..} = dbAge t itemMeta >= secs
+    isAvailable = isLocal |||> itemAvailable
 
     -- all DBs sorted by most recent first
-    sorted = sortOn (Down . metaCreated . itemMeta) (NonEmpty.toList dbs)
+    sorted =
+      sortOn (Down . metaCreated . itemMeta) (NonEmpty.toList dbs)
 
     -- whether to delete a DB according to the deletion policy
     delete =
@@ -541,24 +479,19 @@ dbRetentionForRepo ServerConfig.Retention{..} t dbs = keep
       (ifSet deleteIncompleteIfOlder $ \secs ->
         (not . isComplete) &&& isOlderThan secs)
 
-    -- selects DBs to satisfy retain_at_least
-    shouldHold =
-      isComplete &&&
-      (isLocal ||| ifSet remoteBumpsLocalAfter isOlderThan)
+    -- ensure we have retain_at_least DBs from the available set
+  atLeast <- takeFilterM
+    retainAtLeast
+    (isComplete &&&> isAvailable)
+    -- bound the search since isAvailable is expensive
+    -- this matters only for tier bootstraps where all DBs are unavailable
+    (take (retainAtLeast*10) sorted)
 
-    keep =
-      uniqBy (comparing itemRepo) $
+    -- delete DBs according to the deletion policy, and keep retain_at_most
+  let atMost = maybe id take retainAtMost (filter (not . delete) sorted)
 
-      -- delete DBs according to the deletion policy, and keep retain_at_most
-      maybe id take retainAtMost (filter (not . delete) sorted) ++
+  return $ uniqBy (comparing itemRepo) (atLeast ++ atMost)
 
-      -- ensure we have retain_at_least DBs from the global + local set
-      take retainAtLeast (filter isComplete sorted) ++
-
-      -- Finally, ensure we have retain_at_least DBs from the local set
-      -- to avoid premuaturely deleting local DBs before the remote
-      -- one has downloaded.
-      filter isLocal (take retainAtLeast (filter shouldHold sorted))
 
 data FetchBackups
   = ReusedPreviousBackups {
@@ -623,3 +556,14 @@ transitiveClosureBy k fn xs = HashMap.elems $ go xs HashMap.empty
         go
           (Foldable.toList (fn n) ++ ns)
           (HashMap.insert (k n) n r)
+
+-- | Take the first n items that satisfy the predicate
+takeFilterM :: (Monad m) => Int -> (a -> m Bool) -> [a] -> m [a]
+takeFilterM n pred = loop [] n where
+  loop acc _ [] = return (reverse acc)
+  loop acc 0 _ = return (reverse acc)
+  loop acc n (x:xx) = do
+    accept <- pred x
+    if accept
+      then loop (x:acc) (n-1) xx
+      else loop acc n xx

--- a/glean/db/Glean/Database/Types.hs
+++ b/glean/db/Glean/Database/Types.hs
@@ -214,7 +214,7 @@ data JanitorRunResult
 
 data JanitorException
   = OtherJanitorException SomeException
-  | JanitorFetchBackupsFailure -- ^ Raised only when no catalog available
+  | JanitorFetchBackupsFailure -- ^ Raised only when no remote db list available
   deriving (Typeable, Show)
 
 instance Exception JanitorException
@@ -246,6 +246,7 @@ data Env = forall storage. Storage storage => Env
   , envDatabaseJanitor :: TVar (Maybe JanitorRunResult)
   , envDatabaseJanitorPublishedCounters :: TVar (HashSet ByteString)
   , envCachedRestorableDBs :: TVar (Maybe (UTCTime, [(Thrift.Repo, Meta)]))
+  , envCachedAvailableDBs :: TVar (HashSet Thrift.Repo)
   , envWorkQueue :: WorkQueue
   , envHeartbeats :: Heartbeats
   , envWrites :: TVar (HashMap Text Write)
@@ -264,6 +265,8 @@ data Env = forall storage. Storage storage => Env
   , envShardManager :: SomeShardManager
   , envEnableRecursion :: EnableRecursion
       -- ^ Experimental support for recursive queries. For testing only.
+  , envFilterAvailableDBs :: [Thrift.Repo] -> IO [Thrift.Repo]
+    -- ^ Filter out DBs not currently available in the server tier
   }
 
 instance Show Env where

--- a/glean/server/Glean/Server.hs
+++ b/glean/server/Glean/Server.hs
@@ -30,10 +30,8 @@ import Util.STM
 import Logger.IO
 import Glean.Facebook.Logger.Server
 import Glean.Facebook.Logger.Database
-#endif
-
-#ifdef GLEAN_FACEBOOK
 import qualified Glean.Database.Backup.Manifold as Manifold
+import Glean.Server.Available ( withAvailableDBFilterViaSR )
 #endif
 
 import Glean.Database.Config (Config(..))
@@ -58,12 +56,14 @@ main =
   withConfigProvider cfgOpts $ \(configAPI :: ConfigAPI) ->
 #if GLEAN_FACEBOOK
   withLogger configAPI $ \logger ->
+  withAvailableDBFilterViaSR evb $ \filterAvailableDBs ->
 #endif
   let dbCfg = (cfgDBConfig cfg0){
         cfgShardManager = shardManagerConfig (cfgPort cfg)
 #if GLEAN_FACEBOOK
         , cfgServerLogger = Some (GleanServerFacebookLogger logger)
         , cfgDatabaseLogger = Some (GleanDatabaseFacebookLogger logger)
+        , cfgFilterAvailableDBs = filterAvailableDBs
 #endif
       }
 

--- a/glean/test/tests/DatabaseJanitorTest.hs
+++ b/glean/test/tests/DatabaseJanitorTest.hs
@@ -117,9 +117,6 @@ setupBasicDBs dbdir = do
   makeFakeDB schema dbdir (Repo "test2" "0006") (age (days 6)) (complete 6)
     Nothing
 
-noLocalDBs :: FilePath -> IO ()
-noLocalDBs _ = pure ()
-
 setupBasicCloudDBs :: FilePath -> IO ()
 setupBasicCloudDBs backupDir = do
   now <- getCurrentTime
@@ -129,13 +126,29 @@ setupBasicCloudDBs backupDir = do
   makeFakeCloudDB schema backupDir (Repo "test" "0008")
     (age(days 8)) (complete 8) Nothing
   makeFakeCloudDB schema backupDir (Repo "test2" "0009")
-    (age(days 0)) (complete 9) Nothing
+    (age(days 7)) (complete 9) Nothing
+  makeFakeCloudDB schema backupDir (Repo "test2" "0010")
+    (age(days 6)) (complete 9) Nothing
+  makeFakeCloudDB schema backupDir (Repo "test2" "0011")
+    (age(days 5)) (complete 9) Nothing
+  makeFakeCloudDB schema backupDir (Repo "test2" "0012")
+    (age(days 4)) (complete 9) Nothing
+  makeFakeCloudDB schema backupDir (Repo "test2" "0013")
+    (age(days 3)) (complete 9) Nothing
+  makeFakeCloudDB schema backupDir (Repo "test2" "0014")
+    (age(days 2)) (complete 9) Nothing
 
 withFakeDBs
   :: (EventBaseDataplane -> NullConfigProvider -> FilePath -> FilePath
        -> IO ())
   -> IO ()
 withFakeDBs action = withTest setupBasicDBs (const $ pure ()) action
+
+withFakeCloudDBs
+  :: (EventBaseDataplane -> NullConfigProvider -> FilePath -> FilePath
+       -> IO ())
+  -> IO ()
+withFakeCloudDBs = withTest (const $ pure ()) setupBasicCloudDBs
 
 makeFakeDB
   :: DbSchema
@@ -584,7 +597,6 @@ shardingByRepoNameTest = TestCase $ withFakeDBs $ \evb cfgAPI dbdir backupdir ->
   withDatabases evb cfg cfgAPI $ \env -> do
     runDatabaseJanitor env
     waitDel env
-    waitRestoring env
     dbs <- listHereDBs env
     assertEqual "only test2 dbs belong to the shard"
       ["0003", "0004", "0005", "0006"]
@@ -618,6 +630,49 @@ elsewhereTest = TestCase $ withFakeDBs $ \evb cfgAPI dbdir backupdir -> do
       [ "0001", "0002", "0003", "0004", "0005", "0006"]
       (sort $ map (repo_hash . database_repo) dbs)
 
+makeFilterDBsWithInvariant :: ([Repo] -> IO [Repo]) -> IO ([Repo] -> IO [Repo])
+makeFilterDBsWithInvariant pred = do
+  seenAvailabeDBsRef <- newIORef mempty
+  return $ \dbs -> do
+    available <- pred dbs
+    let availableSet = HashSet.fromList available
+    beenAvailableBefore <- readIORef seenAvailabeDBsRef
+    assertEqual "called cfgFilterAvailableDBs twice on the same DB"
+      mempty (HashSet.intersection availableSet beenAvailableBefore)
+    writeIORef seenAvailabeDBsRef (availableSet <> beenAvailableBefore)
+    return available
+
+elsewhereNotYetAvailableTest :: Test
+elsewhereNotYetAvailableTest =
+  TestCase $ withFakeCloudDBs $ \evb cfgAPI dbdir backupdir -> do
+    let myShards = pure $ Just []
+    filterDBs <- makeFilterDBsWithInvariant $
+      return . filter ((`elem` ["0008","0009"]) . repo_hash)
+    let cfg = (dbConfig dbdir (serverConfig backupdir)
+          { config_retention = def
+            { databaseRetentionPolicy_default_retention = def
+              { retention_delete_if_older =
+                  Just $ fromIntegral $ timeSpanInSeconds $ days 10
+              , retention_retain_at_least = Just 2
+              , retention_retain_at_most = Just 4
+              }
+            },
+            config_restore = def {
+              databaseRestorePolicy_enabled = True
+            }
+          })
+          {cfgShardManager = \_ _ k ->
+              k $ SomeShardManager $ shardByRepoHash myShards
+          ,cfgFilterAvailableDBs = filterDBs
+          }
+    withDatabases evb cfg cfgAPI $ \env -> do
+      runDatabaseJanitor env
+      dbs <- listAllDBs env
+
+      assertEqual
+        "at least 2 dbs actually available + at most 4 more not yet available"
+        ["0008", "0009", "0011", "0012", "0013", "0014"]
+        (sort $ map (repo_hash . database_repo) dbs)
 
 shardUnexpireTest :: Test
 shardUnexpireTest = TestCase $ withFakeDBs $ \evb cfgAPI dbdir backupdir -> do
@@ -732,105 +787,6 @@ ageCountersClearTest = TestCase $ do
     assertBool "glean.db.test.age cleared"
       $ not (HashMap.member "glean.db.test.age" counters)
 
-slackCountersTest :: Test
-slackCountersTest = TestCase $ do
-  shardAssignment <- newIORef $ Just ["0008"]
-  withTest noLocalDBs setupBasicCloudDBs $ \evb cfgAPI dbdir backupDir -> do
-
-    let cfg = (dbConfig dbdir (serverConfig backupDir)
-          { config_restore = def {
-              databaseRestorePolicy_enabled = True
-            }, config_retention = def{
-              databaseRetentionPolicy_default_retention = def{
-              retention_retain_at_least = Just 1,
-              retention_retain_at_most = Just 1
-              }
-            }
-          }) {cfgShardManager = \_ _ k -> k shardManager}
-        shardManager =
-          SomeShardManager $ shardByRepoHash (readIORef shardAssignment)
-    withDatabases evb cfg cfgAPI $ \env -> do
-      let getSlackCounters sideEffects =
-            [ (c,v)
-            | PublishCounter c v <- sideEffects
-            , ".slack.bytes" `BS.isSuffixOf` c
-            ]
-      slackCounters0 <- getSlackCounters <$> runDatabaseJanitorPureish env
-      assertEqual "slack counters" [("glean.db.slack.bytes", 0)] slackCounters0
-      now <- getCurrentTime
-      schema <- parseSchemaDir schemaSourceDir
-      schema <- newDbSchema Nothing schema LatestSchemaAll readWriteContent
-      -- Two new DBs push 0008 out of the retention set
-      makeFakeCloudDB schema backupDir (Repo "test" "0009") now (complete 1)
-        Nothing
-      makeFakeCloudDB schema backupDir (Repo "test" "0010") now (complete 1)
-        Nothing
-      -- Force the janitor to fetch backups
-      atomically $ writeTVar (envCachedRestorableDBs env) Nothing
-      slackCounters1 <- getSlackCounters <$> runDatabaseJanitorPureish env
-      assertEqual "slack counters"
-        [("glean.db.slack.bytes", 8), ("glean.db.test.slack.bytes", 8)]
-        slackCounters1
-
-slackDeletionTest :: Test
-slackDeletionTest = TestCase $ do
-  shardAssignment <- newIORef $ Just ["0008"]
-  withTest noLocalDBs setupBasicCloudDBs $ \evb cfgAPI dbdir backupDir -> do
-
-    let cfg = (dbConfig dbdir (serverConfig backupDir)
-          { config_restore = def {
-              databaseRestorePolicy_enabled = True
-            }, config_retention = def{
-              databaseRetentionPolicy_default_retention = def{
-              retention_retain_at_least = Just 1,
-              retention_retain_at_most = Just 1,
-              retention_remote_db_bumps_local_db_after =
-                Just (fromIntegral (timeSpanInSeconds (days 2)))
-              }
-            }
-          }) {cfgShardManager = \_ _ k -> k shardManager}
-        shardManager =
-          SomeShardManager $ shardByRepoHash (readIORef shardAssignment)
-
-    withDatabases evb cfg cfgAPI $ \env -> do
-      runDatabaseJanitor env
-
-      now <- getCurrentTime
-      schema <- parseSchemaDir schemaSourceDir
-      schema <- newDbSchema Nothing schema LatestSchemaAll readWriteContent
-      let age t = addUTCTime (negate (fromIntegral (timeSpanInSeconds t))) now
-
-      makeFakeCloudDB schema backupDir
-        (Repo "test" "0009") (age (days 0)) (complete 1) Nothing
-      makeFakeCloudDB schema backupDir
-        (Repo "test" "0010") (age (days 1)) (complete 1) Nothing
-      -- 0009/0010 are not in our shard, and they aren't old enough to
-      -- push out 0008
-      atomically $ writeTVar (envCachedRestorableDBs env) Nothing
-      runDatabaseJanitor env
-      res <- timeout 10000000 -- 10s
-                     (waitDel env)
-      waitingDeletion <- readTVarIO (envDeleting env)
-      assertBool ("timeout: " <> show (HashMap.keys waitingDeletion))
-        (isJust res)
-      localDBs <- listHereDBs env
-      assertBool "not deleted" $ case localDBs of
-        [one] -> repo_hash (database_repo one) == "0008"
-        _ -> False
-
-      makeFakeCloudDB schema backupDir
-        (Repo "test" "0011") (age (days 2)) (complete 1) Nothing
-      -- 0010 is not in our shard, and it is old enough to push out 0008
-      atomically $ writeTVar (envCachedRestorableDBs env) Nothing
-      runDatabaseJanitor env
-      res <- timeout 10000000 -- 10s
-                     (waitDel env)
-      waitingDeletion <- readTVarIO (envDeleting env)
-      assertBool ("timeout: " <> show (HashMap.keys waitingDeletion))
-        (isJust res)
-      localDBs <- listHereDBs env
-      assertEqual "deleted" [] localDBs
-
 main :: IO ()
 main = withUnitTest $ testRunner $ TestList
   [ TestLabel "deleteOldDBs" deleteOldDBsTest
@@ -847,9 +803,8 @@ main = withUnitTest $ testRunner $ TestList
   , TestLabel "shardingByRepoName" shardingByRepoNameTest
   , TestLabel "shardingExpiring" shardUnexpireTest
   , TestLabel "availableElsewhere" elsewhereTest
+  , TestLabel "notAvailableElsewhere" elsewhereNotYetAvailableTest
   , TestLabel "ageCountersForAllNewestDBs" ageCountersCompleteTest
   , TestLabel "ageCountersForOnlyNewestDBs" ageCountersOnlyNewestTest
   , TestLabel "ageCountersClear" ageCountersClearTest
-  , TestLabel "slackCounters" slackCountersTest
-  , TestLabel "slackDeletion" slackDeletionTest
   ]


### PR DESCRIPTION
Summary:
This provides an external oracle based on `srGetSelection` to filter available DBs.

We want to be careful here: if the oracle doesn't work correctly it could cause a serious service downtime, where only local DBs are advertised. for this reason it is guarded behind a JK "code_indexing/glean:server_filter_available_dbs".

Reviewed By: simonmar

Differential Revision: D49686454

