### PR TITLE
[scip-python] This fixes the flags used so we get a working indexer

### DIFF
--- a/glean/lang/python-scip/Glean/Indexer/PythonScip.hs
+++ b/glean/lang/python-scip/Glean/Indexer/PythonScip.hs
@@ -34,8 +34,7 @@ indexer = Indexer {
     indexerRun = \PythonScip{..} backend repo IndexerParams{..} -> do
         val <- SCIP.runIndexer ScipIndexerParams {
             scipBinary = pythonScipBinary,
-            scipArgs = const [ "index","--cwd", indexerRoot,
-             "--target-only", "--output"],
+            scipArgs = const [ "index", "."],
             scipRoot = indexerRoot,
             scipWritesLocal = True,
             scipLanguage = Just SCIP.Python


### PR DESCRIPTION
Previously it was failing silently on --cwd etc

Test plan:
$ :index python-scip sample/