### PR TITLE
filter available DBs before computing retention set

### DIFF
--- a/glean/db/Glean/Database/Config.hs
+++ b/glean/db/Glean/Database/Config.hs
@@ -156,6 +156,8 @@ data Config = Config
     -- ^ Backup backends
   , cfgEnableRecursion :: Bool
     -- ^ Enable experimental support for recursion
+  , cfgFilterAvailableDBs :: [Repo] -> IO [Repo]
+    -- ^ Filter out DBs not currently available in the server tier
   }
 
 instance Show Config where
@@ -182,6 +184,7 @@ instance Default Config where
     , cfgDatabaseLogger = Some NullGleanDatabaseLogger
     , cfgBackupBackends = HashMap.fromList [("mock", Backup.Mock.mock)]
     , cfgEnableRecursion = False
+    , cfgFilterAvailableDBs = return
     }
 
 data SchemaIndex = SchemaIndex
@@ -430,6 +433,7 @@ options = do
     , cfgServerLogger = cfgServerLogger def
     , cfgDatabaseLogger = cfgDatabaseLogger def
     , cfgBackupBackends = cfgBackupBackends def
+    , cfgFilterAvailableDBs = return
     , .. }
   where
     recipesConfigThriftSource = option (eitherReader ThriftSource.parse)

--- a/glean/db/Glean/Database/Env.hs
+++ b/glean/db/Glean/Database/Env.hs
@@ -144,6 +144,7 @@ initEnv evb envStorage envCatalog shardManager cfg
           if cfgEnableRecursion cfg
           then EnableRecursion
           else DisableRecursion
+      , envFilterAvailableDBs = cfgFilterAvailableDBs cfg
       , .. }
 
 spawnThreads :: Env -> IO ()

--- a/glean/db/Glean/Database/Env.hs
+++ b/glean/db/Glean/Database/Env.hs
@@ -106,6 +106,7 @@ initEnv evb envStorage envCatalog shardManager cfg
     envDatabaseJanitor <- newTVarIO Nothing
     envDatabaseJanitorPublishedCounters <- newTVarIO mempty
     envCachedRestorableDBs <- newTVarIO Nothing
+    envCachedAvailableDBs <- newTVarIO mempty
 
     envLoggerRateLimit <-
       newRateLimiterMap (fromIntegral config_logging_rate_limit) 600

--- a/glean/db/Glean/Database/Types.hs
+++ b/glean/db/Glean/Database/Types.hs
@@ -246,6 +246,7 @@ data Env = forall storage. Storage storage => Env
   , envDatabaseJanitor :: TVar (Maybe JanitorRunResult)
   , envDatabaseJanitorPublishedCounters :: TVar (HashSet ByteString)
   , envCachedRestorableDBs :: TVar (Maybe (UTCTime, [(Thrift.Repo, Meta)]))
+  , envCachedAvailableDBs :: TVar (HashSet Thrift.Repo)
   , envWorkQueue :: WorkQueue
   , envHeartbeats :: Heartbeats
   , envWrites :: TVar (HashMap Text Write)

--- a/glean/db/Glean/Database/Types.hs
+++ b/glean/db/Glean/Database/Types.hs
@@ -214,7 +214,7 @@ data JanitorRunResult
 
 data JanitorException
   = OtherJanitorException SomeException
-  | JanitorFetchBackupsFailure -- ^ Raised only when no catalog available
+  | JanitorFetchBackupsFailure -- ^ Raised only when no remote db list available
   deriving (Typeable, Show)
 
 instance Exception JanitorException
@@ -264,6 +264,8 @@ data Env = forall storage. Storage storage => Env
   , envShardManager :: SomeShardManager
   , envEnableRecursion :: EnableRecursion
       -- ^ Experimental support for recursive queries. For testing only.
+  , envFilterAvailableDBs :: [Thrift.Repo] -> IO [Thrift.Repo]
+    -- ^ Filter out DBs not currently available in the server tier
   }
 
 instance Show Env where

--- a/glean/test/tests/DatabaseJanitorTest.hs
+++ b/glean/test/tests/DatabaseJanitorTest.hs
@@ -117,9 +117,6 @@ setupBasicDBs dbdir = do
   makeFakeDB schema dbdir (Repo "test2" "0006") (age (days 6)) (complete 6)
     Nothing
 
-noLocalDBs :: FilePath -> IO ()
-noLocalDBs _ = pure ()
-
 setupBasicCloudDBs :: FilePath -> IO ()
 setupBasicCloudDBs backupDir = do
   now <- getCurrentTime
@@ -129,13 +126,29 @@ setupBasicCloudDBs backupDir = do
   makeFakeCloudDB schema backupDir (Repo "test" "0008")
     (age(days 8)) (complete 8) Nothing
   makeFakeCloudDB schema backupDir (Repo "test2" "0009")
-    (age(days 0)) (complete 9) Nothing
+    (age(days 7)) (complete 9) Nothing
+  makeFakeCloudDB schema backupDir (Repo "test2" "0010")
+    (age(days 6)) (complete 9) Nothing
+  makeFakeCloudDB schema backupDir (Repo "test2" "0011")
+    (age(days 5)) (complete 9) Nothing
+  makeFakeCloudDB schema backupDir (Repo "test2" "0012")
+    (age(days 4)) (complete 9) Nothing
+  makeFakeCloudDB schema backupDir (Repo "test2" "0013")
+    (age(days 3)) (complete 9) Nothing
+  makeFakeCloudDB schema backupDir (Repo "test2" "0014")
+    (age(days 2)) (complete 9) Nothing
 
 withFakeDBs
   :: (EventBaseDataplane -> NullConfigProvider -> FilePath -> FilePath
        -> IO ())
   -> IO ()
 withFakeDBs action = withTest setupBasicDBs (const $ pure ()) action
+
+withFakeCloudDBs
+  :: (EventBaseDataplane -> NullConfigProvider -> FilePath -> FilePath
+       -> IO ())
+  -> IO ()
+withFakeCloudDBs = withTest (const $ pure ()) setupBasicCloudDBs
 
 makeFakeDB
   :: DbSchema
@@ -584,7 +597,6 @@ shardingByRepoNameTest = TestCase $ withFakeDBs $ \evb cfgAPI dbdir backupdir ->
   withDatabases evb cfg cfgAPI $ \env -> do
     runDatabaseJanitor env
     waitDel env
-    waitRestoring env
     dbs <- listHereDBs env
     assertEqual "only test2 dbs belong to the shard"
       ["0003", "0004", "0005", "0006"]
@@ -618,31 +630,49 @@ elsewhereTest = TestCase $ withFakeDBs $ \evb cfgAPI dbdir backupdir -> do
       [ "0001", "0002", "0003", "0004", "0005", "0006"]
       (sort $ map (repo_hash . database_repo) dbs)
 
+makeFilterDBsWithInvariant :: ([Repo] -> IO [Repo]) -> IO ([Repo] -> IO [Repo])
+makeFilterDBsWithInvariant pred = do
+  seenAvailabeDBsRef <- newIORef mempty
+  return $ \dbs -> do
+    available <- pred dbs
+    let availableSet = HashSet.fromList available
+    beenAvailableBefore <- readIORef seenAvailabeDBsRef
+    assertEqual "called cfgFilterAvailableDBs twice on the same DB"
+      mempty (HashSet.intersection availableSet beenAvailableBefore)
+    writeIORef seenAvailabeDBsRef (availableSet <> beenAvailableBefore)
+    return available
+
 elsewhereNotYetAvailableTest :: Test
-elsewhereNotYetAvailableTest = TestCase $ withFakeDBs $ \evb cfgAPI dbdir backupdir -> do
-  let myShards = pure $ Just ["0001"]
-  let cfg = (dbConfig dbdir (serverConfig backupdir)
-        { config_retention = def
-          { databaseRetentionPolicy_default_retention = def
-            { retention_delete_if_older =
-                Just $ fromIntegral $ timeSpanInSeconds $ days 10
-            , retention_retain_at_least = Just 10 }
+elsewhereNotYetAvailableTest =
+  TestCase $ withFakeCloudDBs $ \evb cfgAPI dbdir backupdir -> do
+    let myShards = pure $ Just []
+    filterDBs <- makeFilterDBsWithInvariant $
+      return . filter ((`elem` ["0008","0009"]) . repo_hash)
+    let cfg = (dbConfig dbdir (serverConfig backupdir)
+          { config_retention = def
+            { databaseRetentionPolicy_default_retention = def
+              { retention_delete_if_older =
+                  Just $ fromIntegral $ timeSpanInSeconds $ days 10
+              , retention_retain_at_least = Just 2
+              , retention_retain_at_most = Just 4
+              }
+            },
+            config_restore = def {
+              databaseRestorePolicy_enabled = True
+            }
+          })
+          {cfgShardManager = \_ _ k ->
+              k $ SomeShardManager $ shardByRepoHash myShards
+          ,cfgFilterAvailableDBs = filterDBs
           }
-        })
-        {cfgShardManager = \_ _ k ->
-            k $ SomeShardManager $ shardByRepoHash myShards
-        ,cfgFilterAvailableDBs = return . filter (\db -> repo_hash db == "0003")
-        }
-  withDatabases evb cfg cfgAPI $ \env -> do
-    runDatabaseJanitor env
-    waitDel env
-    dbs <- listAllDBs env
+    withDatabases evb cfg cfgAPI $ \env -> do
+      runDatabaseJanitor env
+      dbs <- listAllDBs env
 
-    assertEqual "after: dbs actually available"
-      ["0001", "0003"]
-      (sort $ map (repo_hash . database_repo) dbs)
-
-
+      assertEqual
+        "at least 2 dbs actually available + at most 4 more not yet available"
+        ["0008", "0009", "0011", "0012", "0013", "0014"]
+        (sort $ map (repo_hash . database_repo) dbs)
 
 shardUnexpireTest :: Test
 shardUnexpireTest = TestCase $ withFakeDBs $ \evb cfgAPI dbdir backupdir -> do
@@ -757,105 +787,6 @@ ageCountersClearTest = TestCase $ do
     assertBool "glean.db.test.age cleared"
       $ not (HashMap.member "glean.db.test.age" counters)
 
-slackCountersTest :: Test
-slackCountersTest = TestCase $ do
-  shardAssignment <- newIORef $ Just ["0008"]
-  withTest noLocalDBs setupBasicCloudDBs $ \evb cfgAPI dbdir backupDir -> do
-
-    let cfg = (dbConfig dbdir (serverConfig backupDir)
-          { config_restore = def {
-              databaseRestorePolicy_enabled = True
-            }, config_retention = def{
-              databaseRetentionPolicy_default_retention = def{
-              retention_retain_at_least = Just 1,
-              retention_retain_at_most = Just 1
-              }
-            }
-          }) {cfgShardManager = \_ _ k -> k shardManager}
-        shardManager =
-          SomeShardManager $ shardByRepoHash (readIORef shardAssignment)
-    withDatabases evb cfg cfgAPI $ \env -> do
-      let getSlackCounters sideEffects =
-            [ (c,v)
-            | PublishCounter c v <- sideEffects
-            , ".slack.bytes" `BS.isSuffixOf` c
-            ]
-      slackCounters0 <- getSlackCounters <$> runDatabaseJanitorPureish env
-      assertEqual "slack counters" [("glean.db.slack.bytes", 0)] slackCounters0
-      now <- getCurrentTime
-      schema <- parseSchemaDir schemaSourceDir
-      schema <- newDbSchema Nothing schema LatestSchemaAll readWriteContent
-      -- Two new DBs push 0008 out of the retention set
-      makeFakeCloudDB schema backupDir (Repo "test" "0009") now (complete 1)
-        Nothing
-      makeFakeCloudDB schema backupDir (Repo "test" "0010") now (complete 1)
-        Nothing
-      -- Force the janitor to fetch backups
-      atomically $ writeTVar (envCachedRestorableDBs env) Nothing
-      slackCounters1 <- getSlackCounters <$> runDatabaseJanitorPureish env
-      assertEqual "slack counters"
-        [("glean.db.slack.bytes", 8), ("glean.db.test.slack.bytes", 8)]
-        slackCounters1
-
-slackDeletionTest :: Test
-slackDeletionTest = TestCase $ do
-  shardAssignment <- newIORef $ Just ["0008"]
-  withTest noLocalDBs setupBasicCloudDBs $ \evb cfgAPI dbdir backupDir -> do
-
-    let cfg = (dbConfig dbdir (serverConfig backupDir)
-          { config_restore = def {
-              databaseRestorePolicy_enabled = True
-            }, config_retention = def{
-              databaseRetentionPolicy_default_retention = def{
-              retention_retain_at_least = Just 1,
-              retention_retain_at_most = Just 1,
-              retention_remote_db_bumps_local_db_after =
-                Just (fromIntegral (timeSpanInSeconds (days 2)))
-              }
-            }
-          }) {cfgShardManager = \_ _ k -> k shardManager}
-        shardManager =
-          SomeShardManager $ shardByRepoHash (readIORef shardAssignment)
-
-    withDatabases evb cfg cfgAPI $ \env -> do
-      runDatabaseJanitor env
-
-      now <- getCurrentTime
-      schema <- parseSchemaDir schemaSourceDir
-      schema <- newDbSchema Nothing schema LatestSchemaAll readWriteContent
-      let age t = addUTCTime (negate (fromIntegral (timeSpanInSeconds t))) now
-
-      makeFakeCloudDB schema backupDir
-        (Repo "test" "0009") (age (days 0)) (complete 1) Nothing
-      makeFakeCloudDB schema backupDir
-        (Repo "test" "0010") (age (days 1)) (complete 1) Nothing
-      -- 0009/0010 are not in our shard, and they aren't old enough to
-      -- push out 0008
-      atomically $ writeTVar (envCachedRestorableDBs env) Nothing
-      runDatabaseJanitor env
-      res <- timeout 10000000 -- 10s
-                     (waitDel env)
-      waitingDeletion <- readTVarIO (envDeleting env)
-      assertBool ("timeout: " <> show (HashMap.keys waitingDeletion))
-        (isJust res)
-      localDBs <- listHereDBs env
-      assertBool "not deleted" $ case localDBs of
-        [one] -> repo_hash (database_repo one) == "0008"
-        _ -> False
-
-      makeFakeCloudDB schema backupDir
-        (Repo "test" "0011") (age (days 2)) (complete 1) Nothing
-      -- 0010 is not in our shard, and it is old enough to push out 0008
-      atomically $ writeTVar (envCachedRestorableDBs env) Nothing
-      runDatabaseJanitor env
-      res <- timeout 10000000 -- 10s
-                     (waitDel env)
-      waitingDeletion <- readTVarIO (envDeleting env)
-      assertBool ("timeout: " <> show (HashMap.keys waitingDeletion))
-        (isJust res)
-      localDBs <- listHereDBs env
-      assertEqual "deleted" [] localDBs
-
 main :: IO ()
 main = withUnitTest $ testRunner $ TestList
   [ TestLabel "deleteOldDBs" deleteOldDBsTest
@@ -876,6 +807,4 @@ main = withUnitTest $ testRunner $ TestList
   , TestLabel "ageCountersForAllNewestDBs" ageCountersCompleteTest
   , TestLabel "ageCountersForOnlyNewestDBs" ageCountersOnlyNewestTest
   , TestLabel "ageCountersClear" ageCountersClearTest
-  , TestLabel "slackCounters" slackCountersTest
-  , TestLabel "slackDeletion" slackDeletionTest
   ]


### PR DESCRIPTION
Summary:
We can compute the retention set with full precision if we know which DBs are available elsewhere. That simplifies code a bit as we dont' need to track the remote retention set or to compute slack.

Because `getShards` does not honor locality options, we have to fall back to `getSelection` on every DB. Doing this on every backup would be ridiculously expensive and wasteful, since we will only end up looking at a newest subset.

What we want is to check availability only for the DBs that are considered for the retention set, and do so only once per DB. Laziness fits like a glove here so I am using `unsafePerformIO`, but it should be easy to do it properly with a State monad if we decide to go down this route.

Differential Revision: D49694989

