### PR TITLE
[ci][rust-analyzer] Fix test output for RA (difference between x86 and aarcg64

### DIFF
--- a/glean/lang/rust-scip/tests/cases/xrefs/metadata.out
+++ b/glean/lang/rust-scip/tests/cases/xrefs/metadata.out
@@ -6,7 +6,7 @@
       "toolInfo": {
         "toolName": "rust-analyzer",
         "toolArgs": [ ],
-        "version": "0.3.1722-standalone (c1c9e10f7 2023-11-05)"
+        "version": "0.3.1722-standalone"
       },
       "projectRoot": "",
       "textEncoding": 1


### PR DESCRIPTION
Annoying difference in the two binaries picked up by tests. Irrelevant to us.

Fixes this test error: https://github.com/facebookincubator/Glean/actions/runs/6955665280/job/18924913519 