### PR TITLE
Revert D49682777: Multisect successfully blamed "D49682777: [Codemod][ThriftAnnotationsFBSource] fbcode/glean/" for test or build failures

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1280,6 +1280,7 @@ library glass-lib
         Glean.Glass.SymbolId.Pp
         Glean.Glass.SymbolId.Python
         Glean.Glass.SymbolId.Thrift
+        Glean.Glass.SymbolId.Fbthrift
         Glean.Glass.SymbolKind
         Glean.Glass.SymbolMap
         Glean.Glass.SymbolSig

--- a/glean/glass/if/glass.thrift
+++ b/glean/glass/if/glass.thrift
@@ -8,7 +8,6 @@
 
 include "glean/github/if/fb303.thrift"
 include "glean/if/index.thrift"
-include "thrift/annotation/hack.thrift"
 
 namespace hs Glean
 namespace hack GleanGlass
@@ -312,29 +311,17 @@ struct Annotation {
 }
 
 // Visibility attributes
-@hack.Attributes{
-  attributes = [
-    "\GraphQLEnum('GlassVisibility')",
-    "\SelfDescriptive",
-    "\Oncalls('code_indexing')",
-  ],
-}
 enum Visibility {
   Public = 20,
   Protected = 30,
   Private = 40,
   Internal = 50,
-}
+} (
+  hack.attributes = "\GraphQLEnum('GlassVisibility'), \SelfDescriptive, \Oncalls('code_indexing')",
+)
 
 // Symbol modifiers (see codmearkup.types.Modifiers for those in Glean)
 // nb. upper case for thrift to graphql happiness
-@hack.Attributes{
-  attributes = [
-    "\GraphQLEnum('GlassModifiers')",
-    "\SelfDescriptive",
-    "\Oncalls('code_indexing')",
-  ],
-}
 enum Modifier {
   ABSTRACT = 1,
   FINAL = 2,
@@ -346,7 +333,9 @@ enum Modifier {
   VOLATILE = 8,
   VIRTUAL = 9,
   INLINE = 10,
-}
+} (
+  hack.attributes = "\GraphQLEnum('GlassModifiers'), \SelfDescriptive, \Oncalls('code_indexing')",
+)
 
 // A symbol occuring in a type, together with its
 // span relative to the signature field
@@ -409,14 +398,6 @@ struct SearchContext {
 }
 
 // tags for symbol kinds, so clients can distinguish them
-@hack.Attributes{
-  attributes = [
-    "\GraphQLEnum('GlassSymbolKind')",
-    "\RelayFlowEnum",
-    "\SelfDescriptive",
-    "\Oncalls('code_indexing')",
-  ],
-}
 enum SymbolKind {
   Package = 1,
   Type = 2,
@@ -449,16 +430,10 @@ enum SymbolKind {
   Union = 29,
   Macro = 30,
   Trait = 31,
-}
+} (
+  hack.attributes = "\GraphQLEnum('GlassSymbolKind'), \RelayFlowEnum, \SelfDescriptive, \Oncalls('code_indexing')",
+)
 
-@hack.Attributes{
-  attributes = [
-    "\GraphQLEnum('GlassLanguage')",
-    "\RelayFlowEnum",
-    "\SelfDescriptive",
-    "\Oncalls('code_indexing')",
-  ],
-}
 enum Language {
   Cpp = 1,
   JavaScript = 2,
@@ -475,20 +450,17 @@ enum Language {
   TypeScript = 13,
   Go = 14,
   Kotlin = 15,
-}
+} (
+  hack.attributes = "\GraphQLEnum('GlassLanguage'), \RelayFlowEnum, \SelfDescriptive, \Oncalls('code_indexing')",
+)
 
 // Kinds of definitions. E.g. for jump-to-declaration or jump-to-definition
-@hack.Attributes{
-  attributes = [
-    "\GraphQLEnum('GlassDefinitionKind')",
-    "\SelfDescriptive",
-    "\Oncalls('code_indexing')",
-  ],
-}
 enum DefinitionKind {
   Definition = 1,
   Declaration = 2,
-}
+} (
+  hack.attributes = "\GraphQLEnum('GlassDefinitionKind'), \SelfDescriptive, \Oncalls('code_indexing')",
+)
 
 // What kind of search to conduct
 struct SymbolSearchOptions {

--- a/glean/if/glean.thrift
+++ b/glean/if/glean.thrift
@@ -134,7 +134,7 @@ struct TaskWaiting {}
 
 struct TaskRunning {
   // ParcelState for parcels [0,1..n-1] where n is Recipe.parcels.
-  1: list_ParcelState_7430 parcels;
+  1: list<ParcelState> (hs.type = "Vector") parcels;
 }
 
 struct TaskFinished {
@@ -254,7 +254,7 @@ struct Batch {
   //   - all elements are unique
   //   - ids are reasonably dense (writing the batch to the db will use a
   //     data structure of size O(max id - firstId))
-  4: optional list_i64_7948 ids;
+  4: optional list<i64> (hs.type = "VectorStorable") ids;
 
   // (optional for now)
   //
@@ -268,7 +268,7 @@ struct Batch {
   //
   // Units do not need to be declared beforehand; a Unit exists if
   // it is the owner of at least one fact.
-  5: map_UnitName_listOfIds_7119 owned;
+  5: map<UnitName, listOfIds> (hs.type = "HashMap") owned;
 
   // Specifies explicit dependencies of derived facts per predicate.
   //
@@ -283,7 +283,7 @@ struct Batch {
 
 struct Subst {
   1: Id firstId;
-  2: list_i64_7948 ids;
+  2: list<i64> (hs.type = "VectorStorable") ids;
 }
 
 struct Error {
@@ -803,8 +803,8 @@ struct UserQueryResultsBin {
 
 struct UserQueryResultsListBin {
   1: UserQueryEncodingListBin encoding;
-  2: list_Id_2029 ids;
-  3: list_Fact_2137 facts;
+  2: list<Id> (hs.type = "Vector") ids;
+  3: list<Fact> (hs.type = "Vector") facts;
   4: map<Id, Fact> nestedFacts;
 }
 
@@ -1302,12 +1302,3 @@ struct PredicateAnnotation {
   1: PredicateName name;
   2: i32 version;
 }
-
-// The following were automatically generated and may benefit from renaming.
-typedef list<Fact> (hs.type = "Vector") list_Fact_2137
-typedef list<Id> (hs.type = "Vector") list_Id_2029
-typedef list<ParcelState> (hs.type = "Vector") list_ParcelState_7430
-typedef list<i64> (hs.type = "VectorStorable") list_i64_7948
-typedef map<UnitName, listOfIds> (
-  hs.type = "HashMap",
-) map_UnitName_listOfIds_7119

--- a/glean/if/internal.thrift
+++ b/glean/if/internal.thrift
@@ -14,7 +14,7 @@ namespace hs Glean
 
 // The Schema stored in a DB
 struct StoredSchema {
-  1: string_321 schema;
+  1: string (hs.type = "ByteString") schema;
   2: map<glean.Id, glean.PredicateRef> predicateIds;
 
   // We store the SchemaId corresponding to each all.version in the
@@ -105,6 +105,3 @@ struct SchemaIndex {
   // Older versions of the schema we also know about
   2: list<SchemaInstance> older;
 }
-
-// The following were automatically generated and may benefit from renaming.
-typedef string (hs.type = "ByteString") string_321

--- a/glean/lang/codemarkup/tests/thrift/cases/xrefs/lib.thrift
+++ b/glean/lang/codemarkup/tests/thrift/cases/xrefs/lib.thrift
@@ -11,8 +11,6 @@ namespace hack GleanGlass
 namespace py3 glean
 namespace cpp2 glean
 
-include "thrift/annotation/hack.thrift"
-
 typedef string RepoName (hs.newtype)
 
 typedef string Path (hs.newtype)
@@ -162,14 +160,6 @@ struct SearchContext {
   4: set<SymbolKind> kinds;
 }
 
-@hack.Attributes{
-  attributes = [
-    "\GraphQLEnum('GlassSymbolKind')",
-    "\RelayFlowEnum",
-    "\SelfDescriptive",
-    "\Oncalls('code_indexing')",
-  ],
-}
 enum SymbolKind {
   Package = 1,
   Type = 2,
@@ -201,16 +191,10 @@ enum SymbolKind {
   TypeParameter = 28,
   Union = 29,
   Macro = 30,
-}
+} (
+  hack.attributes = "\GraphQLEnum('GlassSymbolKind'), \RelayFlowEnum, \SelfDescriptive, \Oncalls('code_indexing')",
+)
 
-@hack.Attributes{
-  attributes = [
-    "\GraphQLEnum('GlassLanguage')",
-    "\RelayFlowEnum",
-    "\SelfDescriptive",
-    "\Oncalls('code_indexing')",
-  ],
-}
 enum Language {
   Cpp = 1,
   JavaScript = 2,
@@ -223,19 +207,16 @@ enum Language {
   Thrift = 9,
   Rust = 10,
   Buck = 11,
-}
+} (
+  hack.attributes = "\GraphQLEnum('GlassLanguage'), \RelayFlowEnum, \SelfDescriptive, \Oncalls('code_indexing')",
+)
 
-@hack.Attributes{
-  attributes = [
-    "\GraphQLEnum('GlassDefinitionKind')",
-    "\SelfDescriptive",
-    "\Oncalls('code_indexing')",
-  ],
-}
 enum DefinitionKind {
   Definition = 1,
   Declaration = 2,
-}
+} (
+  hack.attributes = "\GraphQLEnum('GlassDefinitionKind'), \SelfDescriptive, \Oncalls('code_indexing')",
+)
 
 struct SearchByNameRequest {
   1: SearchContext context;


### PR DESCRIPTION
Summary:
This diff is reverting D49682777
D49682777: [Codemod][ThriftAnnotationsFBSource] fbcode/glean/ by generatedunixname226714639793621 has been identified to be causing the following test or build failures:

Tests affected:
- [glean/lang/codemarkup/tests/thrift:tests - cases/xrefs](https://www.internalfb.com/intern/test/844425006128750/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3270522
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Differential Revision: D50240775


