### PR TITLE
[glean][oss] Fix CI: add a missing dep for the LocalOrRemote backend

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -2338,6 +2338,7 @@ library glass-regression
         glean:client-hs,
         glean:glass-lib,
         glean:if-glass-hs,
+        glean:client-hs-local,
         glean:indexers,
         glean:logger,
         glean:regression-test-lib,
@@ -2351,6 +2352,7 @@ common glass-regression-deps
     hs-source-dirs: glean/glass/test/regression
     build-depends:
         HUnit,
+        glean:client-hs-local
         glean:glass-lib,
         glean:glass-regression,
         glean:if-glass-hs,


### PR DESCRIPTION
`cabal build glass-regression-go` will work. Fixes 

```
Test suite glean-snapshot-go: RUNNING...

glean/glass/test/regression/lib/Glean/Glass/Regression/Tests.hs:28:1: error:
    Could not load module ‘Glean.LocalOrRemote’
    It is a member of the hidden package ‘glean-0.1.0.0’.
    Perhaps you need to add ‘glean’ to the build-depends in your .cabal file.
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
28 | import Glean.LocalOrRemote
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
```