### PR TITLE
non-clang CI: llvm 11 -> 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install additional tools
         run: |
           apt-get update
-          apt install -y ninja-build libxxhash-dev m4 rsync wget unzip clang-11 libclang-11-dev llvm-11-dev libgmock-dev
+          apt install -y ninja-build libxxhash-dev m4 rsync wget unzip clang-12 libclang-12-dev llvm-12-dev libgmock-dev
           apt-get remove -y libfmt-dev
 
       - name: Make utf8 default locale


### PR DESCRIPTION
Some of the clang tests fail with LLVM 11, upgrading to 12 fixes it.