### PR TITLE
add dependency on Glean.Glass.SymbolId.Fbthrift

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1280,6 +1280,7 @@ library glass-lib
         Glean.Glass.SymbolId.Pp
         Glean.Glass.SymbolId.Python
         Glean.Glass.SymbolId.Thrift
+        Glean.Glass.SymbolId.Fbthrift
         Glean.Glass.SymbolKind
         Glean.Glass.SymbolMap
         Glean.Glass.SymbolSig


### PR DESCRIPTION
Summary: Add a missing dependency on a new module created in D50078273

Differential Revision: D50262399


