### PR TITLE
[glean][python-scip] Use --project-version to specify a dummy version…

### DIFF
--- a/glean/lang/python-scip/Glean/Indexer/PythonScip.hs
+++ b/glean/lang/python-scip/Glean/Indexer/PythonScip.hs
@@ -34,7 +34,7 @@ indexer = Indexer {
     indexerRun = \PythonScip{..} backend repo IndexerParams{..} -> do
         val <- SCIP.runIndexer ScipIndexerParams {
             scipBinary = pythonScipBinary,
-            scipArgs = const [ "index", "."],
+            scipArgs = const [ "index", "--project-version", "test", "."],
             scipRoot = indexerRoot,
             scipWritesLocal = True,
             scipLanguage = Just SCIP.Python

--- a/glean/lang/python-scip/tests/cases/xrefs/Definition.out
+++ b/glean/lang/python-scip/tests/cases/xrefs/Definition.out
@@ -2,9 +2,7 @@
   "@generated",
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/__init__:"
-      },
+      "symbol": { "key": "scip-python python . test example/__init__:" },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -20,16 +18,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-      },
+      "symbol": { "key": "scip-python python . test example/colors." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 29,
+            "lineBegin": 35,
             "columnBegin": 1,
-            "lineEnd": 29,
+            "lineEnd": 35,
             "columnEnd": 6
           }
         }
@@ -38,16 +34,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-      },
+      "symbol": { "key": "scip-python python . test example/delay." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 6,
+            "lineBegin": 12,
             "columnBegin": 1,
-            "lineEnd": 6,
+            "lineEnd": 12,
             "columnEnd": 5
           }
         }
@@ -56,16 +50,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
+      "symbol": { "key": "scip-python python . test example/food." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 28,
+            "lineBegin": 34,
             "columnBegin": 1,
-            "lineEnd": 28,
+            "lineEnd": 34,
             "columnEnd": 4
           }
         }
@@ -74,27 +66,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/godown()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 54,
-            "columnBegin": 5,
-            "lineEnd": 54,
-            "columnEnd": 10
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goleft()."
-      },
+      "symbol": { "key": "scip-python python . test example/godown()." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -110,9 +82,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goright()."
-      },
+      "symbol": { "key": "scip-python python . test example/goleft()." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -120,60 +90,6 @@
             "lineBegin": 64,
             "columnBegin": 5,
             "lineEnd": 64,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/group()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 49,
-            "columnBegin": 5,
-            "lineEnd": 49,
-            "columnEnd": 9
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 20,
-            "columnBegin": 1,
-            "lineEnd": 20,
-            "columnEnd": 4
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 8,
-            "columnBegin": 1,
-            "lineEnd": 8,
             "columnEnd": 10
           }
         }
@@ -182,27 +98,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 130,
-            "columnBegin": 9,
-            "lineEnd": 130,
-            "columnEnd": 13
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/move()."
-      },
+      "symbol": { "key": "scip-python python . test example/goright()." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -210,7 +106,7 @@
             "lineBegin": 69,
             "columnBegin": 5,
             "lineEnd": 69,
-            "columnEnd": 8
+            "columnEnd": 11
           }
         }
       }
@@ -218,142 +114,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-      },
+      "symbol": { "key": "scip-python python . test example/group()." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 116,
-            "columnBegin": 9,
-            "lineEnd": 116,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 37,
-            "columnBegin": 1,
-            "lineEnd": 37,
-            "columnEnd": 3
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 7,
-            "columnBegin": 1,
-            "lineEnd": 7,
-            "columnEnd": 5
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 102,
-            "columnBegin": 13,
-            "lineEnd": 102,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 90,
-            "columnBegin": 1,
-            "lineEnd": 90,
-            "columnEnd": 8
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 30,
-            "columnBegin": 1,
-            "lineEnd": 30,
-            "columnEnd": 6
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 12,
-            "columnBegin": 1,
-            "lineEnd": 12,
-            "columnEnd": 2
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 111,
-            "columnBegin": 9,
-            "lineEnd": 111,
+            "lineBegin": 54,
+            "columnBegin": 5,
+            "lineEnd": 54,
             "columnEnd": 9
           }
         }
@@ -362,16 +130,206 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 26,
+            "columnBegin": 1,
+            "lineEnd": 26,
+            "columnEnd": 4
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/high_score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 14,
+            "columnBegin": 1,
+            "lineEnd": 14,
+            "columnEnd": 10
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/index." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 146,
+            "columnBegin": 9,
+            "lineEnd": 146,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/move()." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 74,
+            "columnBegin": 5,
+            "lineEnd": 74,
+            "columnEnd": 8
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/new_segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 129,
+            "columnBegin": 9,
+            "lineEnd": 129,
+            "columnEnd": 19
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 43,
+            "columnBegin": 1,
+            "lineEnd": 43,
+            "columnEnd": 3
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 13,
+            "columnBegin": 1,
+            "lineEnd": 13,
+            "columnEnd": 5
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segment." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 112,
-            "columnBegin": 9,
+            "columnBegin": 13,
             "lineEnd": 112,
+            "columnEnd": 19
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 95,
+            "columnBegin": 1,
+            "lineEnd": 95,
+            "columnEnd": 8
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/shapes." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 1,
+            "lineEnd": 36,
+            "columnEnd": 6
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 18,
+            "columnBegin": 1,
+            "lineEnd": 18,
+            "columnEnd": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/x." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 124,
+            "columnBegin": 9,
+            "lineEnd": 124,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/y." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 125,
+            "columnBegin": 9,
+            "lineEnd": 125,
             "columnEnd": 9
           }
         }

--- a/glean/lang/python-scip/tests/cases/xrefs/DefinitionLocation.out
+++ b/glean/lang/python-scip/tests/cases/xrefs/DefinitionLocation.out
@@ -11,9 +11,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/__init__:"
-          },
+          "symbol": { "key": "scip-python python . test example/__init__:" },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -33,23 +31,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 6,
+        "lineBegin": 12,
         "columnBegin": 1,
-        "lineEnd": 6,
+        "lineEnd": 12,
         "columnEnd": 5
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-          },
+          "symbol": { "key": "scip-python python . test example/delay." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 6,
+                "lineBegin": 12,
                 "columnBegin": 1,
-                "lineEnd": 6,
+                "lineEnd": 12,
                 "columnEnd": 5
               }
             }
@@ -62,23 +58,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 7,
+        "lineBegin": 13,
         "columnBegin": 1,
-        "lineEnd": 7,
+        "lineEnd": 13,
         "columnEnd": 5
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-          },
+          "symbol": { "key": "scip-python python . test example/score." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 7,
+                "lineBegin": 13,
                 "columnBegin": 1,
-                "lineEnd": 7,
+                "lineEnd": 13,
                 "columnEnd": 5
               }
             }
@@ -91,23 +85,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 8,
+        "lineBegin": 14,
         "columnBegin": 1,
-        "lineEnd": 8,
+        "lineEnd": 14,
         "columnEnd": 10
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-          },
+          "symbol": { "key": "scip-python python . test example/high_score." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 8,
+                "lineBegin": 14,
                 "columnBegin": 1,
-                "lineEnd": 8,
+                "lineEnd": 14,
                 "columnEnd": 10
               }
             }
@@ -120,23 +112,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 12,
+        "lineBegin": 18,
         "columnBegin": 1,
-        "lineEnd": 12,
+        "lineEnd": 18,
         "columnEnd": 2
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-          },
+          "symbol": { "key": "scip-python python . test example/wn." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 12,
+                "lineBegin": 18,
                 "columnBegin": 1,
-                "lineEnd": 12,
+                "lineEnd": 18,
                 "columnEnd": 2
               }
             }
@@ -149,23 +139,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 20,
+        "lineBegin": 26,
         "columnBegin": 1,
-        "lineEnd": 20,
+        "lineEnd": 26,
         "columnEnd": 4
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 20,
+                "lineBegin": 26,
                 "columnBegin": 1,
-                "lineEnd": 20,
+                "lineEnd": 26,
                 "columnEnd": 4
               }
             }
@@ -178,23 +166,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 28,
+        "lineBegin": 34,
         "columnBegin": 1,
-        "lineEnd": 28,
+        "lineEnd": 34,
         "columnEnd": 4
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-          },
+          "symbol": { "key": "scip-python python . test example/food." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 28,
+                "lineBegin": 34,
                 "columnBegin": 1,
-                "lineEnd": 28,
+                "lineEnd": 34,
                 "columnEnd": 4
               }
             }
@@ -207,23 +193,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 29,
+        "lineBegin": 35,
         "columnBegin": 1,
-        "lineEnd": 29,
+        "lineEnd": 35,
         "columnEnd": 6
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-          },
+          "symbol": { "key": "scip-python python . test example/colors." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 29,
+                "lineBegin": 35,
                 "columnBegin": 1,
-                "lineEnd": 29,
+                "lineEnd": 35,
                 "columnEnd": 6
               }
             }
@@ -236,23 +220,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 30,
+        "lineBegin": 36,
         "columnBegin": 1,
-        "lineEnd": 30,
+        "lineEnd": 36,
         "columnEnd": 6
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-          },
+          "symbol": { "key": "scip-python python . test example/shapes." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 30,
+                "lineBegin": 36,
                 "columnBegin": 1,
-                "lineEnd": 30,
+                "lineEnd": 36,
                 "columnEnd": 6
               }
             }
@@ -265,53 +247,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 37,
+        "lineBegin": 43,
         "columnBegin": 1,
-        "lineEnd": 37,
+        "lineEnd": 43,
         "columnEnd": 3
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
+          "symbol": { "key": "scip-python python . test example/pen." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 37,
+                "lineBegin": 43,
                 "columnBegin": 1,
-                "lineEnd": 37,
+                "lineEnd": 43,
                 "columnEnd": 3
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 49,
-        "columnBegin": 5,
-        "lineEnd": 49,
-        "columnEnd": 9
-      },
-      "defn": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/group()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 49,
-                "columnBegin": 5,
-                "lineEnd": 49,
-                "columnEnd": 9
               }
             }
           }
@@ -326,13 +277,11 @@
         "lineBegin": 54,
         "columnBegin": 5,
         "lineEnd": 54,
-        "columnEnd": 10
+        "columnEnd": 9
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/godown()."
-          },
+          "symbol": { "key": "scip-python python . test example/group()." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -340,7 +289,7 @@
                 "lineBegin": 54,
                 "columnBegin": 5,
                 "lineEnd": 54,
-                "columnEnd": 10
+                "columnEnd": 9
               }
             }
           }
@@ -359,9 +308,7 @@
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goleft()."
-          },
+          "symbol": { "key": "scip-python python . test example/godown()." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -384,13 +331,11 @@
         "lineBegin": 64,
         "columnBegin": 5,
         "lineEnd": 64,
-        "columnEnd": 11
+        "columnEnd": 10
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goright()."
-          },
+          "symbol": { "key": "scip-python python . test example/goleft()." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -398,7 +343,7 @@
                 "lineBegin": 64,
                 "columnBegin": 5,
                 "lineEnd": 64,
-                "columnEnd": 11
+                "columnEnd": 10
               }
             }
           }
@@ -413,13 +358,11 @@
         "lineBegin": 69,
         "columnBegin": 5,
         "lineEnd": 69,
-        "columnEnd": 8
+        "columnEnd": 11
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/move()."
-          },
+          "symbol": { "key": "scip-python python . test example/goright()." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -427,7 +370,7 @@
                 "lineBegin": 69,
                 "columnBegin": 5,
                 "lineEnd": 69,
-                "columnEnd": 8
+                "columnEnd": 11
               }
             }
           }
@@ -439,23 +382,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 90,
-        "columnBegin": 1,
-        "lineEnd": 90,
+        "lineBegin": 74,
+        "columnBegin": 5,
+        "lineEnd": 74,
         "columnEnd": 8
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
+          "symbol": { "key": "scip-python python . test example/move()." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 90,
-                "columnBegin": 1,
-                "lineEnd": 90,
+                "lineBegin": 74,
+                "columnBegin": 5,
+                "lineEnd": 74,
                 "columnEnd": 8
               }
             }
@@ -468,53 +409,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 102,
-        "columnBegin": 13,
-        "lineEnd": 102,
-        "columnEnd": 19
+        "lineBegin": 95,
+        "columnBegin": 1,
+        "lineEnd": 95,
+        "columnEnd": 8
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-          },
+          "symbol": { "key": "scip-python python . test example/segments." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 102,
-                "columnBegin": 13,
-                "lineEnd": 102,
-                "columnEnd": 19
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 111,
-        "columnBegin": 9,
-        "lineEnd": 111,
-        "columnEnd": 9
-      },
-      "defn": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 111,
-                "columnBegin": 9,
-                "lineEnd": 111,
-                "columnEnd": 9
+                "lineBegin": 95,
+                "columnBegin": 1,
+                "lineEnd": 95,
+                "columnEnd": 8
               }
             }
           }
@@ -527,51 +437,20 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 112,
-        "columnBegin": 9,
+        "columnBegin": 13,
         "lineEnd": 112,
-        "columnEnd": 9
+        "columnEnd": 19
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-          },
+          "symbol": { "key": "scip-python python . test example/segment." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 112,
-                "columnBegin": 9,
+                "columnBegin": 13,
                 "lineEnd": 112,
-                "columnEnd": 9
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 116,
-        "columnBegin": 9,
-        "lineEnd": 116,
-        "columnEnd": 19
-      },
-      "defn": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 116,
-                "columnBegin": 9,
-                "lineEnd": 116,
                 "columnEnd": 19
               }
             }
@@ -584,23 +463,102 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 130,
+        "lineBegin": 124,
         "columnBegin": 9,
-        "lineEnd": 130,
-        "columnEnd": 13
+        "lineEnd": 124,
+        "columnEnd": 9
       },
       "defn": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-          },
+          "symbol": { "key": "scip-python python . test example/x." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 130,
+                "lineBegin": 124,
                 "columnBegin": 9,
-                "lineEnd": 130,
+                "lineEnd": 124,
+                "columnEnd": 9
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 125,
+        "columnBegin": 9,
+        "lineEnd": 125,
+        "columnEnd": 9
+      },
+      "defn": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/y." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 125,
+                "columnBegin": 9,
+                "lineEnd": 125,
+                "columnEnd": 9
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 129,
+        "columnBegin": 9,
+        "lineEnd": 129,
+        "columnEnd": 19
+      },
+      "defn": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/new_segment." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 129,
+                "columnBegin": 9,
+                "lineEnd": 129,
+                "columnEnd": 19
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 146,
+        "columnBegin": 9,
+        "lineEnd": 146,
+        "columnEnd": 13
+      },
+      "defn": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/index." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 146,
+                "columnBegin": 9,
+                "lineEnd": 146,
                 "columnEnd": 13
               }
             }

--- a/glean/lang/python-scip/tests/cases/xrefs/FileRange.out
+++ b/glean/lang/python-scip/tests/cases/xrefs/FileRange.out
@@ -15,9 +15,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 2,
+        "lineBegin": 8,
         "columnBegin": 8,
-        "lineEnd": 2,
+        "lineEnd": 8,
         "columnEnd": 13
       }
     }
@@ -26,9 +26,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 3,
+        "lineBegin": 9,
         "columnBegin": 8,
-        "lineEnd": 3,
+        "lineEnd": 9,
         "columnEnd": 11
       }
     }
@@ -37,9 +37,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 4,
+        "lineBegin": 10,
         "columnBegin": 8,
-        "lineEnd": 4,
+        "lineEnd": 10,
         "columnEnd": 13
       }
     }
@@ -48,9 +48,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 6,
+        "lineBegin": 12,
         "columnBegin": 1,
-        "lineEnd": 6,
+        "lineEnd": 12,
         "columnEnd": 5
       }
     }
@@ -59,9 +59,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 7,
+        "lineBegin": 13,
         "columnBegin": 1,
-        "lineEnd": 7,
+        "lineEnd": 13,
         "columnEnd": 5
       }
     }
@@ -70,9 +70,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 8,
+        "lineBegin": 14,
         "columnBegin": 1,
-        "lineEnd": 8,
+        "lineEnd": 14,
         "columnEnd": 10
       }
     }
@@ -81,9 +81,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 12,
+        "lineBegin": 18,
         "columnBegin": 1,
-        "lineEnd": 12,
+        "lineEnd": 18,
         "columnEnd": 2
       }
     }
@@ -92,9 +92,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 12,
+        "lineBegin": 18,
         "columnBegin": 6,
-        "lineEnd": 12,
+        "lineEnd": 18,
         "columnEnd": 11
       }
     }
@@ -103,9 +103,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 12,
+        "lineBegin": 18,
         "columnBegin": 13,
-        "lineEnd": 12,
+        "lineEnd": 18,
         "columnEnd": 18
       }
     }
@@ -114,9 +114,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 13,
+        "lineBegin": 19,
         "columnBegin": 1,
-        "lineEnd": 13,
+        "lineEnd": 19,
         "columnEnd": 2
       }
     }
@@ -125,9 +125,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 13,
+        "lineBegin": 19,
         "columnBegin": 4,
-        "lineEnd": 13,
+        "lineEnd": 19,
         "columnEnd": 8
       }
     }
@@ -136,9 +136,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 14,
+        "lineBegin": 20,
         "columnBegin": 1,
-        "lineEnd": 14,
+        "lineEnd": 20,
         "columnEnd": 2
       }
     }
@@ -147,9 +147,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 14,
+        "lineBegin": 20,
         "columnBegin": 4,
-        "lineEnd": 14,
+        "lineEnd": 20,
         "columnEnd": 10
       }
     }
@@ -158,9 +158,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 16,
+        "lineBegin": 22,
         "columnBegin": 1,
-        "lineEnd": 16,
+        "lineEnd": 22,
         "columnEnd": 2
       }
     }
@@ -169,9 +169,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 16,
+        "lineBegin": 22,
         "columnBegin": 4,
-        "lineEnd": 16,
+        "lineEnd": 22,
         "columnEnd": 8
       }
     }
@@ -180,9 +180,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 16,
+        "lineBegin": 22,
         "columnBegin": 10,
-        "lineEnd": 16,
+        "lineEnd": 22,
         "columnEnd": 14
       }
     }
@@ -191,9 +191,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 16,
+        "lineBegin": 22,
         "columnBegin": 21,
-        "lineEnd": 16,
+        "lineEnd": 22,
         "columnEnd": 26
       }
     }
@@ -202,9 +202,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 17,
+        "lineBegin": 23,
         "columnBegin": 1,
-        "lineEnd": 17,
+        "lineEnd": 23,
         "columnEnd": 2
       }
     }
@@ -213,9 +213,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 17,
+        "lineBegin": 23,
         "columnBegin": 4,
-        "lineEnd": 17,
+        "lineEnd": 23,
         "columnEnd": 9
       }
     }
@@ -224,9 +224,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 20,
+        "lineBegin": 26,
         "columnBegin": 1,
-        "lineEnd": 20,
+        "lineEnd": 26,
         "columnEnd": 4
       }
     }
@@ -235,9 +235,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 20,
+        "lineBegin": 26,
         "columnBegin": 8,
-        "lineEnd": 20,
+        "lineEnd": 26,
         "columnEnd": 13
       }
     }
@@ -246,9 +246,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 20,
+        "lineBegin": 26,
         "columnBegin": 15,
-        "lineEnd": 20,
+        "lineEnd": 26,
         "columnEnd": 20
       }
     }
@@ -257,9 +257,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 21,
+        "lineBegin": 27,
         "columnBegin": 1,
-        "lineEnd": 21,
+        "lineEnd": 27,
         "columnEnd": 4
       }
     }
@@ -268,9 +268,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 21,
+        "lineBegin": 27,
         "columnBegin": 6,
-        "lineEnd": 21,
+        "lineEnd": 27,
         "columnEnd": 10
       }
     }
@@ -279,9 +279,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 22,
+        "lineBegin": 28,
         "columnBegin": 1,
-        "lineEnd": 22,
+        "lineEnd": 28,
         "columnEnd": 4
       }
     }
@@ -290,9 +290,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 22,
+        "lineBegin": 28,
         "columnBegin": 6,
-        "lineEnd": 22,
+        "lineEnd": 28,
         "columnEnd": 10
       }
     }
@@ -301,9 +301,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 23,
+        "lineBegin": 29,
         "columnBegin": 1,
-        "lineEnd": 23,
+        "lineEnd": 29,
         "columnEnd": 4
       }
     }
@@ -312,9 +312,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 23,
+        "lineBegin": 29,
         "columnBegin": 6,
-        "lineEnd": 23,
+        "lineEnd": 29,
         "columnEnd": 10
       }
     }
@@ -323,9 +323,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 24,
+        "lineBegin": 30,
         "columnBegin": 1,
-        "lineEnd": 24,
+        "lineEnd": 30,
         "columnEnd": 4
       }
     }
@@ -334,120 +334,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 24,
+        "lineBegin": 30,
         "columnBegin": 6,
-        "lineEnd": 24,
+        "lineEnd": 30,
         "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 25,
-        "columnBegin": 1,
-        "lineEnd": 25,
-        "columnEnd": 4
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 28,
-        "columnBegin": 1,
-        "lineEnd": 28,
-        "columnEnd": 4
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 28,
-        "columnBegin": 8,
-        "lineEnd": 28,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 28,
-        "columnBegin": 15,
-        "lineEnd": 28,
-        "columnEnd": 20
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 29,
-        "columnBegin": 1,
-        "lineEnd": 29,
-        "columnEnd": 6
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 29,
-        "columnBegin": 10,
-        "lineEnd": 29,
-        "columnEnd": 15
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 29,
-        "columnBegin": 17,
-        "lineEnd": 29,
-        "columnEnd": 22
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 30,
-        "columnBegin": 1,
-        "lineEnd": 30,
-        "columnEnd": 6
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 30,
-        "columnBegin": 10,
-        "lineEnd": 30,
-        "columnEnd": 15
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 30,
-        "columnBegin": 17,
-        "lineEnd": 30,
-        "columnEnd": 22
       }
     }
   },
@@ -459,83 +349,6 @@
         "columnBegin": 1,
         "lineEnd": 31,
         "columnEnd": 4
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 31,
-        "columnBegin": 6,
-        "lineEnd": 31,
-        "columnEnd": 10
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 32,
-        "columnBegin": 1,
-        "lineEnd": 32,
-        "columnEnd": 4
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 32,
-        "columnBegin": 6,
-        "lineEnd": 32,
-        "columnEnd": 10
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 32,
-        "columnBegin": 12,
-        "lineEnd": 32,
-        "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 33,
-        "columnBegin": 1,
-        "lineEnd": 33,
-        "columnEnd": 4
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 33,
-        "columnBegin": 6,
-        "lineEnd": 33,
-        "columnEnd": 10
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 33,
-        "columnBegin": 12,
-        "lineEnd": 33,
-        "columnEnd": 17
       }
     }
   },
@@ -555,9 +368,20 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 34,
-        "columnBegin": 6,
+        "columnBegin": 8,
         "lineEnd": 34,
-        "columnEnd": 10
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 34,
+        "columnBegin": 15,
+        "lineEnd": 34,
+        "columnEnd": 20
       }
     }
   },
@@ -568,7 +392,7 @@
         "lineBegin": 35,
         "columnBegin": 1,
         "lineEnd": 35,
-        "columnEnd": 4
+        "columnEnd": 6
       }
     }
   },
@@ -577,9 +401,53 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 35,
-        "columnBegin": 6,
+        "columnBegin": 10,
         "lineEnd": 35,
-        "columnEnd": 9
+        "columnEnd": 15
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 35,
+        "columnBegin": 17,
+        "lineEnd": 35,
+        "columnEnd": 22
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 1,
+        "lineEnd": 36,
+        "columnEnd": 6
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 10,
+        "lineEnd": 36,
+        "columnEnd": 15
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 17,
+        "lineEnd": 36,
+        "columnEnd": 22
       }
     }
   },
@@ -590,6 +458,138 @@
         "lineBegin": 37,
         "columnBegin": 1,
         "lineEnd": 37,
+        "columnEnd": 4
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 37,
+        "columnBegin": 6,
+        "lineEnd": 37,
+        "columnEnd": 10
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 38,
+        "columnBegin": 1,
+        "lineEnd": 38,
+        "columnEnd": 4
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 38,
+        "columnBegin": 6,
+        "lineEnd": 38,
+        "columnEnd": 10
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 38,
+        "columnBegin": 12,
+        "lineEnd": 38,
+        "columnEnd": 17
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 1,
+        "lineEnd": 39,
+        "columnEnd": 4
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 6,
+        "lineEnd": 39,
+        "columnEnd": 10
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 12,
+        "lineEnd": 39,
+        "columnEnd": 17
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 40,
+        "columnBegin": 1,
+        "lineEnd": 40,
+        "columnEnd": 4
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 40,
+        "columnBegin": 6,
+        "lineEnd": 40,
+        "columnEnd": 10
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 41,
+        "columnBegin": 1,
+        "lineEnd": 41,
+        "columnEnd": 4
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 41,
+        "columnBegin": 6,
+        "lineEnd": 41,
+        "columnEnd": 9
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 43,
+        "columnBegin": 1,
+        "lineEnd": 43,
         "columnEnd": 3
       }
     }
@@ -598,9 +598,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 37,
+        "lineBegin": 43,
         "columnBegin": 7,
-        "lineEnd": 37,
+        "lineEnd": 43,
         "columnEnd": 12
       }
     }
@@ -609,9 +609,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 37,
+        "lineBegin": 43,
         "columnBegin": 14,
-        "lineEnd": 37,
+        "lineEnd": 43,
         "columnEnd": 19
       }
     }
@@ -620,138 +620,6 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 38,
-        "columnBegin": 1,
-        "lineEnd": 38,
-        "columnEnd": 3
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 38,
-        "columnBegin": 5,
-        "lineEnd": 38,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 39,
-        "columnBegin": 1,
-        "lineEnd": 39,
-        "columnEnd": 3
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 39,
-        "columnBegin": 5,
-        "lineEnd": 39,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 40,
-        "columnBegin": 1,
-        "lineEnd": 40,
-        "columnEnd": 3
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 40,
-        "columnBegin": 5,
-        "lineEnd": 40,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 41,
-        "columnBegin": 1,
-        "lineEnd": 41,
-        "columnEnd": 3
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 41,
-        "columnBegin": 5,
-        "lineEnd": 41,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 42,
-        "columnBegin": 1,
-        "lineEnd": 42,
-        "columnEnd": 3
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 42,
-        "columnBegin": 5,
-        "lineEnd": 42,
-        "columnEnd": 14
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 43,
-        "columnBegin": 1,
-        "lineEnd": 43,
-        "columnEnd": 3
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 43,
-        "columnBegin": 5,
-        "lineEnd": 43,
-        "columnEnd": 8
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
         "lineBegin": 44,
         "columnBegin": 1,
         "lineEnd": 44,
@@ -767,17 +635,6 @@
         "columnBegin": 5,
         "lineEnd": 44,
         "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 44,
-        "columnBegin": 40,
-        "lineEnd": 44,
-        "columnEnd": 44
       }
     }
   },
@@ -786,9 +643,97 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 45,
-        "columnBegin": 11,
+        "columnBegin": 1,
         "lineEnd": 45,
+        "columnEnd": 3
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 45,
+        "columnBegin": 5,
+        "lineEnd": 45,
+        "columnEnd": 9
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 46,
+        "columnBegin": 1,
+        "lineEnd": 46,
+        "columnEnd": 3
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 46,
+        "columnBegin": 5,
+        "lineEnd": 46,
+        "columnEnd": 9
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 47,
+        "columnBegin": 1,
+        "lineEnd": 47,
+        "columnEnd": 3
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 47,
+        "columnBegin": 5,
+        "lineEnd": 47,
+        "columnEnd": 9
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 48,
+        "columnBegin": 1,
+        "lineEnd": 48,
+        "columnEnd": 3
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 48,
+        "columnBegin": 5,
+        "lineEnd": 48,
         "columnEnd": 14
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 49,
+        "columnBegin": 1,
+        "lineEnd": 49,
+        "columnEnd": 3
       }
     }
   },
@@ -799,6 +744,28 @@
         "lineBegin": 49,
         "columnBegin": 5,
         "lineEnd": 49,
+        "columnEnd": 8
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 50,
+        "columnBegin": 1,
+        "lineEnd": 50,
+        "columnEnd": 3
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 50,
+        "columnBegin": 5,
+        "lineEnd": 50,
         "columnEnd": 9
       }
     }
@@ -808,9 +775,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 50,
-        "columnBegin": 8,
+        "columnBegin": 40,
         "lineEnd": 50,
-        "columnEnd": 11
+        "columnEnd": 44
       }
     }
   },
@@ -818,10 +785,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 51,
-        "columnBegin": 9,
-        "lineEnd": 51,
-        "columnEnd": 12
+        "lineBegin": 50,
+        "columnBegin": 56,
+        "lineEnd": 50,
+        "columnEnd": 59
       }
     }
   },
@@ -832,7 +799,7 @@
         "lineBegin": 54,
         "columnBegin": 5,
         "lineEnd": 54,
-        "columnEnd": 10
+        "columnEnd": 9
       }
     }
   },
@@ -898,7 +865,7 @@
         "lineBegin": 64,
         "columnBegin": 5,
         "lineEnd": 64,
-        "columnEnd": 11
+        "columnEnd": 10
       }
     }
   },
@@ -931,7 +898,7 @@
         "lineBegin": 69,
         "columnBegin": 5,
         "lineEnd": 69,
-        "columnEnd": 8
+        "columnEnd": 11
       }
     }
   },
@@ -953,39 +920,6 @@
         "lineBegin": 71,
         "columnBegin": 9,
         "lineEnd": 71,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 71,
-        "columnBegin": 13,
-        "lineEnd": 71,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 71,
-        "columnBegin": 18,
-        "lineEnd": 71,
-        "columnEnd": 21
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 72,
-        "columnBegin": 9,
-        "lineEnd": 72,
         "columnEnd": 12
       }
     }
@@ -994,10 +928,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 72,
-        "columnBegin": 14,
-        "lineEnd": 72,
-        "columnEnd": 17
+        "lineBegin": 74,
+        "columnBegin": 5,
+        "lineEnd": 74,
+        "columnEnd": 8
       }
     }
   },
@@ -1005,87 +939,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 72,
-        "columnBegin": 19,
-        "lineEnd": 72,
-        "columnEnd": 19
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 73,
+        "lineBegin": 75,
         "columnBegin": 8,
-        "lineEnd": 73,
+        "lineEnd": 75,
         "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 74,
-        "columnBegin": 9,
-        "lineEnd": 74,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 74,
-        "columnBegin": 13,
-        "lineEnd": 74,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 74,
-        "columnBegin": 18,
-        "lineEnd": 74,
-        "columnEnd": 21
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 75,
-        "columnBegin": 9,
-        "lineEnd": 75,
-        "columnEnd": 12
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 75,
-        "columnBegin": 14,
-        "lineEnd": 75,
-        "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 75,
-        "columnBegin": 19,
-        "lineEnd": 75,
-        "columnEnd": 19
       }
     }
   },
@@ -1094,19 +951,8 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 76,
-        "columnBegin": 8,
-        "lineEnd": 76,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 77,
         "columnBegin": 9,
-        "lineEnd": 77,
+        "lineEnd": 76,
         "columnEnd": 9
       }
     }
@@ -1115,9 +961,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 77,
+        "lineBegin": 76,
         "columnBegin": 13,
-        "lineEnd": 77,
+        "lineEnd": 76,
         "columnEnd": 16
       }
     }
@@ -1126,9 +972,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 77,
+        "lineBegin": 76,
         "columnBegin": 18,
-        "lineEnd": 77,
+        "lineEnd": 76,
         "columnEnd": 21
       }
     }
@@ -1137,9 +983,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 78,
+        "lineBegin": 77,
         "columnBegin": 9,
-        "lineEnd": 78,
+        "lineEnd": 77,
         "columnEnd": 12
       }
     }
@@ -1148,9 +994,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 78,
+        "lineBegin": 77,
         "columnBegin": 14,
-        "lineEnd": 78,
+        "lineEnd": 77,
         "columnEnd": 17
       }
     }
@@ -1159,10 +1005,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 78,
+        "lineBegin": 77,
         "columnBegin": 19,
-        "lineEnd": 78,
+        "lineEnd": 77,
         "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 78,
+        "columnBegin": 8,
+        "lineEnd": 78,
+        "columnEnd": 11
       }
     }
   },
@@ -1171,19 +1028,8 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 79,
-        "columnBegin": 8,
-        "lineEnd": 79,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 80,
         "columnBegin": 9,
-        "lineEnd": 80,
+        "lineEnd": 79,
         "columnEnd": 9
       }
     }
@@ -1192,9 +1038,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 80,
+        "lineBegin": 79,
         "columnBegin": 13,
-        "lineEnd": 80,
+        "lineEnd": 79,
         "columnEnd": 16
       }
     }
@@ -1203,9 +1049,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 80,
+        "lineBegin": 79,
         "columnBegin": 18,
-        "lineEnd": 80,
+        "lineEnd": 79,
         "columnEnd": 21
       }
     }
@@ -1214,9 +1060,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 81,
+        "lineBegin": 80,
         "columnBegin": 9,
-        "lineEnd": 81,
+        "lineEnd": 80,
         "columnEnd": 12
       }
     }
@@ -1225,9 +1071,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 81,
+        "lineBegin": 80,
         "columnBegin": 14,
-        "lineEnd": 81,
+        "lineEnd": 80,
         "columnEnd": 17
       }
     }
@@ -1236,9 +1082,86 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 81,
+        "lineBegin": 80,
         "columnBegin": 19,
+        "lineEnd": 80,
+        "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 81,
+        "columnBegin": 8,
         "lineEnd": 81,
+        "columnEnd": 11
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 82,
+        "columnBegin": 9,
+        "lineEnd": 82,
+        "columnEnd": 9
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 82,
+        "columnBegin": 13,
+        "lineEnd": 82,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 82,
+        "columnBegin": 18,
+        "lineEnd": 82,
+        "columnEnd": 21
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 83,
+        "columnBegin": 9,
+        "lineEnd": 83,
+        "columnEnd": 12
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 83,
+        "columnBegin": 14,
+        "lineEnd": 83,
+        "columnEnd": 17
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 83,
+        "columnBegin": 19,
+        "lineEnd": 83,
         "columnEnd": 19
       }
     }
@@ -1248,9 +1171,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 84,
-        "columnBegin": 1,
+        "columnBegin": 8,
         "lineEnd": 84,
-        "columnEnd": 2
+        "columnEnd": 11
       }
     }
   },
@@ -1258,9 +1181,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 84,
-        "columnBegin": 4,
-        "lineEnd": 84,
+        "lineBegin": 85,
+        "columnBegin": 9,
+        "lineEnd": 85,
         "columnEnd": 9
       }
     }
@@ -1270,9 +1193,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 85,
-        "columnBegin": 1,
+        "columnBegin": 13,
         "lineEnd": 85,
-        "columnEnd": 2
+        "columnEnd": 16
       }
     }
   },
@@ -1281,9 +1204,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 85,
-        "columnBegin": 4,
+        "columnBegin": 18,
         "lineEnd": 85,
-        "columnEnd": 13
+        "columnEnd": 21
       }
     }
   },
@@ -1291,9 +1214,31 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 85,
-        "columnBegin": 15,
-        "lineEnd": 85,
+        "lineBegin": 86,
+        "columnBegin": 9,
+        "lineEnd": 86,
+        "columnEnd": 12
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 86,
+        "columnBegin": 14,
+        "lineEnd": 86,
+        "columnEnd": 17
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 86,
+        "columnBegin": 19,
+        "lineEnd": 86,
         "columnEnd": 19
       }
     }
@@ -1302,9 +1247,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 86,
+        "lineBegin": 89,
         "columnBegin": 1,
-        "lineEnd": 86,
+        "lineEnd": 89,
         "columnEnd": 2
       }
     }
@@ -1313,87 +1258,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 86,
+        "lineBegin": 89,
         "columnBegin": 4,
-        "lineEnd": 86,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 86,
-        "columnBegin": 15,
-        "lineEnd": 86,
-        "columnEnd": 20
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 87,
-        "columnBegin": 1,
-        "lineEnd": 87,
-        "columnEnd": 2
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 87,
-        "columnBegin": 4,
-        "lineEnd": 87,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 87,
-        "columnBegin": 15,
-        "lineEnd": 87,
-        "columnEnd": 20
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 88,
-        "columnBegin": 1,
-        "lineEnd": 88,
-        "columnEnd": 2
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 88,
-        "columnBegin": 4,
-        "lineEnd": 88,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 88,
-        "columnBegin": 15,
-        "lineEnd": 88,
-        "columnEnd": 21
+        "lineEnd": 89,
+        "columnEnd": 9
       }
     }
   },
@@ -1404,6 +1272,138 @@
         "lineBegin": 90,
         "columnBegin": 1,
         "lineEnd": 90,
+        "columnEnd": 2
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 90,
+        "columnBegin": 4,
+        "lineEnd": 90,
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 90,
+        "columnBegin": 15,
+        "lineEnd": 90,
+        "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 91,
+        "columnBegin": 1,
+        "lineEnd": 91,
+        "columnEnd": 2
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 91,
+        "columnBegin": 4,
+        "lineEnd": 91,
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 91,
+        "columnBegin": 15,
+        "lineEnd": 91,
+        "columnEnd": 20
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 92,
+        "columnBegin": 1,
+        "lineEnd": 92,
+        "columnEnd": 2
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 92,
+        "columnBegin": 4,
+        "lineEnd": 92,
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 92,
+        "columnBegin": 15,
+        "lineEnd": 92,
+        "columnEnd": 20
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 93,
+        "columnBegin": 1,
+        "lineEnd": 93,
+        "columnEnd": 2
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 93,
+        "columnBegin": 4,
+        "lineEnd": 93,
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 93,
+        "columnBegin": 15,
+        "lineEnd": 93,
+        "columnEnd": 21
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 95,
+        "columnBegin": 1,
+        "lineEnd": 95,
         "columnEnd": 8
       }
     }
@@ -1412,9 +1412,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 95,
+        "lineBegin": 100,
         "columnBegin": 5,
-        "lineEnd": 95,
+        "lineEnd": 100,
         "columnEnd": 6
       }
     }
@@ -1423,9 +1423,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 95,
+        "lineBegin": 100,
         "columnBegin": 8,
-        "lineEnd": 95,
+        "lineEnd": 100,
         "columnEnd": 13
       }
     }
@@ -1434,97 +1434,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 96,
-        "columnBegin": 8,
-        "lineEnd": 96,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 13,
-        "lineEnd": 96,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 29,
-        "lineEnd": 96,
-        "columnEnd": 32
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 34,
-        "lineEnd": 96,
-        "columnEnd": 37
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 51,
-        "lineEnd": 96,
-        "columnEnd": 54
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 56,
-        "lineEnd": 96,
-        "columnEnd": 59
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 72,
-        "lineEnd": 96,
-        "columnEnd": 75
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 77,
-        "lineEnd": 96,
-        "columnEnd": 80
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 97,
+        "lineBegin": 102,
         "columnBegin": 9,
-        "lineEnd": 97,
+        "lineEnd": 102,
         "columnEnd": 12
       }
     }
@@ -1533,131 +1445,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 97,
+        "lineBegin": 102,
         "columnBegin": 14,
-        "lineEnd": 97,
-        "columnEnd": 18
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 98,
-        "columnBegin": 9,
-        "lineEnd": 98,
-        "columnEnd": 12
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 98,
-        "columnBegin": 14,
-        "lineEnd": 98,
+        "lineEnd": 102,
         "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 99,
-        "columnBegin": 9,
-        "lineEnd": 99,
-        "columnEnd": 12
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 100,
-        "columnBegin": 9,
-        "lineEnd": 100,
-        "columnEnd": 14
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 100,
-        "columnBegin": 18,
-        "lineEnd": 100,
-        "columnEnd": 23
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 100,
-        "columnBegin": 25,
-        "lineEnd": 100,
-        "columnEnd": 30
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 101,
-        "columnBegin": 9,
-        "lineEnd": 101,
-        "columnEnd": 14
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 101,
-        "columnBegin": 18,
-        "lineEnd": 101,
-        "columnEnd": 23
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 101,
-        "columnBegin": 25,
-        "lineEnd": 101,
-        "columnEnd": 30
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 102,
-        "columnBegin": 13,
-        "lineEnd": 102,
-        "columnEnd": 19
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 102,
-        "columnBegin": 24,
-        "lineEnd": 102,
-        "columnEnd": 31
       }
     }
   },
@@ -1666,9 +1457,20 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 103,
-        "columnBegin": 13,
+        "columnBegin": 12,
         "lineEnd": 103,
-        "columnEnd": 19
+        "columnEnd": 15
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 103,
+        "columnBegin": 17,
+        "lineEnd": 103,
+        "columnEnd": 20
       }
     }
   },
@@ -1677,9 +1479,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 104,
-        "columnBegin": 9,
+        "columnBegin": 12,
         "lineEnd": 104,
-        "columnEnd": 16
+        "columnEnd": 15
       }
     }
   },
@@ -1688,9 +1490,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 104,
-        "columnBegin": 18,
+        "columnBegin": 17,
         "lineEnd": 104,
-        "columnEnd": 22
+        "columnEnd": 20
       }
     }
   },
@@ -1699,9 +1501,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 105,
-        "columnBegin": 9,
+        "columnBegin": 12,
         "lineEnd": 105,
-        "columnEnd": 13
+        "columnEnd": 15
       }
     }
   },
@@ -1709,130 +1511,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 106,
-        "columnBegin": 9,
-        "lineEnd": 106,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 107,
-        "columnBegin": 9,
-        "lineEnd": 107,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 107,
-        "columnBegin": 13,
-        "lineEnd": 107,
-        "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 108,
-        "columnBegin": 9,
-        "lineEnd": 108,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 108,
-        "columnBegin": 13,
-        "lineEnd": 108,
-        "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 108,
-        "columnBegin": 49,
-        "lineEnd": 108,
-        "columnEnd": 54
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 109,
-        "columnBegin": 13,
-        "lineEnd": 109,
-        "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 109,
-        "columnBegin": 20,
-        "lineEnd": 109,
-        "columnEnd": 29
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 109,
-        "columnBegin": 33,
-        "lineEnd": 109,
-        "columnEnd": 37
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 109,
-        "columnBegin": 49,
-        "lineEnd": 109,
-        "columnEnd": 52
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 110,
-        "columnBegin": 8,
-        "lineEnd": 110,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 110,
-        "columnBegin": 13,
-        "lineEnd": 110,
+        "lineBegin": 105,
+        "columnBegin": 17,
+        "lineEnd": 105,
         "columnEnd": 20
       }
     }
@@ -1841,86 +1522,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 110,
-        "columnBegin": 22,
-        "lineEnd": 110,
-        "columnEnd": 25
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 111,
+        "lineBegin": 107,
         "columnBegin": 9,
-        "lineEnd": 111,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 111,
-        "columnBegin": 13,
-        "lineEnd": 111,
-        "columnEnd": 18
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 111,
-        "columnBegin": 20,
-        "lineEnd": 111,
-        "columnEnd": 26
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 112,
-        "columnBegin": 9,
-        "lineEnd": 112,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 112,
-        "columnBegin": 13,
-        "lineEnd": 112,
-        "columnEnd": 18
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 112,
-        "columnBegin": 20,
-        "lineEnd": 112,
-        "columnEnd": 26
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 113,
-        "columnBegin": 9,
-        "lineEnd": 113,
+        "lineEnd": 107,
         "columnEnd": 12
       }
     }
@@ -1929,9 +1533,31 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 113,
+        "lineBegin": 107,
         "columnBegin": 14,
-        "lineEnd": 113,
+        "lineEnd": 107,
+        "columnEnd": 18
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 108,
+        "columnBegin": 9,
+        "lineEnd": 108,
+        "columnEnd": 12
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 108,
+        "columnBegin": 14,
+        "lineEnd": 108,
         "columnEnd": 17
       }
     }
@@ -1940,32 +1566,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 113,
-        "columnBegin": 19,
-        "lineEnd": 113,
-        "columnEnd": 19
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 113,
-        "columnBegin": 22,
-        "lineEnd": 113,
-        "columnEnd": 22
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 116,
+        "lineBegin": 109,
         "columnBegin": 9,
-        "lineEnd": 116,
-        "columnEnd": 19
+        "lineEnd": 109,
+        "columnEnd": 12
       }
     }
   },
@@ -1973,32 +1577,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 116,
-        "columnBegin": 23,
-        "lineEnd": 116,
-        "columnEnd": 28
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 116,
-        "columnBegin": 30,
-        "lineEnd": 116,
-        "columnEnd": 35
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 117,
+        "lineBegin": 110,
         "columnBegin": 9,
-        "lineEnd": 117,
-        "columnEnd": 19
+        "lineEnd": 110,
+        "columnEnd": 14
       }
     }
   },
@@ -2006,97 +1588,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 117,
-        "columnBegin": 21,
-        "lineEnd": 117,
-        "columnEnd": 25
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 118,
-        "columnBegin": 9,
-        "lineEnd": 118,
-        "columnEnd": 19
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 118,
-        "columnBegin": 21,
-        "lineEnd": 118,
-        "columnEnd": 25
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 119,
-        "columnBegin": 9,
-        "lineEnd": 119,
-        "columnEnd": 19
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 119,
-        "columnBegin": 21,
-        "lineEnd": 119,
-        "columnEnd": 25
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 120,
-        "columnBegin": 9,
-        "lineEnd": 120,
-        "columnEnd": 19
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 120,
-        "columnBegin": 21,
-        "lineEnd": 120,
-        "columnEnd": 25
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 121,
-        "columnBegin": 9,
-        "lineEnd": 121,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 121,
+        "lineBegin": 110,
         "columnBegin": 18,
-        "lineEnd": 121,
+        "lineEnd": 110,
         "columnEnd": 23
       }
     }
@@ -2105,75 +1599,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 121,
+        "lineBegin": 110,
         "columnBegin": 25,
-        "lineEnd": 121,
-        "columnEnd": 35
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 122,
-        "columnBegin": 9,
-        "lineEnd": 122,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 123,
-        "columnBegin": 9,
-        "lineEnd": 123,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 124,
-        "columnBegin": 12,
-        "lineEnd": 124,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 124,
-        "columnBegin": 20,
-        "lineEnd": 124,
-        "columnEnd": 29
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 125,
-        "columnBegin": 13,
-        "lineEnd": 125,
-        "columnEnd": 22
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 125,
-        "columnBegin": 26,
-        "lineEnd": 125,
+        "lineEnd": 110,
         "columnEnd": 30
       }
     }
@@ -2182,10 +1610,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 126,
+        "lineBegin": 111,
         "columnBegin": 9,
-        "lineEnd": 126,
-        "columnEnd": 11
+        "lineEnd": 111,
+        "columnEnd": 14
       }
     }
   },
@@ -2193,109 +1621,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 126,
-        "columnBegin": 13,
-        "lineEnd": 126,
-        "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 127,
-        "columnBegin": 9,
-        "lineEnd": 127,
-        "columnEnd": 11
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 127,
-        "columnBegin": 13,
-        "lineEnd": 127,
-        "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 127,
-        "columnBegin": 49,
-        "lineEnd": 127,
-        "columnEnd": 54
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 128,
-        "columnBegin": 13,
-        "lineEnd": 128,
-        "columnEnd": 17
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 128,
-        "columnBegin": 20,
-        "lineEnd": 128,
-        "columnEnd": 29
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 128,
-        "columnBegin": 33,
-        "lineEnd": 128,
-        "columnEnd": 37
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 128,
-        "columnBegin": 49,
-        "lineEnd": 128,
-        "columnEnd": 52
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 130,
-        "columnBegin": 9,
-        "lineEnd": 130,
-        "columnEnd": 13
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 130,
+        "lineBegin": 111,
         "columnBegin": 18,
-        "lineEnd": 130,
-        "columnEnd": 22
+        "lineEnd": 111,
+        "columnEnd": 23
       }
     }
   },
@@ -2303,119 +1632,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 130,
-        "columnBegin": 24,
-        "lineEnd": 130,
-        "columnEnd": 26
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 130,
-        "columnBegin": 28,
-        "lineEnd": 130,
-        "columnEnd": 35
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 131,
-        "columnBegin": 9,
-        "lineEnd": 131,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 131,
-        "columnBegin": 13,
-        "lineEnd": 131,
-        "columnEnd": 20
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 131,
-        "columnBegin": 22,
-        "lineEnd": 131,
-        "columnEnd": 26
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 132,
-        "columnBegin": 9,
-        "lineEnd": 132,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 132,
-        "columnBegin": 13,
-        "lineEnd": 132,
-        "columnEnd": 20
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 132,
-        "columnBegin": 22,
-        "lineEnd": 132,
-        "columnEnd": 26
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 133,
-        "columnBegin": 9,
-        "lineEnd": 133,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 133,
-        "columnBegin": 18,
-        "lineEnd": 133,
-        "columnEnd": 22
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 133,
-        "columnBegin": 30,
-        "lineEnd": 133,
+        "lineBegin": 111,
+        "columnBegin": 25,
+        "lineEnd": 111,
         "columnEnd": 30
       }
     }
@@ -2424,31 +1643,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 133,
-        "columnBegin": 33,
-        "lineEnd": 133,
-        "columnEnd": 33
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 134,
-        "columnBegin": 8,
-        "lineEnd": 134,
-        "columnEnd": 10
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 134,
-        "columnBegin": 12,
-        "lineEnd": 134,
+        "lineBegin": 112,
+        "columnBegin": 13,
+        "lineEnd": 112,
         "columnEnd": 19
       }
     }
@@ -2457,9 +1654,207 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 135,
+        "lineBegin": 112,
+        "columnBegin": 24,
+        "lineEnd": 112,
+        "columnEnd": 31
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 113,
+        "columnBegin": 13,
+        "lineEnd": 113,
+        "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 114,
         "columnBegin": 9,
-        "lineEnd": 135,
+        "lineEnd": 114,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 114,
+        "columnBegin": 18,
+        "lineEnd": 114,
+        "columnEnd": 22
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 115,
+        "columnBegin": 9,
+        "lineEnd": 115,
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 116,
+        "columnBegin": 9,
+        "lineEnd": 116,
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 117,
+        "columnBegin": 9,
+        "lineEnd": 117,
+        "columnEnd": 11
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 117,
+        "columnBegin": 13,
+        "lineEnd": 117,
+        "columnEnd": 17
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 118,
+        "columnBegin": 9,
+        "lineEnd": 118,
+        "columnEnd": 11
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 118,
+        "columnBegin": 13,
+        "lineEnd": 118,
+        "columnEnd": 17
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 119,
+        "columnBegin": 43,
+        "lineEnd": 119,
+        "columnEnd": 48
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 119,
+        "columnBegin": 50,
+        "lineEnd": 119,
+        "columnEnd": 54
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 119,
+        "columnBegin": 57,
+        "lineEnd": 119,
+        "columnEnd": 66
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 120,
+        "columnBegin": 13,
+        "lineEnd": 120,
+        "columnEnd": 17
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 121,
+        "columnBegin": 13,
+        "lineEnd": 121,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 123,
+        "columnBegin": 8,
+        "lineEnd": 123,
+        "columnEnd": 11
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 123,
+        "columnBegin": 13,
+        "lineEnd": 123,
+        "columnEnd": 20
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 123,
+        "columnBegin": 22,
+        "lineEnd": 123,
+        "columnEnd": 25
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 124,
+        "columnBegin": 9,
+        "lineEnd": 124,
         "columnEnd": 9
       }
     }
@@ -2468,10 +1863,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 135,
+        "lineBegin": 124,
         "columnBegin": 13,
-        "lineEnd": 135,
-        "columnEnd": 16
+        "lineEnd": 124,
+        "columnEnd": 18
       }
     }
   },
@@ -2479,64 +1874,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 135,
-        "columnBegin": 18,
-        "lineEnd": 135,
-        "columnEnd": 21
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 136,
-        "columnBegin": 9,
-        "lineEnd": 136,
-        "columnEnd": 9
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 136,
-        "columnBegin": 13,
-        "lineEnd": 136,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 136,
-        "columnBegin": 18,
-        "lineEnd": 136,
-        "columnEnd": 21
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 137,
-        "columnBegin": 9,
-        "lineEnd": 137,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 137,
-        "columnBegin": 26,
-        "lineEnd": 137,
+        "lineBegin": 124,
+        "columnBegin": 20,
+        "lineEnd": 124,
         "columnEnd": 26
       }
     }
@@ -2545,8 +1885,272 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
+        "lineBegin": 125,
+        "columnBegin": 9,
+        "lineEnd": 125,
+        "columnEnd": 9
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 125,
+        "columnBegin": 13,
+        "lineEnd": 125,
+        "columnEnd": 18
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 125,
+        "columnBegin": 20,
+        "lineEnd": 125,
+        "columnEnd": 26
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 126,
+        "columnBegin": 9,
+        "lineEnd": 126,
+        "columnEnd": 12
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 126,
+        "columnBegin": 14,
+        "lineEnd": 126,
+        "columnEnd": 17
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 126,
+        "columnBegin": 19,
+        "lineEnd": 126,
+        "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 126,
+        "columnBegin": 22,
+        "lineEnd": 126,
+        "columnEnd": 22
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 129,
+        "columnBegin": 9,
+        "lineEnd": 129,
+        "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 129,
+        "columnBegin": 23,
+        "lineEnd": 129,
+        "columnEnd": 28
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 129,
+        "columnBegin": 30,
+        "lineEnd": 129,
+        "columnEnd": 35
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 130,
+        "columnBegin": 9,
+        "lineEnd": 130,
+        "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 130,
+        "columnBegin": 21,
+        "lineEnd": 130,
+        "columnEnd": 25
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 131,
+        "columnBegin": 9,
+        "lineEnd": 131,
+        "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 131,
+        "columnBegin": 21,
+        "lineEnd": 131,
+        "columnEnd": 25
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 132,
+        "columnBegin": 9,
+        "lineEnd": 132,
+        "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 132,
+        "columnBegin": 21,
+        "lineEnd": 132,
+        "columnEnd": 25
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 133,
+        "columnBegin": 9,
+        "lineEnd": 133,
+        "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 133,
+        "columnBegin": 21,
+        "lineEnd": 133,
+        "columnEnd": 25
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 134,
+        "columnBegin": 9,
+        "lineEnd": 134,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 134,
+        "columnBegin": 18,
+        "lineEnd": 134,
+        "columnEnd": 23
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 134,
+        "columnBegin": 25,
+        "lineEnd": 134,
+        "columnEnd": 35
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 135,
+        "columnBegin": 9,
+        "lineEnd": 135,
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 136,
+        "columnBegin": 9,
+        "lineEnd": 136,
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
         "lineBegin": 137,
-        "columnBegin": 29,
+        "columnBegin": 12,
+        "lineEnd": 137,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 137,
+        "columnBegin": 20,
         "lineEnd": 137,
         "columnEnd": 29
       }
@@ -2557,9 +2161,20 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 138,
-        "columnBegin": 5,
+        "columnBegin": 13,
         "lineEnd": 138,
-        "columnEnd": 8
+        "columnEnd": 22
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 138,
+        "columnBegin": 26,
+        "lineEnd": 138,
+        "columnEnd": 30
       }
     }
   },
@@ -2570,7 +2185,7 @@
         "lineBegin": 139,
         "columnBegin": 9,
         "lineEnd": 139,
-        "columnEnd": 15
+        "columnEnd": 11
       }
     }
   },
@@ -2579,9 +2194,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 139,
-        "columnBegin": 20,
+        "columnBegin": 13,
         "lineEnd": 139,
-        "columnEnd": 27
+        "columnEnd": 17
       }
     }
   },
@@ -2590,9 +2205,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 140,
-        "columnBegin": 12,
+        "columnBegin": 9,
         "lineEnd": 140,
-        "columnEnd": 18
+        "columnEnd": 11
       }
     }
   },
@@ -2601,20 +2216,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 140,
-        "columnBegin": 29,
-        "lineEnd": 140,
-        "columnEnd": 32
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 141,
         "columnBegin": 13,
-        "lineEnd": 141,
-        "columnEnd": 16
+        "lineEnd": 140,
+        "columnEnd": 17
       }
     }
   },
@@ -2623,9 +2227,31 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 141,
-        "columnBegin": 18,
+        "columnBegin": 43,
         "lineEnd": 141,
-        "columnEnd": 22
+        "columnEnd": 48
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 141,
+        "columnBegin": 50,
+        "lineEnd": 141,
+        "columnEnd": 54
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 141,
+        "columnBegin": 57,
+        "lineEnd": 141,
+        "columnEnd": 66
       }
     }
   },
@@ -2636,18 +2262,7 @@
         "lineBegin": 142,
         "columnBegin": 13,
         "lineEnd": 142,
-        "columnEnd": 16
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 142,
-        "columnBegin": 18,
-        "lineEnd": 142,
-        "columnEnd": 21
+        "columnEnd": 17
       }
     }
   },
@@ -2666,65 +2281,10 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 144,
-        "columnBegin": 13,
-        "lineEnd": 144,
-        "columnEnd": 18
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 144,
-        "columnBegin": 22,
-        "lineEnd": 144,
-        "columnEnd": 27
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 144,
-        "columnBegin": 29,
-        "lineEnd": 144,
-        "columnEnd": 34
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 145,
-        "columnBegin": 13,
-        "lineEnd": 145,
-        "columnEnd": 18
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 145,
-        "columnBegin": 22,
-        "lineEnd": 145,
-        "columnEnd": 27
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 145,
-        "columnBegin": 29,
-        "lineEnd": 145,
-        "columnEnd": 34
+        "lineBegin": 146,
+        "columnBegin": 9,
+        "lineEnd": 146,
+        "columnEnd": 13
       }
     }
   },
@@ -2733,9 +2293,20 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 146,
-        "columnBegin": 17,
+        "columnBegin": 18,
         "lineEnd": 146,
-        "columnEnd": 23
+        "columnEnd": 22
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 146,
+        "columnBegin": 24,
+        "lineEnd": 146,
+        "columnEnd": 26
       }
     }
   },
@@ -2755,9 +2326,42 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 147,
-        "columnBegin": 17,
+        "columnBegin": 9,
         "lineEnd": 147,
-        "columnEnd": 23
+        "columnEnd": 9
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 147,
+        "columnBegin": 13,
+        "lineEnd": 147,
+        "columnEnd": 20
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 147,
+        "columnBegin": 22,
+        "lineEnd": 147,
+        "columnEnd": 26
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 148,
+        "columnBegin": 9,
+        "lineEnd": 148,
+        "columnEnd": 9
       }
     }
   },
@@ -2787,10 +2391,76 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
+        "lineBegin": 149,
+        "columnBegin": 9,
+        "lineEnd": 149,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 149,
+        "columnBegin": 18,
+        "lineEnd": 149,
+        "columnEnd": 22
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 149,
+        "columnBegin": 30,
+        "lineEnd": 149,
+        "columnEnd": 30
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 149,
+        "columnBegin": 33,
+        "lineEnd": 149,
+        "columnEnd": 33
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
         "lineBegin": 150,
-        "columnBegin": 13,
+        "columnBegin": 8,
         "lineEnd": 150,
-        "columnEnd": 17
+        "columnEnd": 10
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 150,
+        "columnBegin": 12,
+        "lineEnd": 150,
+        "columnEnd": 19
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 151,
+        "columnBegin": 9,
+        "lineEnd": 151,
+        "columnEnd": 9
       }
     }
   },
@@ -2801,7 +2471,29 @@
         "lineBegin": 151,
         "columnBegin": 13,
         "lineEnd": 151,
-        "columnEnd": 17
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 151,
+        "columnBegin": 18,
+        "lineEnd": 151,
+        "columnEnd": 21
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 152,
+        "columnBegin": 9,
+        "lineEnd": 152,
+        "columnEnd": 9
       }
     }
   },
@@ -2812,7 +2504,7 @@
         "lineBegin": 152,
         "columnBegin": 13,
         "lineEnd": 152,
-        "columnEnd": 15
+        "columnEnd": 16
       }
     }
   },
@@ -2821,7 +2513,7 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 152,
-        "columnBegin": 17,
+        "columnBegin": 18,
         "lineEnd": 152,
         "columnEnd": 21
       }
@@ -2832,9 +2524,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 153,
-        "columnBegin": 13,
+        "columnBegin": 9,
         "lineEnd": 153,
-        "columnEnd": 15
+        "columnEnd": 16
       }
     }
   },
@@ -2843,9 +2535,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 153,
-        "columnBegin": 17,
+        "columnBegin": 26,
         "lineEnd": 153,
-        "columnEnd": 21
+        "columnEnd": 26
       }
     }
   },
@@ -2854,9 +2546,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 153,
-        "columnBegin": 53,
+        "columnBegin": 29,
         "lineEnd": 153,
-        "columnEnd": 58
+        "columnEnd": 29
       }
     }
   },
@@ -2865,52 +2557,8 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 154,
-        "columnBegin": 17,
-        "lineEnd": 154,
-        "columnEnd": 21
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 154,
-        "columnBegin": 24,
-        "lineEnd": 154,
-        "columnEnd": 33
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 154,
-        "columnBegin": 37,
-        "lineEnd": 154,
-        "columnEnd": 41
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 154,
-        "columnBegin": 53,
-        "lineEnd": 154,
-        "columnEnd": 56
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 155,
         "columnBegin": 5,
-        "lineEnd": 155,
+        "lineEnd": 154,
         "columnEnd": 8
       }
     }
@@ -2920,9 +2568,9 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 155,
-        "columnBegin": 10,
+        "columnBegin": 9,
         "lineEnd": 155,
-        "columnEnd": 14
+        "columnEnd": 15
       }
     }
   },
@@ -2931,8 +2579,360 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 155,
-        "columnBegin": 16,
+        "columnBegin": 20,
         "lineEnd": 155,
+        "columnEnd": 27
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 156,
+        "columnBegin": 12,
+        "lineEnd": 156,
+        "columnEnd": 18
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 156,
+        "columnBegin": 29,
+        "lineEnd": 156,
+        "columnEnd": 32
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 157,
+        "columnBegin": 13,
+        "lineEnd": 157,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 157,
+        "columnBegin": 18,
+        "lineEnd": 157,
+        "columnEnd": 22
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 158,
+        "columnBegin": 13,
+        "lineEnd": 158,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 158,
+        "columnBegin": 18,
+        "lineEnd": 158,
+        "columnEnd": 21
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 159,
+        "columnBegin": 13,
+        "lineEnd": 159,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 160,
+        "columnBegin": 13,
+        "lineEnd": 160,
+        "columnEnd": 18
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 160,
+        "columnBegin": 22,
+        "lineEnd": 160,
+        "columnEnd": 27
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 160,
+        "columnBegin": 29,
+        "lineEnd": 160,
+        "columnEnd": 34
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 161,
+        "columnBegin": 13,
+        "lineEnd": 161,
+        "columnEnd": 18
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 161,
+        "columnBegin": 22,
+        "lineEnd": 161,
+        "columnEnd": 27
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 161,
+        "columnBegin": 29,
+        "lineEnd": 161,
+        "columnEnd": 34
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 162,
+        "columnBegin": 17,
+        "lineEnd": 162,
+        "columnEnd": 23
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 162,
+        "columnBegin": 28,
+        "lineEnd": 162,
+        "columnEnd": 35
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 163,
+        "columnBegin": 17,
+        "lineEnd": 163,
+        "columnEnd": 23
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 164,
+        "columnBegin": 13,
+        "lineEnd": 164,
+        "columnEnd": 20
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 164,
+        "columnBegin": 22,
+        "lineEnd": 164,
+        "columnEnd": 26
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 166,
+        "columnBegin": 13,
+        "lineEnd": 166,
+        "columnEnd": 17
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 167,
+        "columnBegin": 13,
+        "lineEnd": 167,
+        "columnEnd": 17
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 168,
+        "columnBegin": 13,
+        "lineEnd": 168,
+        "columnEnd": 15
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 168,
+        "columnBegin": 17,
+        "lineEnd": 168,
+        "columnEnd": 21
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 169,
+        "columnBegin": 13,
+        "lineEnd": 169,
+        "columnEnd": 15
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 169,
+        "columnBegin": 17,
+        "lineEnd": 169,
+        "columnEnd": 21
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 170,
+        "columnBegin": 47,
+        "lineEnd": 170,
+        "columnEnd": 52
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 170,
+        "columnBegin": 54,
+        "lineEnd": 170,
+        "columnEnd": 58
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 170,
+        "columnBegin": 61,
+        "lineEnd": 170,
+        "columnEnd": 70
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 171,
+        "columnBegin": 17,
+        "lineEnd": 171,
+        "columnEnd": 21
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 172,
+        "columnBegin": 17,
+        "lineEnd": 172,
+        "columnEnd": 20
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 174,
+        "columnBegin": 5,
+        "lineEnd": 174,
+        "columnEnd": 8
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 174,
+        "columnBegin": 10,
+        "lineEnd": 174,
+        "columnEnd": 14
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 174,
+        "columnBegin": 16,
+        "lineEnd": 174,
         "columnEnd": 20
       }
     }

--- a/glean/lang/python-scip/tests/cases/xrefs/Reference.out
+++ b/glean/lang/python-scip/tests/cases/xrefs/Reference.out
@@ -2,16 +2,14 @@
   "@generated",
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-      },
+      "symbol": { "key": "scip-python python . test example/colors." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 33,
+            "lineBegin": 39,
             "columnBegin": 12,
-            "lineEnd": 33,
+            "lineEnd": 39,
             "columnEnd": 17
           }
         }
@@ -20,16 +18,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-      },
+      "symbol": { "key": "scip-python python . test example/colors." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 100,
+            "lineBegin": 110,
             "columnBegin": 9,
-            "lineEnd": 100,
+            "lineEnd": 110,
             "columnEnd": 14
           }
         }
@@ -38,16 +34,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-      },
+      "symbol": { "key": "scip-python python . test example/colors." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 144,
+            "lineBegin": 160,
             "columnBegin": 13,
-            "lineEnd": 144,
+            "lineEnd": 160,
             "columnEnd": 18
           }
         }
@@ -56,16 +50,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-      },
+      "symbol": { "key": "scip-python python . test example/delay." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 106,
+            "lineBegin": 116,
             "columnBegin": 9,
-            "lineEnd": 106,
+            "lineEnd": 116,
             "columnEnd": 13
           }
         }
@@ -74,16 +66,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-      },
+      "symbol": { "key": "scip-python python . test example/delay." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 122,
+            "lineBegin": 135,
             "columnBegin": 9,
-            "lineEnd": 122,
+            "lineEnd": 135,
             "columnEnd": 13
           }
         }
@@ -92,16 +82,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-      },
+      "symbol": { "key": "scip-python python . test example/delay." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 151,
+            "lineBegin": 167,
             "columnBegin": 13,
-            "lineEnd": 151,
+            "lineEnd": 167,
             "columnEnd": 17
           }
         }
@@ -110,16 +98,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-      },
+      "symbol": { "key": "scip-python python . test example/delay." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 155,
+            "lineBegin": 174,
             "columnBegin": 16,
-            "lineEnd": 155,
+            "lineEnd": 174,
             "columnEnd": 20
           }
         }
@@ -128,9 +114,247 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
+      "symbol": { "key": "scip-python python . test example/food." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 37,
+            "columnBegin": 1,
+            "lineEnd": 37,
+            "columnEnd": 4
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/food." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 38,
+            "columnBegin": 1,
+            "lineEnd": 38,
+            "columnEnd": 4
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/food." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 1,
+            "lineEnd": 39,
+            "columnEnd": 4
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/food." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 40,
+            "columnBegin": 1,
+            "lineEnd": 40,
+            "columnEnd": 4
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/food." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 41,
+            "columnBegin": 1,
+            "lineEnd": 41,
+            "columnEnd": 4
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/food." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 123,
+            "columnBegin": 22,
+            "lineEnd": 123,
+            "columnEnd": 25
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/food." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 126,
+            "columnBegin": 9,
+            "lineEnd": 126,
+            "columnEnd": 12
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/godown()." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 91,
+            "columnBegin": 15,
+            "lineEnd": 91,
+            "columnEnd": 20
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/goleft()." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 92,
+            "columnBegin": 15,
+            "lineEnd": 92,
+            "columnEnd": 20
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/goright()." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 93,
+            "columnBegin": 15,
+            "lineEnd": 93,
+            "columnEnd": 21
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/group()." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 90,
+            "columnBegin": 15,
+            "lineEnd": 90,
+            "columnEnd": 19
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 27,
+            "columnBegin": 1,
+            "lineEnd": 27,
+            "columnEnd": 4
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 28,
+            "columnBegin": 1,
+            "lineEnd": 28,
+            "columnEnd": 4
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 29,
+            "columnBegin": 1,
+            "lineEnd": 29,
+            "columnEnd": 4
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 30,
+            "columnBegin": 1,
+            "lineEnd": 30,
+            "columnEnd": 4
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -146,315 +370,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 32,
-            "columnBegin": 1,
-            "lineEnd": 32,
-            "columnEnd": 4
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 33,
-            "columnBegin": 1,
-            "lineEnd": 33,
-            "columnEnd": 4
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 34,
-            "columnBegin": 1,
-            "lineEnd": 34,
-            "columnEnd": 4
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 35,
-            "columnBegin": 1,
-            "lineEnd": 35,
-            "columnEnd": 4
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 110,
-            "columnBegin": 22,
-            "lineEnd": 110,
-            "columnEnd": 25
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 113,
-            "columnBegin": 9,
-            "lineEnd": 113,
-            "columnEnd": 12
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/godown()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 86,
-            "columnBegin": 15,
-            "lineEnd": 86,
-            "columnEnd": 20
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goleft()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 87,
-            "columnBegin": 15,
-            "lineEnd": 87,
-            "columnEnd": 20
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goright()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 88,
-            "columnBegin": 15,
-            "lineEnd": 88,
-            "columnEnd": 21
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/group()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 85,
-            "columnBegin": 15,
-            "lineEnd": 85,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 21,
-            "columnBegin": 1,
-            "lineEnd": 21,
-            "columnEnd": 4
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 22,
-            "columnBegin": 1,
-            "lineEnd": 22,
-            "columnEnd": 4
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 23,
-            "columnBegin": 1,
-            "lineEnd": 23,
-            "columnEnd": 4
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 24,
-            "columnBegin": 1,
-            "lineEnd": 24,
-            "columnEnd": 4
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 25,
-            "columnBegin": 1,
-            "lineEnd": 25,
-            "columnEnd": 4
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 50,
-            "columnBegin": 8,
-            "lineEnd": 50,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 51,
-            "columnBegin": 9,
-            "lineEnd": 51,
-            "columnEnd": 12
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -470,9 +386,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -488,9 +402,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -506,9 +418,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -524,9 +434,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -542,9 +450,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -560,9 +466,7 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
@@ -578,34 +482,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 71,
-            "columnBegin": 13,
-            "lineEnd": 71,
-            "columnEnd": 16
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 72,
             "columnBegin": 9,
-            "lineEnd": 72,
+            "lineEnd": 71,
             "columnEnd": 12
           }
         }
@@ -614,53 +498,15 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 73,
-            "columnBegin": 8,
-            "lineEnd": 73,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 74,
-            "columnBegin": 13,
-            "lineEnd": 74,
-            "columnEnd": 16
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 75,
-            "columnBegin": 9,
+            "columnBegin": 8,
             "lineEnd": 75,
-            "columnEnd": 12
+            "columnEnd": 11
           }
         }
       }
@@ -668,17 +514,15 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 76,
-            "columnBegin": 8,
+            "columnBegin": 13,
             "lineEnd": 76,
-            "columnEnd": 11
+            "columnEnd": 16
           }
         }
       }
@@ -686,17 +530,15 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 77,
-            "columnBegin": 13,
+            "columnBegin": 9,
             "lineEnd": 77,
-            "columnEnd": 16
+            "columnEnd": 12
           }
         }
       }
@@ -704,34 +546,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 78,
-            "columnBegin": 9,
-            "lineEnd": 78,
-            "columnEnd": 12
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 79,
             "columnBegin": 8,
-            "lineEnd": 79,
+            "lineEnd": 78,
             "columnEnd": 11
           }
         }
@@ -740,16 +562,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 80,
+            "lineBegin": 79,
             "columnBegin": 13,
-            "lineEnd": 80,
+            "lineEnd": 79,
             "columnEnd": 16
           }
         }
@@ -758,16 +578,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 81,
+            "lineBegin": 80,
             "columnBegin": 9,
-            "lineEnd": 81,
+            "lineEnd": 80,
             "columnEnd": 12
           }
         }
@@ -776,16 +594,14 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 96,
+            "lineBegin": 81,
             "columnBegin": 8,
-            "lineEnd": 96,
+            "lineEnd": 81,
             "columnEnd": 11
           }
         }
@@ -794,16 +610,238 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 96,
+            "lineBegin": 82,
+            "columnBegin": 13,
+            "lineEnd": 82,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 83,
+            "columnBegin": 9,
+            "lineEnd": 83,
+            "columnEnd": 12
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 84,
+            "columnBegin": 8,
+            "lineEnd": 84,
+            "columnEnd": 11
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 85,
+            "columnBegin": 13,
+            "lineEnd": 85,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 86,
+            "columnBegin": 9,
+            "lineEnd": 86,
+            "columnEnd": 12
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 102,
+            "columnBegin": 9,
+            "lineEnd": 102,
+            "columnEnd": 12
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 103,
+            "columnBegin": 12,
+            "lineEnd": 103,
+            "columnEnd": 15
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 104,
+            "columnBegin": 12,
+            "lineEnd": 104,
+            "columnEnd": 15
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 105,
+            "columnBegin": 12,
+            "lineEnd": 105,
+            "columnEnd": 15
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 108,
+            "columnBegin": 9,
+            "lineEnd": 108,
+            "columnEnd": 12
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 109,
+            "columnBegin": 9,
+            "lineEnd": 109,
+            "columnEnd": 12
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 123,
+            "columnBegin": 8,
+            "lineEnd": 123,
+            "columnEnd": 11
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 151,
+            "columnBegin": 13,
+            "lineEnd": 151,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 152,
+            "columnBegin": 13,
+            "lineEnd": 152,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 156,
             "columnBegin": 29,
-            "lineEnd": 96,
+            "lineEnd": 156,
             "columnEnd": 32
           }
         }
@@ -812,16 +850,494 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 96,
-            "columnBegin": 51,
-            "lineEnd": 96,
+            "lineBegin": 158,
+            "columnBegin": 13,
+            "lineEnd": 158,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/head." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 159,
+            "columnBegin": 13,
+            "lineEnd": 159,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/high_score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 119,
+            "columnBegin": 57,
+            "lineEnd": 119,
+            "columnEnd": 66
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/high_score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 137,
+            "columnBegin": 20,
+            "lineEnd": 137,
+            "columnEnd": 29
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/high_score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 138,
+            "columnBegin": 13,
+            "lineEnd": 138,
+            "columnEnd": 22
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/high_score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 141,
+            "columnBegin": 57,
+            "lineEnd": 141,
+            "columnEnd": 66
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/high_score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 170,
+            "columnBegin": 61,
+            "lineEnd": 170,
+            "columnEnd": 70
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/index." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 147,
+            "columnBegin": 22,
+            "lineEnd": 147,
+            "columnEnd": 26
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/index." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 148,
+            "columnBegin": 22,
+            "lineEnd": 148,
+            "columnEnd": 26
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/index." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 149,
+            "columnBegin": 18,
+            "lineEnd": 149,
+            "columnEnd": 22
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/move()." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 154,
+            "columnBegin": 5,
+            "lineEnd": 154,
+            "columnEnd": 8
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/new_segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 130,
+            "columnBegin": 9,
+            "lineEnd": 130,
+            "columnEnd": 19
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/new_segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 131,
+            "columnBegin": 9,
+            "lineEnd": 131,
+            "columnEnd": 19
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/new_segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 132,
+            "columnBegin": 9,
+            "lineEnd": 132,
+            "columnEnd": 19
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/new_segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 133,
+            "columnBegin": 9,
+            "lineEnd": 133,
+            "columnEnd": 19
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/new_segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 134,
+            "columnBegin": 25,
+            "lineEnd": 134,
+            "columnEnd": 35
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 44,
+            "columnBegin": 1,
+            "lineEnd": 44,
+            "columnEnd": 3
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 45,
+            "columnBegin": 1,
+            "lineEnd": 45,
+            "columnEnd": 3
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 46,
+            "columnBegin": 1,
+            "lineEnd": 46,
+            "columnEnd": 3
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 47,
+            "columnBegin": 1,
+            "lineEnd": 47,
+            "columnEnd": 3
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 48,
+            "columnBegin": 1,
+            "lineEnd": 48,
+            "columnEnd": 3
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 49,
+            "columnBegin": 1,
+            "lineEnd": 49,
+            "columnEnd": 3
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 50,
+            "columnBegin": 1,
+            "lineEnd": 50,
+            "columnEnd": 3
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 117,
+            "columnBegin": 9,
+            "lineEnd": 117,
+            "columnEnd": 11
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 118,
+            "columnBegin": 9,
+            "lineEnd": 118,
+            "columnEnd": 11
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 139,
+            "columnBegin": 9,
+            "lineEnd": 139,
+            "columnEnd": 11
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 140,
+            "columnBegin": 9,
+            "lineEnd": 140,
+            "columnEnd": 11
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 168,
+            "columnBegin": 13,
+            "lineEnd": 168,
+            "columnEnd": 15
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/pen." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 169,
+            "columnBegin": 13,
+            "lineEnd": 169,
+            "columnEnd": 15
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 115,
+            "columnBegin": 9,
+            "lineEnd": 115,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 119,
+            "columnBegin": 50,
+            "lineEnd": 119,
             "columnEnd": 54
           }
         }
@@ -830,35 +1346,735 @@
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/score." },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 96,
-            "columnBegin": 72,
-            "lineEnd": 96,
-            "columnEnd": 75
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 98,
+            "lineBegin": 136,
             "columnBegin": 9,
-            "lineEnd": 98,
-            "columnEnd": 12
+            "lineEnd": 136,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 137,
+            "columnBegin": 12,
+            "lineEnd": 137,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 138,
+            "columnBegin": 26,
+            "lineEnd": 138,
+            "columnEnd": 30
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 141,
+            "columnBegin": 50,
+            "lineEnd": 141,
+            "columnEnd": 54
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 166,
+            "columnBegin": 13,
+            "lineEnd": 166,
+            "columnEnd": 17
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/score." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 170,
+            "columnBegin": 54,
+            "lineEnd": 170,
+            "columnEnd": 58
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 113,
+            "columnBegin": 13,
+            "lineEnd": 113,
+            "columnEnd": 19
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 155,
+            "columnBegin": 9,
+            "lineEnd": 155,
+            "columnEnd": 15
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 156,
+            "columnBegin": 12,
+            "lineEnd": 156,
+            "columnEnd": 18
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 162,
+            "columnBegin": 17,
+            "lineEnd": 162,
+            "columnEnd": 23
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segment." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 163,
+            "columnBegin": 17,
+            "lineEnd": 163,
+            "columnEnd": 23
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 112,
+            "columnBegin": 24,
+            "lineEnd": 112,
+            "columnEnd": 31
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 114,
+            "columnBegin": 9,
+            "lineEnd": 114,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 134,
+            "columnBegin": 9,
+            "lineEnd": 134,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 146,
+            "columnBegin": 28,
+            "lineEnd": 146,
+            "columnEnd": 35
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 147,
+            "columnBegin": 13,
+            "lineEnd": 147,
+            "columnEnd": 20
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 148,
+            "columnBegin": 13,
+            "lineEnd": 148,
+            "columnEnd": 20
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 149,
+            "columnBegin": 9,
+            "lineEnd": 149,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 150,
+            "columnBegin": 12,
+            "lineEnd": 150,
+            "columnEnd": 19
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 153,
+            "columnBegin": 9,
+            "lineEnd": 153,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 155,
+            "columnBegin": 20,
+            "lineEnd": 155,
+            "columnEnd": 27
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 162,
+            "columnBegin": 28,
+            "lineEnd": 162,
+            "columnEnd": 35
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/segments." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 164,
+            "columnBegin": 13,
+            "lineEnd": 164,
+            "columnEnd": 20
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/shapes." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 38,
+            "columnBegin": 12,
+            "lineEnd": 38,
+            "columnEnd": 17
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/shapes." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 111,
+            "columnBegin": 9,
+            "lineEnd": 111,
+            "columnEnd": 14
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/shapes." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 161,
+            "columnBegin": 13,
+            "lineEnd": 161,
+            "columnEnd": 18
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 19,
+            "columnBegin": 1,
+            "lineEnd": 19,
+            "columnEnd": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 20,
+            "columnBegin": 1,
+            "lineEnd": 20,
+            "columnEnd": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 22,
+            "columnBegin": 1,
+            "lineEnd": 22,
+            "columnEnd": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 23,
+            "columnBegin": 1,
+            "lineEnd": 23,
+            "columnEnd": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 89,
+            "columnBegin": 1,
+            "lineEnd": 89,
+            "columnEnd": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 90,
+            "columnBegin": 1,
+            "lineEnd": 90,
+            "columnEnd": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 91,
+            "columnBegin": 1,
+            "lineEnd": 91,
+            "columnEnd": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 92,
+            "columnBegin": 1,
+            "lineEnd": 92,
+            "columnEnd": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 93,
+            "columnBegin": 1,
+            "lineEnd": 93,
+            "columnEnd": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/wn." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 100,
+            "columnBegin": 5,
+            "lineEnd": 100,
+            "columnEnd": 6
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/x." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 126,
+            "columnBegin": 19,
+            "lineEnd": 126,
+            "columnEnd": 19
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/x." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 147,
+            "columnBegin": 9,
+            "lineEnd": 147,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/x." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 149,
+            "columnBegin": 30,
+            "lineEnd": 149,
+            "columnEnd": 30
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/x." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 151,
+            "columnBegin": 9,
+            "lineEnd": 151,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/x." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 153,
+            "columnBegin": 26,
+            "lineEnd": 153,
+            "columnEnd": 26
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/y." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 126,
+            "columnBegin": 22,
+            "lineEnd": 126,
+            "columnEnd": 22
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/y." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 148,
+            "columnBegin": 9,
+            "lineEnd": 148,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/y." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 149,
+            "columnBegin": 33,
+            "lineEnd": 149,
+            "columnEnd": 33
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/y." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 152,
+            "columnBegin": 9,
+            "lineEnd": 152,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "scip-python python . test example/y." },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 153,
+            "columnBegin": 29,
+            "lineEnd": 153,
+            "columnEnd": 29
           }
         }
       }
@@ -867,16 +2083,16 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+        "key": "scip-python python python-stdlib 3.11 builtins/list#append()."
       },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 99,
-            "columnBegin": 9,
-            "lineEnd": 99,
-            "columnEnd": 12
+            "lineBegin": 134,
+            "columnBegin": 18,
+            "lineEnd": 134,
+            "columnEnd": 23
           }
         }
       }
@@ -885,15 +2101,339 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+        "key": "scip-python python python-stdlib 3.11 builtins/range#"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 146,
+            "columnBegin": 18,
+            "lineEnd": 146,
+            "columnEnd": 22
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/__init__:"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 8,
+            "columnBegin": 8,
+            "lineEnd": 8,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/__init__:"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 10,
+            "lineEnd": 35,
+            "columnEnd": 15
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/__init__:"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 10,
+            "lineEnd": 36,
+            "columnEnd": 15
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/__init__:"
       },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 110,
-            "columnBegin": 8,
+            "columnBegin": 18,
             "lineEnd": 110,
+            "columnEnd": 23
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/__init__:"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 111,
+            "columnBegin": 18,
+            "lineEnd": 111,
+            "columnEnd": 23
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/__init__:"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 124,
+            "columnBegin": 13,
+            "lineEnd": 124,
+            "columnEnd": 18
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/__init__:"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 125,
+            "columnBegin": 13,
+            "lineEnd": 125,
+            "columnEnd": 18
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/__init__:"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 160,
+            "columnBegin": 22,
+            "lineEnd": 160,
+            "columnEnd": 27
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/__init__:"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 161,
+            "columnBegin": 22,
+            "lineEnd": 161,
+            "columnEnd": 27
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/choice."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 17,
+            "lineEnd": 35,
+            "columnEnd": 22
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/choice."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 17,
+            "lineEnd": 36,
+            "columnEnd": 22
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/choice."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 110,
+            "columnBegin": 25,
+            "lineEnd": 110,
+            "columnEnd": 30
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/choice."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 111,
+            "columnBegin": 25,
+            "lineEnd": 111,
+            "columnEnd": 30
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/choice."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 160,
+            "columnBegin": 29,
+            "lineEnd": 160,
+            "columnEnd": 34
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/choice."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 161,
+            "columnBegin": 29,
+            "lineEnd": 161,
+            "columnEnd": 34
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/randint."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 124,
+            "columnBegin": 20,
+            "lineEnd": 124,
+            "columnEnd": 26
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 random/randint."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 125,
+            "columnBegin": 20,
+            "lineEnd": 125,
+            "columnEnd": 26
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 time/__init__:"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 9,
+            "columnBegin": 8,
+            "lineEnd": 9,
             "columnEnd": 11
           }
         }
@@ -903,15 +2443,33 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+        "key": "scip-python python python-stdlib 3.11 time/__init__:"
       },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 135,
+            "lineBegin": 107,
+            "columnBegin": 9,
+            "lineEnd": 107,
+            "columnEnd": 12
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 time/__init__:"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 157,
             "columnBegin": 13,
-            "lineEnd": 135,
+            "lineEnd": 157,
             "columnEnd": 16
           }
         }
@@ -921,16 +2479,16 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+        "key": "scip-python python python-stdlib 3.11 time/__init__:"
       },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 136,
-            "columnBegin": 13,
-            "lineEnd": 136,
-            "columnEnd": 16
+            "lineBegin": 174,
+            "columnBegin": 5,
+            "lineEnd": 174,
+            "columnEnd": 8
           }
         }
       }
@@ -939,16 +2497,232 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+        "key": "scip-python python python-stdlib 3.11 time/sleep()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 107,
+            "columnBegin": 14,
+            "lineEnd": 107,
+            "columnEnd": 18
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 time/sleep()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 157,
+            "columnBegin": 18,
+            "lineEnd": 157,
+            "columnEnd": 22
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 time/sleep()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 174,
+            "columnBegin": 10,
+            "lineEnd": 174,
+            "columnEnd": 14
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 117,
+            "columnBegin": 13,
+            "lineEnd": 117,
+            "columnEnd": 17
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 139,
+            "columnBegin": 13,
+            "lineEnd": 139,
+            "columnEnd": 17
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 168,
+            "columnBegin": 17,
+            "lineEnd": 168,
+            "columnEnd": 21
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 27,
+            "columnBegin": 6,
+            "lineEnd": 27,
+            "columnEnd": 10
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 38,
+            "columnBegin": 6,
+            "lineEnd": 38,
+            "columnEnd": 10
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 45,
+            "columnBegin": 5,
+            "lineEnd": 45,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 131,
+            "columnBegin": 21,
+            "lineEnd": 131,
+            "columnEnd": 25
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 50,
+            "columnBegin": 5,
+            "lineEnd": 50,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 118,
+            "columnBegin": 13,
+            "lineEnd": 118,
+            "columnEnd": 17
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
       },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 140,
-            "columnBegin": 29,
+            "columnBegin": 13,
             "lineEnd": 140,
-            "columnEnd": 32
+            "columnEnd": 17
           }
         }
       }
@@ -957,7 +2731,61 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 169,
+            "columnBegin": 17,
+            "lineEnd": 169,
+            "columnEnd": 21
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 50,
+            "columnBegin": 40,
+            "lineEnd": 50,
+            "columnEnd": 44
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 120,
+            "columnBegin": 13,
+            "lineEnd": 120,
+            "columnEnd": 17
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
       },
       "location": {
         "key": {
@@ -966,6 +2794,60 @@
             "lineBegin": 142,
             "columnBegin": 13,
             "lineEnd": 142,
+            "columnEnd": 17
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 171,
+            "columnBegin": 17,
+            "lineEnd": 171,
+            "columnEnd": 21
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 50,
+            "columnBegin": 56,
+            "lineEnd": 50,
+            "columnEnd": 59
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 121,
+            "columnBegin": 13,
+            "lineEnd": 121,
             "columnEnd": 16
           }
         }
@@ -975,7 +2857,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
       },
       "location": {
         "key": {
@@ -993,2158 +2875,16 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
+        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
       },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 109,
-            "columnBegin": 20,
-            "lineEnd": 109,
-            "columnEnd": 29
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 124,
-            "columnBegin": 20,
-            "lineEnd": 124,
-            "columnEnd": 29
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 125,
-            "columnBegin": 13,
-            "lineEnd": 125,
-            "columnEnd": 22
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 128,
-            "columnBegin": 20,
-            "lineEnd": 128,
-            "columnEnd": 29
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 154,
-            "columnBegin": 24,
-            "lineEnd": 154,
-            "columnEnd": 33
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 131,
-            "columnBegin": 22,
-            "lineEnd": 131,
-            "columnEnd": 26
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 132,
-            "columnBegin": 22,
-            "lineEnd": 132,
-            "columnEnd": 26
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 133,
-            "columnBegin": 18,
-            "lineEnd": 133,
-            "columnEnd": 22
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/move()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 138,
-            "columnBegin": 5,
-            "lineEnd": 138,
-            "columnEnd": 8
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 117,
-            "columnBegin": 9,
-            "lineEnd": 117,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 118,
-            "columnBegin": 9,
-            "lineEnd": 118,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 119,
-            "columnBegin": 9,
-            "lineEnd": 119,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 120,
-            "columnBegin": 9,
-            "lineEnd": 120,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 121,
-            "columnBegin": 25,
-            "lineEnd": 121,
-            "columnEnd": 35
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 1,
-            "lineEnd": 38,
-            "columnEnd": 3
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 39,
-            "columnBegin": 1,
-            "lineEnd": 39,
-            "columnEnd": 3
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 40,
-            "columnBegin": 1,
-            "lineEnd": 40,
-            "columnEnd": 3
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 41,
-            "columnBegin": 1,
-            "lineEnd": 41,
-            "columnEnd": 3
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 42,
-            "columnBegin": 1,
-            "lineEnd": 42,
-            "columnEnd": 3
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 43,
-            "columnBegin": 1,
-            "lineEnd": 43,
-            "columnEnd": 3
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 44,
-            "columnBegin": 1,
-            "lineEnd": 44,
-            "columnEnd": 3
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 107,
-            "columnBegin": 9,
-            "lineEnd": 107,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 108,
-            "columnBegin": 9,
-            "lineEnd": 108,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 126,
-            "columnBegin": 9,
-            "lineEnd": 126,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 127,
-            "columnBegin": 9,
-            "lineEnd": 127,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 152,
-            "columnBegin": 13,
-            "lineEnd": 152,
-            "columnEnd": 15
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 153,
-            "columnBegin": 13,
-            "lineEnd": 153,
-            "columnEnd": 15
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 105,
-            "columnBegin": 9,
-            "lineEnd": 105,
-            "columnEnd": 13
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 109,
-            "columnBegin": 13,
-            "lineEnd": 109,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 123,
-            "columnBegin": 9,
-            "lineEnd": 123,
-            "columnEnd": 13
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 124,
-            "columnBegin": 12,
-            "lineEnd": 124,
-            "columnEnd": 16
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 125,
-            "columnBegin": 26,
-            "lineEnd": 125,
-            "columnEnd": 30
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 128,
-            "columnBegin": 13,
-            "lineEnd": 128,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 150,
-            "columnBegin": 13,
-            "lineEnd": 150,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 154,
+            "lineBegin": 172,
             "columnBegin": 17,
-            "lineEnd": 154,
-            "columnEnd": 21
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 103,
-            "columnBegin": 13,
-            "lineEnd": 103,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 139,
-            "columnBegin": 9,
-            "lineEnd": 139,
-            "columnEnd": 15
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 140,
-            "columnBegin": 12,
-            "lineEnd": 140,
-            "columnEnd": 18
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 146,
-            "columnBegin": 17,
-            "lineEnd": 146,
-            "columnEnd": 23
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 147,
-            "columnBegin": 17,
-            "lineEnd": 147,
-            "columnEnd": 23
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 102,
-            "columnBegin": 24,
-            "lineEnd": 102,
-            "columnEnd": 31
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 104,
-            "columnBegin": 9,
-            "lineEnd": 104,
-            "columnEnd": 16
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 121,
-            "columnBegin": 9,
-            "lineEnd": 121,
-            "columnEnd": 16
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 130,
-            "columnBegin": 28,
-            "lineEnd": 130,
-            "columnEnd": 35
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 131,
-            "columnBegin": 13,
-            "lineEnd": 131,
+            "lineEnd": 172,
             "columnEnd": 20
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 132,
-            "columnBegin": 13,
-            "lineEnd": 132,
-            "columnEnd": 20
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 133,
-            "columnBegin": 9,
-            "lineEnd": 133,
-            "columnEnd": 16
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 134,
-            "columnBegin": 12,
-            "lineEnd": 134,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 137,
-            "columnBegin": 9,
-            "lineEnd": 137,
-            "columnEnd": 16
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 139,
-            "columnBegin": 20,
-            "lineEnd": 139,
-            "columnEnd": 27
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 146,
-            "columnBegin": 28,
-            "lineEnd": 146,
-            "columnEnd": 35
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 148,
-            "columnBegin": 13,
-            "lineEnd": 148,
-            "columnEnd": 20
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 32,
-            "columnBegin": 12,
-            "lineEnd": 32,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 101,
-            "columnBegin": 9,
-            "lineEnd": 101,
-            "columnEnd": 14
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 145,
-            "columnBegin": 13,
-            "lineEnd": 145,
-            "columnEnd": 18
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 13,
-            "columnBegin": 1,
-            "lineEnd": 13,
-            "columnEnd": 2
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 14,
-            "columnBegin": 1,
-            "lineEnd": 14,
-            "columnEnd": 2
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 16,
-            "columnBegin": 1,
-            "lineEnd": 16,
-            "columnEnd": 2
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 17,
-            "columnBegin": 1,
-            "lineEnd": 17,
-            "columnEnd": 2
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 84,
-            "columnBegin": 1,
-            "lineEnd": 84,
-            "columnEnd": 2
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 85,
-            "columnBegin": 1,
-            "lineEnd": 85,
-            "columnEnd": 2
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 86,
-            "columnBegin": 1,
-            "lineEnd": 86,
-            "columnEnd": 2
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 87,
-            "columnBegin": 1,
-            "lineEnd": 87,
-            "columnEnd": 2
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 88,
-            "columnBegin": 1,
-            "lineEnd": 88,
-            "columnEnd": 2
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 95,
-            "columnBegin": 5,
-            "lineEnd": 95,
-            "columnEnd": 6
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 113,
-            "columnBegin": 19,
-            "lineEnd": 113,
-            "columnEnd": 19
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 131,
-            "columnBegin": 9,
-            "lineEnd": 131,
-            "columnEnd": 9
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 133,
-            "columnBegin": 30,
-            "lineEnd": 133,
-            "columnEnd": 30
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 135,
-            "columnBegin": 9,
-            "lineEnd": 135,
-            "columnEnd": 9
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 137,
-            "columnBegin": 26,
-            "lineEnd": 137,
-            "columnEnd": 26
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 113,
-            "columnBegin": 22,
-            "lineEnd": 113,
-            "columnEnd": 22
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 132,
-            "columnBegin": 9,
-            "lineEnd": 132,
-            "columnEnd": 9
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 133,
-            "columnBegin": 33,
-            "lineEnd": 133,
-            "columnEnd": 33
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 136,
-            "columnBegin": 9,
-            "lineEnd": 136,
-            "columnEnd": 9
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 137,
-            "columnBegin": 29,
-            "lineEnd": 137,
-            "columnEnd": 29
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 builtins/list#append()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 121,
-            "columnBegin": 18,
-            "lineEnd": 121,
-            "columnEnd": 23
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 builtins/range#"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 130,
-            "columnBegin": 18,
-            "lineEnd": 130,
-            "columnEnd": 22
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 4,
-            "columnBegin": 8,
-            "lineEnd": 4,
-            "columnEnd": 13
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 29,
-            "columnBegin": 10,
-            "lineEnd": 29,
-            "columnEnd": 15
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 30,
-            "columnBegin": 10,
-            "lineEnd": 30,
-            "columnEnd": 15
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 100,
-            "columnBegin": 18,
-            "lineEnd": 100,
-            "columnEnd": 23
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 101,
-            "columnBegin": 18,
-            "lineEnd": 101,
-            "columnEnd": 23
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 111,
-            "columnBegin": 13,
-            "lineEnd": 111,
-            "columnEnd": 18
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 112,
-            "columnBegin": 13,
-            "lineEnd": 112,
-            "columnEnd": 18
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 144,
-            "columnBegin": 22,
-            "lineEnd": 144,
-            "columnEnd": 27
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 145,
-            "columnBegin": 22,
-            "lineEnd": 145,
-            "columnEnd": 27
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/choice."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 29,
-            "columnBegin": 17,
-            "lineEnd": 29,
-            "columnEnd": 22
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/choice."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 30,
-            "columnBegin": 17,
-            "lineEnd": 30,
-            "columnEnd": 22
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/choice."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 100,
-            "columnBegin": 25,
-            "lineEnd": 100,
-            "columnEnd": 30
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/choice."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 101,
-            "columnBegin": 25,
-            "lineEnd": 101,
-            "columnEnd": 30
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/choice."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 144,
-            "columnBegin": 29,
-            "lineEnd": 144,
-            "columnEnd": 34
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/choice."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 145,
-            "columnBegin": 29,
-            "lineEnd": 145,
-            "columnEnd": 34
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/randint."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 111,
-            "columnBegin": 20,
-            "lineEnd": 111,
-            "columnEnd": 26
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 random/randint."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 112,
-            "columnBegin": 20,
-            "lineEnd": 112,
-            "columnEnd": 26
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 time/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 3,
-            "columnBegin": 8,
-            "lineEnd": 3,
-            "columnEnd": 11
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 time/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 97,
-            "columnBegin": 9,
-            "lineEnd": 97,
-            "columnEnd": 12
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 time/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 141,
-            "columnBegin": 13,
-            "lineEnd": 141,
-            "columnEnd": 16
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 time/__init__:"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 155,
-            "columnBegin": 5,
-            "lineEnd": 155,
-            "columnEnd": 8
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 time/sleep()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 97,
-            "columnBegin": 14,
-            "lineEnd": 97,
-            "columnEnd": 18
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 time/sleep()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 141,
-            "columnBegin": 18,
-            "lineEnd": 141,
-            "columnEnd": 22
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 time/sleep()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 155,
-            "columnBegin": 10,
-            "lineEnd": 155,
-            "columnEnd": 14
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 107,
-            "columnBegin": 13,
-            "lineEnd": 107,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 126,
-            "columnBegin": 13,
-            "lineEnd": 126,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 152,
-            "columnBegin": 17,
-            "lineEnd": 152,
-            "columnEnd": 21
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 21,
-            "columnBegin": 6,
-            "lineEnd": 21,
-            "columnEnd": 10
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 32,
-            "columnBegin": 6,
-            "lineEnd": 32,
-            "columnEnd": 10
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 39,
-            "columnBegin": 5,
-            "lineEnd": 39,
-            "columnEnd": 9
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 118,
-            "columnBegin": 21,
-            "lineEnd": 118,
-            "columnEnd": 25
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 44,
-            "columnBegin": 5,
-            "lineEnd": 44,
-            "columnEnd": 9
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 108,
-            "columnBegin": 13,
-            "lineEnd": 108,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 127,
-            "columnBegin": 13,
-            "lineEnd": 127,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 153,
-            "columnBegin": 17,
-            "lineEnd": 153,
-            "columnEnd": 21
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 44,
-            "columnBegin": 40,
-            "lineEnd": 44,
-            "columnEnd": 44
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 109,
-            "columnBegin": 33,
-            "lineEnd": 109,
-            "columnEnd": 37
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 128,
-            "columnBegin": 33,
-            "lineEnd": 128,
-            "columnEnd": 37
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 154,
-            "columnBegin": 37,
-            "lineEnd": 154,
-            "columnEnd": 41
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 45,
-            "columnBegin": 11,
-            "lineEnd": 45,
-            "columnEnd": 14
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 109,
-            "columnBegin": 49,
-            "lineEnd": 109,
-            "columnEnd": 52
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 128,
-            "columnBegin": 49,
-            "lineEnd": 128,
-            "columnEnd": 52
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 154,
-            "columnBegin": 53,
-            "lineEnd": 154,
-            "columnEnd": 56
           }
         }
       }
@@ -3159,9 +2899,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 12,
+            "lineBegin": 18,
             "columnBegin": 13,
-            "lineEnd": 12,
+            "lineEnd": 18,
             "columnEnd": 18
           }
         }
@@ -3177,9 +2917,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 110,
+            "lineBegin": 123,
             "columnBegin": 13,
-            "lineEnd": 110,
+            "lineEnd": 123,
             "columnEnd": 20
           }
         }
@@ -3195,9 +2935,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 24,
+            "lineBegin": 30,
             "columnBegin": 6,
-            "lineEnd": 24,
+            "lineEnd": 30,
             "columnEnd": 9
           }
         }
@@ -3213,9 +2953,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 35,
+            "lineBegin": 41,
             "columnBegin": 6,
-            "lineEnd": 35,
+            "lineEnd": 41,
             "columnEnd": 9
           }
         }
@@ -3231,9 +2971,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 43,
+            "lineBegin": 49,
             "columnBegin": 5,
-            "lineEnd": 43,
+            "lineEnd": 49,
             "columnEnd": 8
           }
         }
@@ -3249,9 +2989,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 98,
+            "lineBegin": 108,
             "columnBegin": 14,
-            "lineEnd": 98,
+            "lineEnd": 108,
             "columnEnd": 17
           }
         }
@@ -3267,9 +3007,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 113,
+            "lineBegin": 126,
             "columnBegin": 14,
-            "lineEnd": 113,
+            "lineEnd": 126,
             "columnEnd": 17
           }
         }
@@ -3285,9 +3025,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 142,
+            "lineBegin": 158,
             "columnBegin": 18,
-            "lineEnd": 142,
+            "lineEnd": 158,
             "columnEnd": 21
           }
         }
@@ -3303,9 +3043,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 78,
+            "lineBegin": 83,
             "columnBegin": 14,
-            "lineEnd": 78,
+            "lineEnd": 83,
             "columnEnd": 17
           }
         }
@@ -3321,9 +3061,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 81,
+            "lineBegin": 86,
             "columnBegin": 14,
-            "lineEnd": 81,
+            "lineEnd": 86,
             "columnEnd": 17
           }
         }
@@ -3334,51 +3074,15 @@
     "key": {
       "symbol": {
         "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#sety()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 72,
-            "columnBegin": 14,
-            "lineEnd": 72,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#sety()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 75,
-            "columnBegin": 14,
-            "lineEnd": 75,
-            "columnEnd": 17
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
       },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 77,
-            "columnBegin": 18,
+            "columnBegin": 14,
             "lineEnd": 77,
-            "columnEnd": 21
+            "columnEnd": 17
           }
         }
       }
@@ -3387,15 +3091,33 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
+        "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#sety()."
       },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 80,
-            "columnBegin": 18,
+            "columnBegin": 14,
             "lineEnd": 80,
+            "columnEnd": 17
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 82,
+            "columnBegin": 18,
+            "lineEnd": 82,
             "columnEnd": 21
           }
         }
@@ -3411,10 +3133,10 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 96,
-            "columnBegin": 13,
-            "lineEnd": 96,
-            "columnEnd": 16
+            "lineBegin": 85,
+            "columnBegin": 18,
+            "lineEnd": 85,
+            "columnEnd": 21
           }
         }
       }
@@ -3429,10 +3151,10 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 96,
-            "columnBegin": 34,
-            "lineEnd": 96,
-            "columnEnd": 37
+            "lineBegin": 102,
+            "columnBegin": 14,
+            "lineEnd": 102,
+            "columnEnd": 17
           }
         }
       }
@@ -3447,9 +3169,27 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 135,
+            "lineBegin": 103,
+            "columnBegin": 17,
+            "lineEnd": 103,
+            "columnEnd": 20
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 151,
             "columnBegin": 18,
-            "lineEnd": 135,
+            "lineEnd": 151,
             "columnEnd": 21
           }
         }
@@ -3465,9 +3205,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 71,
+            "lineBegin": 76,
             "columnBegin": 18,
-            "lineEnd": 71,
+            "lineEnd": 76,
             "columnEnd": 21
           }
         }
@@ -3483,9 +3223,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 74,
+            "lineBegin": 79,
             "columnBegin": 18,
-            "lineEnd": 74,
+            "lineEnd": 79,
             "columnEnd": 21
           }
         }
@@ -3501,10 +3241,10 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 96,
-            "columnBegin": 56,
-            "lineEnd": 96,
-            "columnEnd": 59
+            "lineBegin": 104,
+            "columnBegin": 17,
+            "lineEnd": 104,
+            "columnEnd": 20
           }
         }
       }
@@ -3519,10 +3259,10 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 96,
-            "columnBegin": 77,
-            "lineEnd": 96,
-            "columnEnd": 80
+            "lineBegin": 105,
+            "columnBegin": 17,
+            "lineEnd": 105,
+            "columnEnd": 20
           }
         }
       }
@@ -3537,9 +3277,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 136,
+            "lineBegin": 152,
             "columnBegin": 18,
-            "lineEnd": 136,
+            "lineEnd": 152,
             "columnEnd": 21
           }
         }
@@ -3555,9 +3295,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 22,
+            "lineBegin": 28,
             "columnBegin": 6,
-            "lineEnd": 22,
+            "lineEnd": 28,
             "columnEnd": 10
           }
         }
@@ -3573,9 +3313,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 33,
+            "lineBegin": 39,
             "columnBegin": 6,
-            "lineEnd": 33,
+            "lineEnd": 39,
             "columnEnd": 10
           }
         }
@@ -3591,9 +3331,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 40,
+            "lineBegin": 46,
             "columnBegin": 5,
-            "lineEnd": 40,
+            "lineEnd": 46,
             "columnEnd": 9
           }
         }
@@ -3609,9 +3349,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 119,
+            "lineBegin": 132,
             "columnBegin": 21,
-            "lineEnd": 119,
+            "lineEnd": 132,
             "columnEnd": 25
           }
         }
@@ -3627,9 +3367,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 42,
+            "lineBegin": 48,
             "columnBegin": 5,
-            "lineEnd": 42,
+            "lineEnd": 48,
             "columnEnd": 14
           }
         }
@@ -3645,9 +3385,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 23,
+            "lineBegin": 29,
             "columnBegin": 6,
-            "lineEnd": 23,
+            "lineEnd": 29,
             "columnEnd": 10
           }
         }
@@ -3663,9 +3403,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 34,
+            "lineBegin": 40,
             "columnBegin": 6,
-            "lineEnd": 34,
+            "lineEnd": 40,
             "columnEnd": 10
           }
         }
@@ -3681,9 +3421,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 41,
+            "lineBegin": 47,
             "columnBegin": 5,
-            "lineEnd": 41,
+            "lineEnd": 47,
             "columnEnd": 9
           }
         }
@@ -3699,9 +3439,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 120,
+            "lineBegin": 133,
             "columnBegin": 21,
-            "lineEnd": 120,
+            "lineEnd": 133,
             "columnEnd": 25
           }
         }
@@ -3712,104 +3452,104 @@
     "key": {
       "symbol": {
         "key": "scip-python python python-stdlib 3.11 turtle/TPen#speed()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 31,
-            "columnBegin": 6,
-            "lineEnd": 31,
-            "columnEnd": 10
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/TPen#speed()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 38,
-            "columnBegin": 5,
-            "lineEnd": 38,
-            "columnEnd": 9
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/TPen#speed()."
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 117,
-            "columnBegin": 21,
-            "lineEnd": 117,
-            "columnEnd": 25
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/Turtle#"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 20,
-            "columnBegin": 15,
-            "lineEnd": 20,
-            "columnEnd": 20
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/Turtle#"
-      },
-      "location": {
-        "key": {
-          "file": { "key": "example.py" },
-          "range": {
-            "lineBegin": 28,
-            "columnBegin": 15,
-            "lineEnd": 28,
-            "columnEnd": 20
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "symbol": {
-        "key": "scip-python python python-stdlib 3.11 turtle/Turtle#"
       },
       "location": {
         "key": {
           "file": { "key": "example.py" },
           "range": {
             "lineBegin": 37,
-            "columnBegin": 14,
+            "columnBegin": 6,
             "lineEnd": 37,
+            "columnEnd": 10
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/TPen#speed()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 44,
+            "columnBegin": 5,
+            "lineEnd": 44,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/TPen#speed()."
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 130,
+            "columnBegin": 21,
+            "lineEnd": 130,
+            "columnEnd": 25
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/Turtle#"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 26,
+            "columnBegin": 15,
+            "lineEnd": 26,
+            "columnEnd": 20
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/Turtle#"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 34,
+            "columnBegin": 15,
+            "lineEnd": 34,
+            "columnEnd": 20
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": {
+        "key": "scip-python python python-stdlib 3.11 turtle/Turtle#"
+      },
+      "location": {
+        "key": {
+          "file": { "key": "example.py" },
+          "range": {
+            "lineBegin": 43,
+            "columnBegin": 14,
+            "lineEnd": 43,
             "columnEnd": 19
           }
         }
@@ -3825,9 +3565,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 116,
+            "lineBegin": 129,
             "columnBegin": 30,
-            "lineEnd": 116,
+            "lineEnd": 129,
             "columnEnd": 35
           }
         }
@@ -3843,9 +3583,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 14,
+            "lineBegin": 20,
             "columnBegin": 4,
-            "lineEnd": 14,
+            "lineEnd": 20,
             "columnEnd": 10
           }
         }
@@ -3861,9 +3601,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 84,
+            "lineBegin": 89,
             "columnBegin": 4,
-            "lineEnd": 84,
+            "lineEnd": 89,
             "columnEnd": 9
           }
         }
@@ -3879,9 +3619,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 85,
+            "lineBegin": 90,
             "columnBegin": 4,
-            "lineEnd": 85,
+            "lineEnd": 90,
             "columnEnd": 13
           }
         }
@@ -3897,9 +3637,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 86,
+            "lineBegin": 91,
             "columnBegin": 4,
-            "lineEnd": 86,
+            "lineEnd": 91,
             "columnEnd": 13
           }
         }
@@ -3915,9 +3655,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 87,
+            "lineBegin": 92,
             "columnBegin": 4,
-            "lineEnd": 87,
+            "lineEnd": 92,
             "columnEnd": 13
           }
         }
@@ -3933,9 +3673,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 88,
+            "lineBegin": 93,
             "columnBegin": 4,
-            "lineEnd": 88,
+            "lineEnd": 93,
             "columnEnd": 13
           }
         }
@@ -3951,9 +3691,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 17,
+            "lineBegin": 23,
             "columnBegin": 4,
-            "lineEnd": 17,
+            "lineEnd": 23,
             "columnEnd": 9
           }
         }
@@ -3969,9 +3709,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 95,
+            "lineBegin": 100,
             "columnBegin": 8,
-            "lineEnd": 95,
+            "lineEnd": 100,
             "columnEnd": 13
           }
         }
@@ -3987,9 +3727,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 16,
+            "lineBegin": 22,
             "columnBegin": 4,
-            "lineEnd": 16,
+            "lineEnd": 22,
             "columnEnd": 8
           }
         }
@@ -4005,9 +3745,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 16,
+            "lineBegin": 22,
             "columnBegin": 21,
-            "lineEnd": 16,
+            "lineEnd": 22,
             "columnEnd": 26
           }
         }
@@ -4023,9 +3763,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 16,
+            "lineBegin": 22,
             "columnBegin": 10,
-            "lineEnd": 16,
+            "lineEnd": 22,
             "columnEnd": 14
           }
         }
@@ -4041,9 +3781,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 13,
+            "lineBegin": 19,
             "columnBegin": 4,
-            "lineEnd": 13,
+            "lineEnd": 19,
             "columnEnd": 8
           }
         }
@@ -4059,9 +3799,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 2,
+            "lineBegin": 10,
             "columnBegin": 8,
-            "lineEnd": 2,
+            "lineEnd": 10,
             "columnEnd": 13
           }
         }
@@ -4077,9 +3817,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 12,
+            "lineBegin": 18,
             "columnBegin": 6,
-            "lineEnd": 12,
+            "lineEnd": 18,
             "columnEnd": 11
           }
         }
@@ -4095,9 +3835,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 20,
+            "lineBegin": 26,
             "columnBegin": 8,
-            "lineEnd": 20,
+            "lineEnd": 26,
             "columnEnd": 13
           }
         }
@@ -4113,9 +3853,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 28,
+            "lineBegin": 34,
             "columnBegin": 8,
-            "lineEnd": 28,
+            "lineEnd": 34,
             "columnEnd": 13
           }
         }
@@ -4131,9 +3871,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 37,
+            "lineBegin": 43,
             "columnBegin": 7,
-            "lineEnd": 37,
+            "lineEnd": 43,
             "columnEnd": 12
           }
         }
@@ -4149,9 +3889,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 116,
+            "lineBegin": 129,
             "columnBegin": 23,
-            "lineEnd": 116,
+            "lineEnd": 129,
             "columnEnd": 28
           }
         }
@@ -4167,9 +3907,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 104,
+            "lineBegin": 114,
             "columnBegin": 18,
-            "lineEnd": 104,
+            "lineEnd": 114,
             "columnEnd": 22
           }
         }
@@ -4185,9 +3925,9 @@
         "key": {
           "file": { "key": "example.py" },
           "range": {
-            "lineBegin": 148,
+            "lineBegin": 164,
             "columnBegin": 22,
-            "lineEnd": 148,
+            "lineEnd": 164,
             "columnEnd": 26
           }
         }

--- a/glean/lang/python-scip/tests/cases/xrefs/ReferenceLocation.out
+++ b/glean/lang/python-scip/tests/cases/xrefs/ReferenceLocation.out
@@ -4,67 +4,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 2,
+        "lineBegin": 8,
         "columnBegin": 8,
-        "lineEnd": 2,
-        "columnEnd": 13
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 2,
-                "columnBegin": 8,
-                "lineEnd": 2,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 3,
-        "columnBegin": 8,
-        "lineEnd": 3,
-        "columnEnd": 11
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 time/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 3,
-                "columnBegin": 8,
-                "lineEnd": 3,
-                "columnEnd": 11
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 4,
-        "columnBegin": 8,
-        "lineEnd": 4,
+        "lineEnd": 8,
         "columnEnd": 13
       },
       "xref": {
@@ -76,9 +18,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 4,
+                "lineBegin": 8,
                 "columnBegin": 8,
-                "lineEnd": 4,
+                "lineEnd": 8,
                 "columnEnd": 13
               }
             }
@@ -91,23 +33,23 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 12,
-        "columnBegin": 6,
-        "lineEnd": 12,
+        "lineBegin": 9,
+        "columnBegin": 8,
+        "lineEnd": 9,
         "columnEnd": 11
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/__init__:"
+            "key": "scip-python python python-stdlib 3.11 time/__init__:"
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 12,
-                "columnBegin": 6,
-                "lineEnd": 12,
+                "lineBegin": 9,
+                "columnBegin": 8,
+                "lineEnd": 9,
                 "columnEnd": 11
               }
             }
@@ -120,9 +62,67 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 12,
+        "lineBegin": 10,
+        "columnBegin": 8,
+        "lineEnd": 10,
+        "columnEnd": 13
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/__init__:"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 10,
+                "columnBegin": 8,
+                "lineEnd": 10,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 18,
+        "columnBegin": 6,
+        "lineEnd": 18,
+        "columnEnd": 11
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/__init__:"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 18,
+                "columnBegin": 6,
+                "lineEnd": 18,
+                "columnEnd": 11
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 18,
         "columnBegin": 13,
-        "lineEnd": 12,
+        "lineEnd": 18,
         "columnEnd": 18
       },
       "xref": {
@@ -134,9 +134,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 12,
+                "lineBegin": 18,
                 "columnBegin": 13,
-                "lineEnd": 12,
+                "lineEnd": 18,
                 "columnEnd": 18
               }
             }
@@ -149,23 +149,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 13,
+        "lineBegin": 19,
         "columnBegin": 1,
-        "lineEnd": 13,
+        "lineEnd": 19,
         "columnEnd": 2
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-          },
+          "symbol": { "key": "scip-python python . test example/wn." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 13,
+                "lineBegin": 19,
                 "columnBegin": 1,
-                "lineEnd": 13,
+                "lineEnd": 19,
                 "columnEnd": 2
               }
             }
@@ -178,9 +176,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 13,
+        "lineBegin": 19,
         "columnBegin": 4,
-        "lineEnd": 13,
+        "lineEnd": 19,
         "columnEnd": 8
       },
       "xref": {
@@ -192,9 +190,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 13,
+                "lineBegin": 19,
                 "columnBegin": 4,
-                "lineEnd": 13,
+                "lineEnd": 19,
                 "columnEnd": 8
               }
             }
@@ -207,23 +205,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 14,
+        "lineBegin": 20,
         "columnBegin": 1,
-        "lineEnd": 14,
+        "lineEnd": 20,
         "columnEnd": 2
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-          },
+          "symbol": { "key": "scip-python python . test example/wn." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 14,
+                "lineBegin": 20,
                 "columnBegin": 1,
-                "lineEnd": 14,
+                "lineEnd": 20,
                 "columnEnd": 2
               }
             }
@@ -236,9 +232,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 14,
+        "lineBegin": 20,
         "columnBegin": 4,
-        "lineEnd": 14,
+        "lineEnd": 20,
         "columnEnd": 10
       },
       "xref": {
@@ -250,9 +246,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 14,
+                "lineBegin": 20,
                 "columnBegin": 4,
-                "lineEnd": 14,
+                "lineEnd": 20,
                 "columnEnd": 10
               }
             }
@@ -265,23 +261,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 16,
+        "lineBegin": 22,
         "columnBegin": 1,
-        "lineEnd": 16,
+        "lineEnd": 22,
         "columnEnd": 2
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-          },
+          "symbol": { "key": "scip-python python . test example/wn." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 16,
+                "lineBegin": 22,
                 "columnBegin": 1,
-                "lineEnd": 16,
+                "lineEnd": 22,
                 "columnEnd": 2
               }
             }
@@ -294,9 +288,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 16,
+        "lineBegin": 22,
         "columnBegin": 4,
-        "lineEnd": 16,
+        "lineEnd": 22,
         "columnEnd": 8
       },
       "xref": {
@@ -308,9 +302,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 16,
+                "lineBegin": 22,
                 "columnBegin": 4,
-                "lineEnd": 16,
+                "lineEnd": 22,
                 "columnEnd": 8
               }
             }
@@ -323,9 +317,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 16,
+        "lineBegin": 22,
         "columnBegin": 10,
-        "lineEnd": 16,
+        "lineEnd": 22,
         "columnEnd": 14
       },
       "xref": {
@@ -337,9 +331,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 16,
+                "lineBegin": 22,
                 "columnBegin": 10,
-                "lineEnd": 16,
+                "lineEnd": 22,
                 "columnEnd": 14
               }
             }
@@ -352,9 +346,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 16,
+        "lineBegin": 22,
         "columnBegin": 21,
-        "lineEnd": 16,
+        "lineEnd": 22,
         "columnEnd": 26
       },
       "xref": {
@@ -366,9 +360,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 16,
+                "lineBegin": 22,
                 "columnBegin": 21,
-                "lineEnd": 16,
+                "lineEnd": 22,
                 "columnEnd": 26
               }
             }
@@ -381,23 +375,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 17,
+        "lineBegin": 23,
         "columnBegin": 1,
-        "lineEnd": 17,
+        "lineEnd": 23,
         "columnEnd": 2
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-          },
+          "symbol": { "key": "scip-python python . test example/wn." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 17,
+                "lineBegin": 23,
                 "columnBegin": 1,
-                "lineEnd": 17,
+                "lineEnd": 23,
                 "columnEnd": 2
               }
             }
@@ -410,9 +402,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 17,
+        "lineBegin": 23,
         "columnBegin": 4,
-        "lineEnd": 17,
+        "lineEnd": 23,
         "columnEnd": 9
       },
       "xref": {
@@ -424,9 +416,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 17,
+                "lineBegin": 23,
                 "columnBegin": 4,
-                "lineEnd": 17,
+                "lineEnd": 23,
                 "columnEnd": 9
               }
             }
@@ -439,9 +431,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 20,
+        "lineBegin": 26,
         "columnBegin": 8,
-        "lineEnd": 20,
+        "lineEnd": 26,
         "columnEnd": 13
       },
       "xref": {
@@ -453,9 +445,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 20,
+                "lineBegin": 26,
                 "columnBegin": 8,
-                "lineEnd": 20,
+                "lineEnd": 26,
                 "columnEnd": 13
               }
             }
@@ -468,9 +460,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 20,
+        "lineBegin": 26,
         "columnBegin": 15,
-        "lineEnd": 20,
+        "lineEnd": 26,
         "columnEnd": 20
       },
       "xref": {
@@ -482,9 +474,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 20,
+                "lineBegin": 26,
                 "columnBegin": 15,
-                "lineEnd": 20,
+                "lineEnd": 26,
                 "columnEnd": 20
               }
             }
@@ -497,23 +489,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 21,
+        "lineBegin": 27,
         "columnBegin": 1,
-        "lineEnd": 21,
+        "lineEnd": 27,
         "columnEnd": 4
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 21,
+                "lineBegin": 27,
                 "columnBegin": 1,
-                "lineEnd": 21,
+                "lineEnd": 27,
                 "columnEnd": 4
               }
             }
@@ -526,9 +516,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 21,
+        "lineBegin": 27,
         "columnBegin": 6,
-        "lineEnd": 21,
+        "lineEnd": 27,
         "columnEnd": 10
       },
       "xref": {
@@ -540,9 +530,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 21,
+                "lineBegin": 27,
                 "columnBegin": 6,
-                "lineEnd": 21,
+                "lineEnd": 27,
                 "columnEnd": 10
               }
             }
@@ -555,23 +545,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 22,
+        "lineBegin": 28,
         "columnBegin": 1,
-        "lineEnd": 22,
+        "lineEnd": 28,
         "columnEnd": 4
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 22,
+                "lineBegin": 28,
                 "columnBegin": 1,
-                "lineEnd": 22,
+                "lineEnd": 28,
                 "columnEnd": 4
               }
             }
@@ -584,9 +572,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 22,
+        "lineBegin": 28,
         "columnBegin": 6,
-        "lineEnd": 22,
+        "lineEnd": 28,
         "columnEnd": 10
       },
       "xref": {
@@ -598,9 +586,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 22,
+                "lineBegin": 28,
                 "columnBegin": 6,
-                "lineEnd": 22,
+                "lineEnd": 28,
                 "columnEnd": 10
               }
             }
@@ -613,23 +601,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 23,
+        "lineBegin": 29,
         "columnBegin": 1,
-        "lineEnd": 23,
+        "lineEnd": 29,
         "columnEnd": 4
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 23,
+                "lineBegin": 29,
                 "columnBegin": 1,
-                "lineEnd": 23,
+                "lineEnd": 29,
                 "columnEnd": 4
               }
             }
@@ -642,9 +628,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 23,
+        "lineBegin": 29,
         "columnBegin": 6,
-        "lineEnd": 23,
+        "lineEnd": 29,
         "columnEnd": 10
       },
       "xref": {
@@ -656,9 +642,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 23,
+                "lineBegin": 29,
                 "columnBegin": 6,
-                "lineEnd": 23,
+                "lineEnd": 29,
                 "columnEnd": 10
               }
             }
@@ -671,23 +657,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 24,
+        "lineBegin": 30,
         "columnBegin": 1,
-        "lineEnd": 24,
+        "lineEnd": 30,
         "columnEnd": 4
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 24,
+                "lineBegin": 30,
                 "columnBegin": 1,
-                "lineEnd": 24,
+                "lineEnd": 30,
                 "columnEnd": 4
               }
             }
@@ -700,9 +684,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 24,
+        "lineBegin": 30,
         "columnBegin": 6,
-        "lineEnd": 24,
+        "lineEnd": 30,
         "columnEnd": 9
       },
       "xref": {
@@ -714,213 +698,10 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 24,
+                "lineBegin": 30,
                 "columnBegin": 6,
-                "lineEnd": 24,
+                "lineEnd": 30,
                 "columnEnd": 9
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 25,
-        "columnBegin": 1,
-        "lineEnd": 25,
-        "columnEnd": 4
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 25,
-                "columnBegin": 1,
-                "lineEnd": 25,
-                "columnEnd": 4
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 28,
-        "columnBegin": 8,
-        "lineEnd": 28,
-        "columnEnd": 13
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 28,
-                "columnBegin": 8,
-                "lineEnd": 28,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 28,
-        "columnBegin": 15,
-        "lineEnd": 28,
-        "columnEnd": 20
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/Turtle#"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 28,
-                "columnBegin": 15,
-                "lineEnd": 28,
-                "columnEnd": 20
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 29,
-        "columnBegin": 10,
-        "lineEnd": 29,
-        "columnEnd": 15
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 29,
-                "columnBegin": 10,
-                "lineEnd": 29,
-                "columnEnd": 15
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 29,
-        "columnBegin": 17,
-        "lineEnd": 29,
-        "columnEnd": 22
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/choice."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 29,
-                "columnBegin": 17,
-                "lineEnd": 29,
-                "columnEnd": 22
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 30,
-        "columnBegin": 10,
-        "lineEnd": 30,
-        "columnEnd": 15
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 30,
-                "columnBegin": 10,
-                "lineEnd": 30,
-                "columnEnd": 15
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 30,
-        "columnBegin": 17,
-        "lineEnd": 30,
-        "columnEnd": 22
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/choice."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 30,
-                "columnBegin": 17,
-                "lineEnd": 30,
-                "columnEnd": 22
               }
             }
           }
@@ -939,9 +720,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -961,198 +740,24 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 31,
-        "columnBegin": 6,
-        "lineEnd": 31,
-        "columnEnd": 10
+        "lineBegin": 34,
+        "columnBegin": 8,
+        "lineEnd": 34,
+        "columnEnd": 13
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TPen#speed()."
+            "key": "scip-python python python-stdlib 3.11 turtle/__init__:"
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 31,
-                "columnBegin": 6,
-                "lineEnd": 31,
-                "columnEnd": 10
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 32,
-        "columnBegin": 1,
-        "lineEnd": 32,
-        "columnEnd": 4
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 32,
-                "columnBegin": 1,
-                "lineEnd": 32,
-                "columnEnd": 4
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 32,
-        "columnBegin": 6,
-        "lineEnd": 32,
-        "columnEnd": 10
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 32,
-                "columnBegin": 6,
-                "lineEnd": 32,
-                "columnEnd": 10
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 32,
-        "columnBegin": 12,
-        "lineEnd": 32,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 32,
-                "columnBegin": 12,
-                "lineEnd": 32,
-                "columnEnd": 17
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 33,
-        "columnBegin": 1,
-        "lineEnd": 33,
-        "columnEnd": 4
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 33,
-                "columnBegin": 1,
-                "lineEnd": 33,
-                "columnEnd": 4
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 33,
-        "columnBegin": 6,
-        "lineEnd": 33,
-        "columnEnd": 10
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TPen#color()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 33,
-                "columnBegin": 6,
-                "lineEnd": 33,
-                "columnEnd": 10
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 33,
-        "columnBegin": 12,
-        "lineEnd": 33,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 33,
-                "columnBegin": 12,
-                "lineEnd": 33,
-                "columnEnd": 17
+                "lineBegin": 34,
+                "columnBegin": 8,
+                "lineEnd": 34,
+                "columnEnd": 13
               }
             }
           }
@@ -1165,52 +770,23 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 34,
-        "columnBegin": 1,
+        "columnBegin": 15,
         "lineEnd": 34,
-        "columnEnd": 4
+        "columnEnd": 20
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
+            "key": "scip-python python python-stdlib 3.11 turtle/Turtle#"
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 34,
-                "columnBegin": 1,
+                "columnBegin": 15,
                 "lineEnd": 34,
-                "columnEnd": 4
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 34,
-        "columnBegin": 6,
-        "lineEnd": 34,
-        "columnEnd": 10
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TPen#penup()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 34,
-                "columnBegin": 6,
-                "lineEnd": 34,
-                "columnEnd": 10
+                "columnEnd": 20
               }
             }
           }
@@ -1223,23 +799,23 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 35,
-        "columnBegin": 1,
+        "columnBegin": 10,
         "lineEnd": 35,
-        "columnEnd": 4
+        "columnEnd": 15
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
+            "key": "scip-python python python-stdlib 3.11 random/__init__:"
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 35,
-                "columnBegin": 1,
+                "columnBegin": 10,
                 "lineEnd": 35,
-                "columnEnd": 4
+                "columnEnd": 15
               }
             }
           }
@@ -1252,23 +828,81 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 35,
-        "columnBegin": 6,
+        "columnBegin": 17,
         "lineEnd": 35,
-        "columnEnd": 9
+        "columnEnd": 22
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#goto()."
+            "key": "scip-python python python-stdlib 3.11 random/choice."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 35,
-                "columnBegin": 6,
+                "columnBegin": 17,
                 "lineEnd": 35,
-                "columnEnd": 9
+                "columnEnd": 22
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 10,
+        "lineEnd": 36,
+        "columnEnd": 15
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 random/__init__:"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 36,
+                "columnBegin": 10,
+                "lineEnd": 36,
+                "columnEnd": 15
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 36,
+        "columnBegin": 17,
+        "lineEnd": 36,
+        "columnEnd": 22
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 random/choice."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 36,
+                "columnBegin": 17,
+                "lineEnd": 36,
+                "columnEnd": 22
               }
             }
           }
@@ -1281,8 +915,342 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 37,
-        "columnBegin": 7,
+        "columnBegin": 1,
         "lineEnd": 37,
+        "columnEnd": 4
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/food." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 37,
+                "columnBegin": 1,
+                "lineEnd": 37,
+                "columnEnd": 4
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 37,
+        "columnBegin": 6,
+        "lineEnd": 37,
+        "columnEnd": 10
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TPen#speed()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 37,
+                "columnBegin": 6,
+                "lineEnd": 37,
+                "columnEnd": 10
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 38,
+        "columnBegin": 1,
+        "lineEnd": 38,
+        "columnEnd": 4
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/food." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 38,
+                "columnBegin": 1,
+                "lineEnd": 38,
+                "columnEnd": 4
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 38,
+        "columnBegin": 6,
+        "lineEnd": 38,
+        "columnEnd": 10
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 38,
+                "columnBegin": 6,
+                "lineEnd": 38,
+                "columnEnd": 10
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 38,
+        "columnBegin": 12,
+        "lineEnd": 38,
+        "columnEnd": 17
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/shapes." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 38,
+                "columnBegin": 12,
+                "lineEnd": 38,
+                "columnEnd": 17
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 1,
+        "lineEnd": 39,
+        "columnEnd": 4
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/food." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 39,
+                "columnBegin": 1,
+                "lineEnd": 39,
+                "columnEnd": 4
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 6,
+        "lineEnd": 39,
+        "columnEnd": 10
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TPen#color()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 39,
+                "columnBegin": 6,
+                "lineEnd": 39,
+                "columnEnd": 10
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 39,
+        "columnBegin": 12,
+        "lineEnd": 39,
+        "columnEnd": 17
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/colors." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 39,
+                "columnBegin": 12,
+                "lineEnd": 39,
+                "columnEnd": 17
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 40,
+        "columnBegin": 1,
+        "lineEnd": 40,
+        "columnEnd": 4
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/food." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 40,
+                "columnBegin": 1,
+                "lineEnd": 40,
+                "columnEnd": 4
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 40,
+        "columnBegin": 6,
+        "lineEnd": 40,
+        "columnEnd": 10
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TPen#penup()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 40,
+                "columnBegin": 6,
+                "lineEnd": 40,
+                "columnEnd": 10
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 41,
+        "columnBegin": 1,
+        "lineEnd": 41,
+        "columnEnd": 4
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/food." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 41,
+                "columnBegin": 1,
+                "lineEnd": 41,
+                "columnEnd": 4
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 41,
+        "columnBegin": 6,
+        "lineEnd": 41,
+        "columnEnd": 9
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#goto()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 41,
+                "columnBegin": 6,
+                "lineEnd": 41,
+                "columnEnd": 9
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 43,
+        "columnBegin": 7,
+        "lineEnd": 43,
         "columnEnd": 12
       },
       "xref": {
@@ -1294,9 +1262,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 37,
+                "lineBegin": 43,
                 "columnBegin": 7,
-                "lineEnd": 37,
+                "lineEnd": 43,
                 "columnEnd": 12
               }
             }
@@ -1309,9 +1277,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 37,
+        "lineBegin": 43,
         "columnBegin": 14,
-        "lineEnd": 37,
+        "lineEnd": 43,
         "columnEnd": 19
       },
       "xref": {
@@ -1323,9 +1291,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 37,
+                "lineBegin": 43,
                 "columnBegin": 14,
-                "lineEnd": 37,
+                "lineEnd": 43,
                 "columnEnd": 19
               }
             }
@@ -1338,23 +1306,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 38,
+        "lineBegin": 44,
         "columnBegin": 1,
-        "lineEnd": 38,
+        "lineEnd": 44,
         "columnEnd": 3
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
+          "symbol": { "key": "scip-python python . test example/pen." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 38,
+                "lineBegin": 44,
                 "columnBegin": 1,
-                "lineEnd": 38,
+                "lineEnd": 44,
                 "columnEnd": 3
               }
             }
@@ -1367,9 +1333,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 38,
+        "lineBegin": 44,
         "columnBegin": 5,
-        "lineEnd": 38,
+        "lineEnd": 44,
         "columnEnd": 9
       },
       "xref": {
@@ -1381,387 +1347,10 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 38,
-                "columnBegin": 5,
-                "lineEnd": 38,
-                "columnEnd": 9
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 39,
-        "columnBegin": 1,
-        "lineEnd": 39,
-        "columnEnd": 3
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 39,
-                "columnBegin": 1,
-                "lineEnd": 39,
-                "columnEnd": 3
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 39,
-        "columnBegin": 5,
-        "lineEnd": 39,
-        "columnEnd": 9
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 39,
-                "columnBegin": 5,
-                "lineEnd": 39,
-                "columnEnd": 9
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 40,
-        "columnBegin": 1,
-        "lineEnd": 40,
-        "columnEnd": 3
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 40,
-                "columnBegin": 1,
-                "lineEnd": 40,
-                "columnEnd": 3
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 40,
-        "columnBegin": 5,
-        "lineEnd": 40,
-        "columnEnd": 9
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TPen#color()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 40,
-                "columnBegin": 5,
-                "lineEnd": 40,
-                "columnEnd": 9
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 41,
-        "columnBegin": 1,
-        "lineEnd": 41,
-        "columnEnd": 3
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 41,
-                "columnBegin": 1,
-                "lineEnd": 41,
-                "columnEnd": 3
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 41,
-        "columnBegin": 5,
-        "lineEnd": 41,
-        "columnEnd": 9
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TPen#penup()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 41,
-                "columnBegin": 5,
-                "lineEnd": 41,
-                "columnEnd": 9
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 42,
-        "columnBegin": 1,
-        "lineEnd": 42,
-        "columnEnd": 3
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 42,
-                "columnBegin": 1,
-                "lineEnd": 42,
-                "columnEnd": 3
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 42,
-        "columnBegin": 5,
-        "lineEnd": 42,
-        "columnEnd": 14
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TPen#hideturtle()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 42,
-                "columnBegin": 5,
-                "lineEnd": 42,
-                "columnEnd": 14
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 43,
-        "columnBegin": 1,
-        "lineEnd": 43,
-        "columnEnd": 3
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 43,
-                "columnBegin": 1,
-                "lineEnd": 43,
-                "columnEnd": 3
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 43,
-        "columnBegin": 5,
-        "lineEnd": 43,
-        "columnEnd": 8
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#goto()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 43,
-                "columnBegin": 5,
-                "lineEnd": 43,
-                "columnEnd": 8
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 44,
-        "columnBegin": 1,
-        "lineEnd": 44,
-        "columnEnd": 3
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 44,
-                "columnBegin": 1,
-                "lineEnd": 44,
-                "columnEnd": 3
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 44,
-        "columnBegin": 5,
-        "lineEnd": 44,
-        "columnEnd": 9
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
                 "lineBegin": 44,
                 "columnBegin": 5,
                 "lineEnd": 44,
                 "columnEnd": 9
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 44,
-        "columnBegin": 40,
-        "lineEnd": 44,
-        "columnEnd": 44
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 44,
-                "columnBegin": 40,
-                "lineEnd": 44,
-                "columnEnd": 44
               }
             }
           }
@@ -1774,22 +1363,217 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 45,
-        "columnBegin": 11,
+        "columnBegin": 1,
         "lineEnd": 45,
-        "columnEnd": 14
+        "columnEnd": 3
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/pen." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 45,
+                "columnBegin": 1,
+                "lineEnd": 45,
+                "columnEnd": 3
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 45,
+        "columnBegin": 5,
+        "lineEnd": 45,
+        "columnEnd": 9
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 45,
-                "columnBegin": 11,
+                "columnBegin": 5,
                 "lineEnd": 45,
+                "columnEnd": 9
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 46,
+        "columnBegin": 1,
+        "lineEnd": 46,
+        "columnEnd": 3
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/pen." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 46,
+                "columnBegin": 1,
+                "lineEnd": 46,
+                "columnEnd": 3
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 46,
+        "columnBegin": 5,
+        "lineEnd": 46,
+        "columnEnd": 9
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TPen#color()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 46,
+                "columnBegin": 5,
+                "lineEnd": 46,
+                "columnEnd": 9
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 47,
+        "columnBegin": 1,
+        "lineEnd": 47,
+        "columnEnd": 3
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/pen." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 47,
+                "columnBegin": 1,
+                "lineEnd": 47,
+                "columnEnd": 3
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 47,
+        "columnBegin": 5,
+        "lineEnd": 47,
+        "columnEnd": 9
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TPen#penup()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 47,
+                "columnBegin": 5,
+                "lineEnd": 47,
+                "columnEnd": 9
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 48,
+        "columnBegin": 1,
+        "lineEnd": 48,
+        "columnEnd": 3
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/pen." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 48,
+                "columnBegin": 1,
+                "lineEnd": 48,
+                "columnEnd": 3
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 48,
+        "columnBegin": 5,
+        "lineEnd": 48,
+        "columnEnd": 14
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TPen#hideturtle()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 48,
+                "columnBegin": 5,
+                "lineEnd": 48,
                 "columnEnd": 14
               }
             }
@@ -1802,24 +1586,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 50,
-        "columnBegin": 8,
-        "lineEnd": 50,
-        "columnEnd": 11
+        "lineBegin": 49,
+        "columnBegin": 1,
+        "lineEnd": 49,
+        "columnEnd": 3
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/pen." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 50,
-                "columnBegin": 8,
-                "lineEnd": 50,
-                "columnEnd": 11
+                "lineBegin": 49,
+                "columnBegin": 1,
+                "lineEnd": 49,
+                "columnEnd": 3
               }
             }
           }
@@ -1831,24 +1613,138 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 51,
-        "columnBegin": 9,
-        "lineEnd": 51,
-        "columnEnd": 12
+        "lineBegin": 49,
+        "columnBegin": 5,
+        "lineEnd": 49,
+        "columnEnd": 8
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#goto()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 51,
-                "columnBegin": 9,
-                "lineEnd": 51,
-                "columnEnd": 12
+                "lineBegin": 49,
+                "columnBegin": 5,
+                "lineEnd": 49,
+                "columnEnd": 8
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 50,
+        "columnBegin": 1,
+        "lineEnd": 50,
+        "columnEnd": 3
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/pen." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 50,
+                "columnBegin": 1,
+                "lineEnd": 50,
+                "columnEnd": 3
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 50,
+        "columnBegin": 5,
+        "lineEnd": 50,
+        "columnEnd": 9
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 50,
+                "columnBegin": 5,
+                "lineEnd": 50,
+                "columnEnd": 9
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 50,
+        "columnBegin": 40,
+        "lineEnd": 50,
+        "columnEnd": 44
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 50,
+                "columnBegin": 40,
+                "lineEnd": 50,
+                "columnEnd": 44
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 50,
+        "columnBegin": 56,
+        "lineEnd": 50,
+        "columnEnd": 59
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 50,
+                "columnBegin": 56,
+                "lineEnd": 50,
+                "columnEnd": 59
               }
             }
           }
@@ -1867,9 +1763,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -1896,9 +1790,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -1925,9 +1817,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -1954,9 +1844,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -1983,9 +1871,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -2012,9 +1898,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -2041,9 +1925,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -2064,80 +1946,20 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 71,
-        "columnBegin": 13,
-        "lineEnd": 71,
-        "columnEnd": 16
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 71,
-                "columnBegin": 13,
-                "lineEnd": 71,
-                "columnEnd": 16
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 71,
-        "columnBegin": 18,
-        "lineEnd": 71,
-        "columnEnd": 21
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#ycor()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 71,
-                "columnBegin": 18,
-                "lineEnd": 71,
-                "columnEnd": 21
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 72,
         "columnBegin": 9,
-        "lineEnd": 72,
+        "lineEnd": 71,
         "columnEnd": 12
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 72,
+                "lineBegin": 71,
                 "columnBegin": 9,
-                "lineEnd": 72,
+                "lineEnd": 71,
                 "columnEnd": 12
               }
             }
@@ -2150,169 +1972,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 72,
-        "columnBegin": 14,
-        "lineEnd": 72,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#sety()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 72,
-                "columnBegin": 14,
-                "lineEnd": 72,
-                "columnEnd": 17
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 73,
+        "lineBegin": 75,
         "columnBegin": 8,
-        "lineEnd": 73,
+        "lineEnd": 75,
         "columnEnd": 11
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 73,
+                "lineBegin": 75,
                 "columnBegin": 8,
-                "lineEnd": 73,
+                "lineEnd": 75,
                 "columnEnd": 11
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 74,
-        "columnBegin": 13,
-        "lineEnd": 74,
-        "columnEnd": 16
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 74,
-                "columnBegin": 13,
-                "lineEnd": 74,
-                "columnEnd": 16
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 74,
-        "columnBegin": 18,
-        "lineEnd": 74,
-        "columnEnd": 21
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#ycor()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 74,
-                "columnBegin": 18,
-                "lineEnd": 74,
-                "columnEnd": 21
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 75,
-        "columnBegin": 9,
-        "lineEnd": 75,
-        "columnEnd": 12
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 75,
-                "columnBegin": 9,
-                "lineEnd": 75,
-                "columnEnd": 12
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 75,
-        "columnBegin": 14,
-        "lineEnd": 75,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#sety()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 75,
-                "columnBegin": 14,
-                "lineEnd": 75,
-                "columnEnd": 17
               }
             }
           }
@@ -2325,51 +2000,20 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 76,
-        "columnBegin": 8,
+        "columnBegin": 13,
         "lineEnd": 76,
-        "columnEnd": 11
+        "columnEnd": 16
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 76,
-                "columnBegin": 8,
-                "lineEnd": 76,
-                "columnEnd": 11
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 77,
-        "columnBegin": 13,
-        "lineEnd": 77,
-        "columnEnd": 16
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 77,
                 "columnBegin": 13,
-                "lineEnd": 77,
+                "lineEnd": 76,
                 "columnEnd": 16
               }
             }
@@ -2382,23 +2026,23 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 77,
+        "lineBegin": 76,
         "columnBegin": 18,
-        "lineEnd": 77,
+        "lineEnd": 76,
         "columnEnd": 21
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#ycor()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 77,
+                "lineBegin": 76,
                 "columnBegin": 18,
-                "lineEnd": 77,
+                "lineEnd": 76,
                 "columnEnd": 21
               }
             }
@@ -2411,23 +2055,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 78,
+        "lineBegin": 77,
         "columnBegin": 9,
-        "lineEnd": 78,
+        "lineEnd": 77,
         "columnEnd": 12
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 78,
+                "lineBegin": 77,
                 "columnBegin": 9,
-                "lineEnd": 78,
+                "lineEnd": 77,
                 "columnEnd": 12
               }
             }
@@ -2440,24 +2082,51 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 78,
+        "lineBegin": 77,
         "columnBegin": 14,
-        "lineEnd": 78,
+        "lineEnd": 77,
         "columnEnd": 17
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#setx()."
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#sety()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 78,
+                "lineBegin": 77,
                 "columnBegin": 14,
-                "lineEnd": 78,
+                "lineEnd": 77,
                 "columnEnd": 17
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 78,
+        "columnBegin": 8,
+        "lineEnd": 78,
+        "columnEnd": 11
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/head." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 78,
+                "columnBegin": 8,
+                "lineEnd": 78,
+                "columnEnd": 11
               }
             }
           }
@@ -2470,51 +2139,20 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 79,
-        "columnBegin": 8,
+        "columnBegin": 13,
         "lineEnd": 79,
-        "columnEnd": 11
+        "columnEnd": 16
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 79,
-                "columnBegin": 8,
-                "lineEnd": 79,
-                "columnEnd": 11
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 80,
-        "columnBegin": 13,
-        "lineEnd": 80,
-        "columnEnd": 16
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 80,
                 "columnBegin": 13,
-                "lineEnd": 80,
+                "lineEnd": 79,
                 "columnEnd": 16
               }
             }
@@ -2527,23 +2165,23 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 80,
+        "lineBegin": 79,
         "columnBegin": 18,
-        "lineEnd": 80,
+        "lineEnd": 79,
         "columnEnd": 21
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#ycor()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 80,
+                "lineBegin": 79,
                 "columnBegin": 18,
-                "lineEnd": 80,
+                "lineEnd": 79,
                 "columnEnd": 21
               }
             }
@@ -2556,23 +2194,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 81,
+        "lineBegin": 80,
         "columnBegin": 9,
-        "lineEnd": 81,
+        "lineEnd": 80,
         "columnEnd": 12
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 81,
+                "lineBegin": 80,
                 "columnBegin": 9,
-                "lineEnd": 81,
+                "lineEnd": 80,
                 "columnEnd": 12
               }
             }
@@ -2585,9 +2221,148 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 81,
+        "lineBegin": 80,
         "columnBegin": 14,
+        "lineEnd": 80,
+        "columnEnd": 17
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#sety()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 80,
+                "columnBegin": 14,
+                "lineEnd": 80,
+                "columnEnd": 17
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 81,
+        "columnBegin": 8,
         "lineEnd": 81,
+        "columnEnd": 11
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/head." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 81,
+                "columnBegin": 8,
+                "lineEnd": 81,
+                "columnEnd": 11
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 82,
+        "columnBegin": 13,
+        "lineEnd": 82,
+        "columnEnd": 16
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/head." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 82,
+                "columnBegin": 13,
+                "lineEnd": 82,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 82,
+        "columnBegin": 18,
+        "lineEnd": 82,
+        "columnEnd": 21
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 82,
+                "columnBegin": 18,
+                "lineEnd": 82,
+                "columnEnd": 21
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 83,
+        "columnBegin": 9,
+        "lineEnd": 83,
+        "columnEnd": 12
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/head." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 83,
+                "columnBegin": 9,
+                "lineEnd": 83,
+                "columnEnd": 12
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 83,
+        "columnBegin": 14,
+        "lineEnd": 83,
         "columnEnd": 17
       },
       "xref": {
@@ -2599,9 +2374,9 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 81,
+                "lineBegin": 83,
                 "columnBegin": 14,
-                "lineEnd": 81,
+                "lineEnd": 83,
                 "columnEnd": 17
               }
             }
@@ -2615,52 +2390,21 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 84,
-        "columnBegin": 1,
+        "columnBegin": 8,
         "lineEnd": 84,
-        "columnEnd": 2
+        "columnEnd": 11
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 84,
-                "columnBegin": 1,
+                "columnBegin": 8,
                 "lineEnd": 84,
-                "columnEnd": 2
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 84,
-        "columnBegin": 4,
-        "lineEnd": 84,
-        "columnEnd": 9
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TurtleScreen#listen()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 84,
-                "columnBegin": 4,
-                "lineEnd": 84,
-                "columnEnd": 9
+                "columnEnd": 11
               }
             }
           }
@@ -2673,23 +2417,21 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 85,
-        "columnBegin": 1,
+        "columnBegin": 13,
         "lineEnd": 85,
-        "columnEnd": 2
+        "columnEnd": 16
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 85,
-                "columnBegin": 1,
+                "columnBegin": 13,
                 "lineEnd": 85,
-                "columnEnd": 2
+                "columnEnd": 16
               }
             }
           }
@@ -2702,312 +2444,22 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 85,
-        "columnBegin": 4,
+        "columnBegin": 18,
         "lineEnd": 85,
-        "columnEnd": 13
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TurtleScreen#onkeypress()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 85,
-                "columnBegin": 4,
-                "lineEnd": 85,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 85,
-        "columnBegin": 15,
-        "lineEnd": 85,
-        "columnEnd": 19
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/group()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 85,
-                "columnBegin": 15,
-                "lineEnd": 85,
-                "columnEnd": 19
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 86,
-        "columnBegin": 1,
-        "lineEnd": 86,
-        "columnEnd": 2
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 86,
-                "columnBegin": 1,
-                "lineEnd": 86,
-                "columnEnd": 2
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 86,
-        "columnBegin": 4,
-        "lineEnd": 86,
-        "columnEnd": 13
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TurtleScreen#onkeypress()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 86,
-                "columnBegin": 4,
-                "lineEnd": 86,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 86,
-        "columnBegin": 15,
-        "lineEnd": 86,
-        "columnEnd": 20
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/godown()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 86,
-                "columnBegin": 15,
-                "lineEnd": 86,
-                "columnEnd": 20
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 87,
-        "columnBegin": 1,
-        "lineEnd": 87,
-        "columnEnd": 2
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 87,
-                "columnBegin": 1,
-                "lineEnd": 87,
-                "columnEnd": 2
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 87,
-        "columnBegin": 4,
-        "lineEnd": 87,
-        "columnEnd": 13
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TurtleScreen#onkeypress()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 87,
-                "columnBegin": 4,
-                "lineEnd": 87,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 87,
-        "columnBegin": 15,
-        "lineEnd": 87,
-        "columnEnd": 20
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goleft()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 87,
-                "columnBegin": 15,
-                "lineEnd": 87,
-                "columnEnd": 20
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 88,
-        "columnBegin": 1,
-        "lineEnd": 88,
-        "columnEnd": 2
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 88,
-                "columnBegin": 1,
-                "lineEnd": 88,
-                "columnEnd": 2
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 88,
-        "columnBegin": 4,
-        "lineEnd": 88,
-        "columnEnd": 13
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TurtleScreen#onkeypress()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 88,
-                "columnBegin": 4,
-                "lineEnd": 88,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 88,
-        "columnBegin": 15,
-        "lineEnd": 88,
         "columnEnd": 21
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goright()."
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 88,
-                "columnBegin": 15,
-                "lineEnd": 88,
+                "lineBegin": 85,
+                "columnBegin": 18,
+                "lineEnd": 85,
                 "columnEnd": 21
               }
             }
@@ -3020,23 +2472,465 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 95,
-        "columnBegin": 5,
-        "lineEnd": 95,
-        "columnEnd": 6
+        "lineBegin": 86,
+        "columnBegin": 9,
+        "lineEnd": 86,
+        "columnEnd": 12
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/head." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 86,
+                "columnBegin": 9,
+                "lineEnd": 86,
+                "columnEnd": 12
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 86,
+        "columnBegin": 14,
+        "lineEnd": 86,
+        "columnEnd": 17
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#setx()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 95,
+                "lineBegin": 86,
+                "columnBegin": 14,
+                "lineEnd": 86,
+                "columnEnd": 17
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 89,
+        "columnBegin": 1,
+        "lineEnd": 89,
+        "columnEnd": 2
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/wn." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 89,
+                "columnBegin": 1,
+                "lineEnd": 89,
+                "columnEnd": 2
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 89,
+        "columnBegin": 4,
+        "lineEnd": 89,
+        "columnEnd": 9
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TurtleScreen#listen()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 89,
+                "columnBegin": 4,
+                "lineEnd": 89,
+                "columnEnd": 9
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 90,
+        "columnBegin": 1,
+        "lineEnd": 90,
+        "columnEnd": 2
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/wn." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 90,
+                "columnBegin": 1,
+                "lineEnd": 90,
+                "columnEnd": 2
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 90,
+        "columnBegin": 4,
+        "lineEnd": 90,
+        "columnEnd": 13
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TurtleScreen#onkeypress()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 90,
+                "columnBegin": 4,
+                "lineEnd": 90,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 90,
+        "columnBegin": 15,
+        "lineEnd": 90,
+        "columnEnd": 19
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/group()." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 90,
+                "columnBegin": 15,
+                "lineEnd": 90,
+                "columnEnd": 19
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 91,
+        "columnBegin": 1,
+        "lineEnd": 91,
+        "columnEnd": 2
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/wn." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 91,
+                "columnBegin": 1,
+                "lineEnd": 91,
+                "columnEnd": 2
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 91,
+        "columnBegin": 4,
+        "lineEnd": 91,
+        "columnEnd": 13
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TurtleScreen#onkeypress()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 91,
+                "columnBegin": 4,
+                "lineEnd": 91,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 91,
+        "columnBegin": 15,
+        "lineEnd": 91,
+        "columnEnd": 20
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/godown()." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 91,
+                "columnBegin": 15,
+                "lineEnd": 91,
+                "columnEnd": 20
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 92,
+        "columnBegin": 1,
+        "lineEnd": 92,
+        "columnEnd": 2
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/wn." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 92,
+                "columnBegin": 1,
+                "lineEnd": 92,
+                "columnEnd": 2
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 92,
+        "columnBegin": 4,
+        "lineEnd": 92,
+        "columnEnd": 13
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TurtleScreen#onkeypress()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 92,
+                "columnBegin": 4,
+                "lineEnd": 92,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 92,
+        "columnBegin": 15,
+        "lineEnd": 92,
+        "columnEnd": 20
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/goleft()." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 92,
+                "columnBegin": 15,
+                "lineEnd": 92,
+                "columnEnd": 20
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 93,
+        "columnBegin": 1,
+        "lineEnd": 93,
+        "columnEnd": 2
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/wn." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 93,
+                "columnBegin": 1,
+                "lineEnd": 93,
+                "columnEnd": 2
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 93,
+        "columnBegin": 4,
+        "lineEnd": 93,
+        "columnEnd": 13
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TurtleScreen#onkeypress()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 93,
+                "columnBegin": 4,
+                "lineEnd": 93,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 93,
+        "columnBegin": 15,
+        "lineEnd": 93,
+        "columnEnd": 21
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/goright()." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 93,
+                "columnBegin": 15,
+                "lineEnd": 93,
+                "columnEnd": 21
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 100,
+        "columnBegin": 5,
+        "lineEnd": 100,
+        "columnEnd": 6
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/wn." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 100,
                 "columnBegin": 5,
-                "lineEnd": 95,
+                "lineEnd": 100,
                 "columnEnd": 6
               }
             }
@@ -3049,9 +2943,9 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 95,
+        "lineBegin": 100,
         "columnBegin": 8,
-        "lineEnd": 95,
+        "lineEnd": 100,
         "columnEnd": 13
       },
       "xref": {
@@ -3063,561 +2957,10 @@
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 95,
+                "lineBegin": 100,
                 "columnBegin": 8,
-                "lineEnd": 95,
+                "lineEnd": 100,
                 "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 8,
-        "lineEnd": 96,
-        "columnEnd": 11
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 96,
-                "columnBegin": 8,
-                "lineEnd": 96,
-                "columnEnd": 11
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 13,
-        "lineEnd": 96,
-        "columnEnd": 16
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 96,
-                "columnBegin": 13,
-                "lineEnd": 96,
-                "columnEnd": 16
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 29,
-        "lineEnd": 96,
-        "columnEnd": 32
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 96,
-                "columnBegin": 29,
-                "lineEnd": 96,
-                "columnEnd": 32
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 34,
-        "lineEnd": 96,
-        "columnEnd": 37
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 96,
-                "columnBegin": 34,
-                "lineEnd": 96,
-                "columnEnd": 37
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 51,
-        "lineEnd": 96,
-        "columnEnd": 54
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 96,
-                "columnBegin": 51,
-                "lineEnd": 96,
-                "columnEnd": 54
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 56,
-        "lineEnd": 96,
-        "columnEnd": 59
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#ycor()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 96,
-                "columnBegin": 56,
-                "lineEnd": 96,
-                "columnEnd": 59
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 72,
-        "lineEnd": 96,
-        "columnEnd": 75
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 96,
-                "columnBegin": 72,
-                "lineEnd": 96,
-                "columnEnd": 75
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 96,
-        "columnBegin": 77,
-        "lineEnd": 96,
-        "columnEnd": 80
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#ycor()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 96,
-                "columnBegin": 77,
-                "lineEnd": 96,
-                "columnEnd": 80
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 97,
-        "columnBegin": 9,
-        "lineEnd": 97,
-        "columnEnd": 12
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 time/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 97,
-                "columnBegin": 9,
-                "lineEnd": 97,
-                "columnEnd": 12
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 97,
-        "columnBegin": 14,
-        "lineEnd": 97,
-        "columnEnd": 18
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 time/sleep()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 97,
-                "columnBegin": 14,
-                "lineEnd": 97,
-                "columnEnd": 18
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 98,
-        "columnBegin": 9,
-        "lineEnd": 98,
-        "columnEnd": 12
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 98,
-                "columnBegin": 9,
-                "lineEnd": 98,
-                "columnEnd": 12
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 98,
-        "columnBegin": 14,
-        "lineEnd": 98,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#goto()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 98,
-                "columnBegin": 14,
-                "lineEnd": 98,
-                "columnEnd": 17
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 99,
-        "columnBegin": 9,
-        "lineEnd": 99,
-        "columnEnd": 12
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 99,
-                "columnBegin": 9,
-                "lineEnd": 99,
-                "columnEnd": 12
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 100,
-        "columnBegin": 9,
-        "lineEnd": 100,
-        "columnEnd": 14
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 100,
-                "columnBegin": 9,
-                "lineEnd": 100,
-                "columnEnd": 14
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 100,
-        "columnBegin": 18,
-        "lineEnd": 100,
-        "columnEnd": 23
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 100,
-                "columnBegin": 18,
-                "lineEnd": 100,
-                "columnEnd": 23
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 100,
-        "columnBegin": 25,
-        "lineEnd": 100,
-        "columnEnd": 30
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/choice."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 100,
-                "columnBegin": 25,
-                "lineEnd": 100,
-                "columnEnd": 30
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 101,
-        "columnBegin": 9,
-        "lineEnd": 101,
-        "columnEnd": 14
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 101,
-                "columnBegin": 9,
-                "lineEnd": 101,
-                "columnEnd": 14
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 101,
-        "columnBegin": 18,
-        "lineEnd": 101,
-        "columnEnd": 23
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 101,
-                "columnBegin": 18,
-                "lineEnd": 101,
-                "columnEnd": 23
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 101,
-        "columnBegin": 25,
-        "lineEnd": 101,
-        "columnEnd": 30
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/choice."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 101,
-                "columnBegin": 25,
-                "lineEnd": 101,
-                "columnEnd": 30
               }
             }
           }
@@ -3630,631 +2973,20 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 102,
-        "columnBegin": 24,
+        "columnBegin": 9,
         "lineEnd": 102,
-        "columnEnd": 31
+        "columnEnd": 12
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 102,
-                "columnBegin": 24,
+                "columnBegin": 9,
                 "lineEnd": 102,
-                "columnEnd": 31
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 103,
-        "columnBegin": 13,
-        "lineEnd": 103,
-        "columnEnd": 19
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 103,
-                "columnBegin": 13,
-                "lineEnd": 103,
-                "columnEnd": 19
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 104,
-        "columnBegin": 9,
-        "lineEnd": 104,
-        "columnEnd": 16
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 104,
-                "columnBegin": 9,
-                "lineEnd": 104,
-                "columnEnd": 16
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 104,
-        "columnBegin": 18,
-        "lineEnd": 104,
-        "columnEnd": 22
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 typing/MutableSequence#clear()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 104,
-                "columnBegin": 18,
-                "lineEnd": 104,
-                "columnEnd": 22
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 105,
-        "columnBegin": 9,
-        "lineEnd": 105,
-        "columnEnd": 13
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 105,
-                "columnBegin": 9,
-                "lineEnd": 105,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 106,
-        "columnBegin": 9,
-        "lineEnd": 106,
-        "columnEnd": 13
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 106,
-                "columnBegin": 9,
-                "lineEnd": 106,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 107,
-        "columnBegin": 9,
-        "lineEnd": 107,
-        "columnEnd": 11
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 107,
-                "columnBegin": 9,
-                "lineEnd": 107,
-                "columnEnd": 11
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 107,
-        "columnBegin": 13,
-        "lineEnd": 107,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 107,
-                "columnBegin": 13,
-                "lineEnd": 107,
-                "columnEnd": 17
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 108,
-        "columnBegin": 9,
-        "lineEnd": 108,
-        "columnEnd": 11
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 108,
-                "columnBegin": 9,
-                "lineEnd": 108,
-                "columnEnd": 11
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 108,
-        "columnBegin": 13,
-        "lineEnd": 108,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 108,
-                "columnBegin": 13,
-                "lineEnd": 108,
-                "columnEnd": 17
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 109,
-        "columnBegin": 13,
-        "lineEnd": 109,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 109,
-                "columnBegin": 13,
-                "lineEnd": 109,
-                "columnEnd": 17
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 109,
-        "columnBegin": 20,
-        "lineEnd": 109,
-        "columnEnd": 29
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 109,
-                "columnBegin": 20,
-                "lineEnd": 109,
-                "columnEnd": 29
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 109,
-        "columnBegin": 33,
-        "lineEnd": 109,
-        "columnEnd": 37
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 109,
-                "columnBegin": 33,
-                "lineEnd": 109,
-                "columnEnd": 37
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 109,
-        "columnBegin": 49,
-        "lineEnd": 109,
-        "columnEnd": 52
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 109,
-                "columnBegin": 49,
-                "lineEnd": 109,
-                "columnEnd": 52
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 110,
-        "columnBegin": 8,
-        "lineEnd": 110,
-        "columnEnd": 11
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 110,
-                "columnBegin": 8,
-                "lineEnd": 110,
-                "columnEnd": 11
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 110,
-        "columnBegin": 13,
-        "lineEnd": 110,
-        "columnEnd": 20
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#distance()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 110,
-                "columnBegin": 13,
-                "lineEnd": 110,
-                "columnEnd": 20
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 110,
-        "columnBegin": 22,
-        "lineEnd": 110,
-        "columnEnd": 25
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 110,
-                "columnBegin": 22,
-                "lineEnd": 110,
-                "columnEnd": 25
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 111,
-        "columnBegin": 13,
-        "lineEnd": 111,
-        "columnEnd": 18
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 111,
-                "columnBegin": 13,
-                "lineEnd": 111,
-                "columnEnd": 18
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 111,
-        "columnBegin": 20,
-        "lineEnd": 111,
-        "columnEnd": 26
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/randint."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 111,
-                "columnBegin": 20,
-                "lineEnd": 111,
-                "columnEnd": 26
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 112,
-        "columnBegin": 13,
-        "lineEnd": 112,
-        "columnEnd": 18
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 112,
-                "columnBegin": 13,
-                "lineEnd": 112,
-                "columnEnd": 18
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 112,
-        "columnBegin": 20,
-        "lineEnd": 112,
-        "columnEnd": 26
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/randint."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 112,
-                "columnBegin": 20,
-                "lineEnd": 112,
-                "columnEnd": 26
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 113,
-        "columnBegin": 9,
-        "lineEnd": 113,
-        "columnEnd": 12
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 113,
-                "columnBegin": 9,
-                "lineEnd": 113,
                 "columnEnd": 12
               }
             }
@@ -4267,23 +2999,23 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 113,
+        "lineBegin": 102,
         "columnBegin": 14,
-        "lineEnd": 113,
+        "lineEnd": 102,
         "columnEnd": 17
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#goto()."
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 113,
+                "lineBegin": 102,
                 "columnBegin": 14,
-                "lineEnd": 113,
+                "lineEnd": 102,
                 "columnEnd": 17
               }
             }
@@ -4296,24 +3028,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 113,
-        "columnBegin": 19,
-        "lineEnd": 113,
-        "columnEnd": 19
+        "lineBegin": 103,
+        "columnBegin": 12,
+        "lineEnd": 103,
+        "columnEnd": 15
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 113,
-                "columnBegin": 19,
-                "lineEnd": 113,
-                "columnEnd": 19
+                "lineBegin": 103,
+                "columnBegin": 12,
+                "lineEnd": 103,
+                "columnEnd": 15
               }
             }
           }
@@ -4325,24 +3055,24 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 113,
-        "columnBegin": 22,
-        "lineEnd": 113,
-        "columnEnd": 22
+        "lineBegin": 103,
+        "columnBegin": 17,
+        "lineEnd": 103,
+        "columnEnd": 20
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 113,
-                "columnBegin": 22,
-                "lineEnd": 113,
-                "columnEnd": 22
+                "lineBegin": 103,
+                "columnBegin": 17,
+                "lineEnd": 103,
+                "columnEnd": 20
               }
             }
           }
@@ -4354,24 +3084,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 116,
-        "columnBegin": 23,
-        "lineEnd": 116,
-        "columnEnd": 28
+        "lineBegin": 104,
+        "columnBegin": 12,
+        "lineEnd": 104,
+        "columnEnd": 15
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/__init__:"
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 116,
-                "columnBegin": 23,
-                "lineEnd": 116,
-                "columnEnd": 28
+                "lineBegin": 104,
+                "columnBegin": 12,
+                "lineEnd": 104,
+                "columnEnd": 15
               }
             }
           }
@@ -4383,24 +3111,24 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 116,
-        "columnBegin": 30,
-        "lineEnd": 116,
-        "columnEnd": 35
+        "lineBegin": 104,
+        "columnBegin": 17,
+        "lineEnd": 104,
+        "columnEnd": 20
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/Turtle#"
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#ycor()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 116,
-                "columnBegin": 30,
-                "lineEnd": 116,
-                "columnEnd": 35
+                "lineBegin": 104,
+                "columnBegin": 17,
+                "lineEnd": 104,
+                "columnEnd": 20
               }
             }
           }
@@ -4412,24 +3140,80 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 117,
+        "lineBegin": 105,
+        "columnBegin": 12,
+        "lineEnd": 105,
+        "columnEnd": 15
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/head." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 105,
+                "columnBegin": 12,
+                "lineEnd": 105,
+                "columnEnd": 15
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 105,
+        "columnBegin": 17,
+        "lineEnd": 105,
+        "columnEnd": 20
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#ycor()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 105,
+                "columnBegin": 17,
+                "lineEnd": 105,
+                "columnEnd": 20
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 107,
         "columnBegin": 9,
-        "lineEnd": 117,
-        "columnEnd": 19
+        "lineEnd": 107,
+        "columnEnd": 12
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
+            "key": "scip-python python python-stdlib 3.11 time/__init__:"
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 117,
+                "lineBegin": 107,
                 "columnBegin": 9,
-                "lineEnd": 117,
-                "columnEnd": 19
+                "lineEnd": 107,
+                "columnEnd": 12
               }
             }
           }
@@ -4441,24 +3225,24 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 117,
-        "columnBegin": 21,
-        "lineEnd": 117,
-        "columnEnd": 25
+        "lineBegin": 107,
+        "columnBegin": 14,
+        "lineEnd": 107,
+        "columnEnd": 18
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TPen#speed()."
+            "key": "scip-python python python-stdlib 3.11 time/sleep()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 117,
-                "columnBegin": 21,
-                "lineEnd": 117,
-                "columnEnd": 25
+                "lineBegin": 107,
+                "columnBegin": 14,
+                "lineEnd": 107,
+                "columnEnd": 18
               }
             }
           }
@@ -4470,24 +3254,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 118,
+        "lineBegin": 108,
         "columnBegin": 9,
-        "lineEnd": 118,
-        "columnEnd": 19
+        "lineEnd": 108,
+        "columnEnd": 12
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 118,
+                "lineBegin": 108,
                 "columnBegin": 9,
-                "lineEnd": 118,
-                "columnEnd": 19
+                "lineEnd": 108,
+                "columnEnd": 12
               }
             }
           }
@@ -4499,24 +3281,24 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 118,
-        "columnBegin": 21,
-        "lineEnd": 118,
-        "columnEnd": 25
+        "lineBegin": 108,
+        "columnBegin": 14,
+        "lineEnd": 108,
+        "columnEnd": 17
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#goto()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 118,
-                "columnBegin": 21,
-                "lineEnd": 118,
-                "columnEnd": 25
+                "lineBegin": 108,
+                "columnBegin": 14,
+                "lineEnd": 108,
+                "columnEnd": 17
               }
             }
           }
@@ -4528,24 +3310,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 119,
+        "lineBegin": 109,
         "columnBegin": 9,
-        "lineEnd": 119,
-        "columnEnd": 19
+        "lineEnd": 109,
+        "columnEnd": 12
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 119,
+                "lineBegin": 109,
                 "columnBegin": 9,
-                "lineEnd": 119,
-                "columnEnd": 19
+                "lineEnd": 109,
+                "columnEnd": 12
               }
             }
           }
@@ -4557,53 +3337,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 119,
-        "columnBegin": 21,
-        "lineEnd": 119,
-        "columnEnd": 25
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TPen#color()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 119,
-                "columnBegin": 21,
-                "lineEnd": 119,
-                "columnEnd": 25
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 120,
+        "lineBegin": 110,
         "columnBegin": 9,
-        "lineEnd": 120,
-        "columnEnd": 19
+        "lineEnd": 110,
+        "columnEnd": 14
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-          },
+          "symbol": { "key": "scip-python python . test example/colors." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 120,
+                "lineBegin": 110,
                 "columnBegin": 9,
-                "lineEnd": 120,
-                "columnEnd": 19
+                "lineEnd": 110,
+                "columnEnd": 14
               }
             }
           }
@@ -4615,81 +3364,23 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 120,
-        "columnBegin": 21,
-        "lineEnd": 120,
-        "columnEnd": 25
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TPen#penup()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 120,
-                "columnBegin": 21,
-                "lineEnd": 120,
-                "columnEnd": 25
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 121,
-        "columnBegin": 9,
-        "lineEnd": 121,
-        "columnEnd": 16
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 121,
-                "columnBegin": 9,
-                "lineEnd": 121,
-                "columnEnd": 16
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 121,
+        "lineBegin": 110,
         "columnBegin": 18,
-        "lineEnd": 121,
+        "lineEnd": 110,
         "columnEnd": 23
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 builtins/list#append()."
+            "key": "scip-python python python-stdlib 3.11 random/__init__:"
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 121,
+                "lineBegin": 110,
                 "columnBegin": 18,
-                "lineEnd": 121,
+                "lineEnd": 110,
                 "columnEnd": 23
               }
             }
@@ -4702,197 +3393,23 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 121,
+        "lineBegin": 110,
         "columnBegin": 25,
-        "lineEnd": 121,
-        "columnEnd": 35
+        "lineEnd": 110,
+        "columnEnd": 30
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
+            "key": "scip-python python python-stdlib 3.11 random/choice."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 121,
+                "lineBegin": 110,
                 "columnBegin": 25,
-                "lineEnd": 121,
-                "columnEnd": 35
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 122,
-        "columnBegin": 9,
-        "lineEnd": 122,
-        "columnEnd": 13
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 122,
-                "columnBegin": 9,
-                "lineEnd": 122,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 123,
-        "columnBegin": 9,
-        "lineEnd": 123,
-        "columnEnd": 13
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 123,
-                "columnBegin": 9,
-                "lineEnd": 123,
-                "columnEnd": 13
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 124,
-        "columnBegin": 12,
-        "lineEnd": 124,
-        "columnEnd": 16
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 124,
-                "columnBegin": 12,
-                "lineEnd": 124,
-                "columnEnd": 16
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 124,
-        "columnBegin": 20,
-        "lineEnd": 124,
-        "columnEnd": 29
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 124,
-                "columnBegin": 20,
-                "lineEnd": 124,
-                "columnEnd": 29
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 125,
-        "columnBegin": 13,
-        "lineEnd": 125,
-        "columnEnd": 22
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 125,
-                "columnBegin": 13,
-                "lineEnd": 125,
-                "columnEnd": 22
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 125,
-        "columnBegin": 26,
-        "lineEnd": 125,
-        "columnEnd": 30
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 125,
-                "columnBegin": 26,
-                "lineEnd": 125,
+                "lineEnd": 110,
                 "columnEnd": 30
               }
             }
@@ -4905,24 +3422,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 126,
+        "lineBegin": 111,
         "columnBegin": 9,
-        "lineEnd": 126,
-        "columnEnd": 11
+        "lineEnd": 111,
+        "columnEnd": 14
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
+          "symbol": { "key": "scip-python python . test example/shapes." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 126,
+                "lineBegin": 111,
                 "columnBegin": 9,
-                "lineEnd": 126,
-                "columnEnd": 11
+                "lineEnd": 111,
+                "columnEnd": 14
               }
             }
           }
@@ -4934,227 +3449,24 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 126,
-        "columnBegin": 13,
-        "lineEnd": 126,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 126,
-                "columnBegin": 13,
-                "lineEnd": 126,
-                "columnEnd": 17
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 127,
-        "columnBegin": 9,
-        "lineEnd": 127,
-        "columnEnd": 11
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 127,
-                "columnBegin": 9,
-                "lineEnd": 127,
-                "columnEnd": 11
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 127,
-        "columnBegin": 13,
-        "lineEnd": 127,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 127,
-                "columnBegin": 13,
-                "lineEnd": 127,
-                "columnEnd": 17
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 128,
-        "columnBegin": 13,
-        "lineEnd": 128,
-        "columnEnd": 17
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 128,
-                "columnBegin": 13,
-                "lineEnd": 128,
-                "columnEnd": 17
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 128,
-        "columnBegin": 20,
-        "lineEnd": 128,
-        "columnEnd": 29
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 128,
-                "columnBegin": 20,
-                "lineEnd": 128,
-                "columnEnd": 29
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 128,
-        "columnBegin": 33,
-        "lineEnd": 128,
-        "columnEnd": 37
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 128,
-                "columnBegin": 33,
-                "lineEnd": 128,
-                "columnEnd": 37
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 128,
-        "columnBegin": 49,
-        "lineEnd": 128,
-        "columnEnd": 52
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 128,
-                "columnBegin": 49,
-                "lineEnd": 128,
-                "columnEnd": 52
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 130,
+        "lineBegin": 111,
         "columnBegin": 18,
-        "lineEnd": 130,
-        "columnEnd": 22
+        "lineEnd": 111,
+        "columnEnd": 23
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 builtins/range#"
+            "key": "scip-python python python-stdlib 3.11 random/__init__:"
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 130,
+                "lineBegin": 111,
                 "columnBegin": 18,
-                "lineEnd": 130,
-                "columnEnd": 22
+                "lineEnd": 111,
+                "columnEnd": 23
               }
             }
           }
@@ -5166,284 +3478,23 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 130,
-        "columnBegin": 28,
-        "lineEnd": 130,
-        "columnEnd": 35
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 130,
-                "columnBegin": 28,
-                "lineEnd": 130,
-                "columnEnd": 35
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 131,
-        "columnBegin": 9,
-        "lineEnd": 131,
-        "columnEnd": 9
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 131,
-                "columnBegin": 9,
-                "lineEnd": 131,
-                "columnEnd": 9
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 131,
-        "columnBegin": 13,
-        "lineEnd": 131,
-        "columnEnd": 20
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 131,
-                "columnBegin": 13,
-                "lineEnd": 131,
-                "columnEnd": 20
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 131,
-        "columnBegin": 22,
-        "lineEnd": 131,
-        "columnEnd": 26
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 131,
-                "columnBegin": 22,
-                "lineEnd": 131,
-                "columnEnd": 26
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 132,
-        "columnBegin": 9,
-        "lineEnd": 132,
-        "columnEnd": 9
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 132,
-                "columnBegin": 9,
-                "lineEnd": 132,
-                "columnEnd": 9
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 132,
-        "columnBegin": 13,
-        "lineEnd": 132,
-        "columnEnd": 20
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 132,
-                "columnBegin": 13,
-                "lineEnd": 132,
-                "columnEnd": 20
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 132,
-        "columnBegin": 22,
-        "lineEnd": 132,
-        "columnEnd": 26
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 132,
-                "columnBegin": 22,
-                "lineEnd": 132,
-                "columnEnd": 26
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 133,
-        "columnBegin": 9,
-        "lineEnd": 133,
-        "columnEnd": 16
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 133,
-                "columnBegin": 9,
-                "lineEnd": 133,
-                "columnEnd": 16
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 133,
-        "columnBegin": 18,
-        "lineEnd": 133,
-        "columnEnd": 22
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 133,
-                "columnBegin": 18,
-                "lineEnd": 133,
-                "columnEnd": 22
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 133,
-        "columnBegin": 30,
-        "lineEnd": 133,
+        "lineBegin": 111,
+        "columnBegin": 25,
+        "lineEnd": 111,
         "columnEnd": 30
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
+            "key": "scip-python python python-stdlib 3.11 random/choice."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 133,
-                "columnBegin": 30,
-                "lineEnd": 133,
+                "lineBegin": 111,
+                "columnBegin": 25,
+                "lineEnd": 111,
                 "columnEnd": 30
               }
             }
@@ -5456,24 +3507,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 133,
-        "columnBegin": 33,
-        "lineEnd": 133,
-        "columnEnd": 33
+        "lineBegin": 112,
+        "columnBegin": 24,
+        "lineEnd": 112,
+        "columnEnd": 31
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-          },
+          "symbol": { "key": "scip-python python . test example/segments." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 133,
-                "columnBegin": 33,
-                "lineEnd": 133,
-                "columnEnd": 33
+                "lineBegin": 112,
+                "columnBegin": 24,
+                "lineEnd": 112,
+                "columnEnd": 31
               }
             }
           }
@@ -5485,23 +3534,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 134,
-        "columnBegin": 12,
-        "lineEnd": 134,
+        "lineBegin": 113,
+        "columnBegin": 13,
+        "lineEnd": 113,
         "columnEnd": 19
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
+          "symbol": { "key": "scip-python python . test example/segment." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 134,
-                "columnBegin": 12,
-                "lineEnd": 134,
+                "lineBegin": 113,
+                "columnBegin": 13,
+                "lineEnd": 113,
                 "columnEnd": 19
               }
             }
@@ -5514,52 +3561,21 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 135,
+        "lineBegin": 114,
         "columnBegin": 9,
-        "lineEnd": 135,
-        "columnEnd": 9
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 135,
-                "columnBegin": 9,
-                "lineEnd": 135,
-                "columnEnd": 9
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 135,
-        "columnBegin": 13,
-        "lineEnd": 135,
+        "lineEnd": 114,
         "columnEnd": 16
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
+          "symbol": { "key": "scip-python python . test example/segments." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 135,
-                "columnBegin": 13,
-                "lineEnd": 135,
+                "lineBegin": 114,
+                "columnBegin": 9,
+                "lineEnd": 114,
                 "columnEnd": 16
               }
             }
@@ -5572,24 +3588,24 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 135,
+        "lineBegin": 114,
         "columnBegin": 18,
-        "lineEnd": 135,
-        "columnEnd": 21
+        "lineEnd": 114,
+        "columnEnd": 22
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
+            "key": "scip-python python python-stdlib 3.11 typing/MutableSequence#clear()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 135,
+                "lineBegin": 114,
                 "columnBegin": 18,
-                "lineEnd": 135,
-                "columnEnd": 21
+                "lineEnd": 114,
+                "columnEnd": 22
               }
             }
           }
@@ -5601,24 +3617,22 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 136,
+        "lineBegin": 115,
         "columnBegin": 9,
-        "lineEnd": 136,
-        "columnEnd": 9
+        "lineEnd": 115,
+        "columnEnd": 13
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-          },
+          "symbol": { "key": "scip-python python . test example/score." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 136,
+                "lineBegin": 115,
                 "columnBegin": 9,
-                "lineEnd": 136,
-                "columnEnd": 9
+                "lineEnd": 115,
+                "columnEnd": 13
               }
             }
           }
@@ -5630,24 +3644,78 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 136,
+        "lineBegin": 116,
+        "columnBegin": 9,
+        "lineEnd": 116,
+        "columnEnd": 13
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/delay." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 116,
+                "columnBegin": 9,
+                "lineEnd": 116,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 117,
+        "columnBegin": 9,
+        "lineEnd": 117,
+        "columnEnd": 11
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/pen." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 117,
+                "columnBegin": 9,
+                "lineEnd": 117,
+                "columnEnd": 11
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 117,
         "columnBegin": 13,
-        "lineEnd": 136,
-        "columnEnd": 16
+        "lineEnd": 117,
+        "columnEnd": 17
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 136,
+                "lineBegin": 117,
                 "columnBegin": 13,
-                "lineEnd": 136,
-                "columnEnd": 16
+                "lineEnd": 117,
+                "columnEnd": 17
               }
             }
           }
@@ -5659,24 +3727,51 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 136,
-        "columnBegin": 18,
-        "lineEnd": 136,
-        "columnEnd": 21
+        "lineBegin": 118,
+        "columnBegin": 9,
+        "lineEnd": 118,
+        "columnEnd": 11
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/pen." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 118,
+                "columnBegin": 9,
+                "lineEnd": 118,
+                "columnEnd": 11
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 118,
+        "columnBegin": 13,
+        "lineEnd": 118,
+        "columnEnd": 17
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#ycor()."
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 136,
-                "columnBegin": 18,
-                "lineEnd": 136,
-                "columnEnd": 21
+                "lineBegin": 118,
+                "columnBegin": 13,
+                "lineEnd": 118,
+                "columnEnd": 17
               }
             }
           }
@@ -5688,23 +3783,106 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 137,
-        "columnBegin": 9,
-        "lineEnd": 137,
+        "lineBegin": 119,
+        "columnBegin": 50,
+        "lineEnd": 119,
+        "columnEnd": 54
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/score." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 119,
+                "columnBegin": 50,
+                "lineEnd": 119,
+                "columnEnd": 54
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 119,
+        "columnBegin": 57,
+        "lineEnd": 119,
+        "columnEnd": 66
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/high_score." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 119,
+                "columnBegin": 57,
+                "lineEnd": 119,
+                "columnEnd": 66
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 120,
+        "columnBegin": 13,
+        "lineEnd": 120,
+        "columnEnd": 17
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 120,
+                "columnBegin": 13,
+                "lineEnd": 120,
+                "columnEnd": 17
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 121,
+        "columnBegin": 13,
+        "lineEnd": 121,
         "columnEnd": 16
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 137,
-                "columnBegin": 9,
-                "lineEnd": 137,
+                "lineBegin": 121,
+                "columnBegin": 13,
+                "lineEnd": 121,
                 "columnEnd": 16
               }
             }
@@ -5717,23 +3895,135 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 137,
-        "columnBegin": 26,
-        "lineEnd": 137,
+        "lineBegin": 123,
+        "columnBegin": 8,
+        "lineEnd": 123,
+        "columnEnd": 11
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/head." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 123,
+                "columnBegin": 8,
+                "lineEnd": 123,
+                "columnEnd": 11
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 123,
+        "columnBegin": 13,
+        "lineEnd": 123,
+        "columnEnd": 20
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#distance()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 123,
+                "columnBegin": 13,
+                "lineEnd": 123,
+                "columnEnd": 20
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 123,
+        "columnBegin": 22,
+        "lineEnd": 123,
+        "columnEnd": 25
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/food." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 123,
+                "columnBegin": 22,
+                "lineEnd": 123,
+                "columnEnd": 25
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 124,
+        "columnBegin": 13,
+        "lineEnd": 124,
+        "columnEnd": 18
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 random/__init__:"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 124,
+                "columnBegin": 13,
+                "lineEnd": 124,
+                "columnEnd": 18
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 124,
+        "columnBegin": 20,
+        "lineEnd": 124,
         "columnEnd": 26
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
+            "key": "scip-python python python-stdlib 3.11 random/randint."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 137,
-                "columnBegin": 26,
-                "lineEnd": 137,
+                "lineBegin": 124,
+                "columnBegin": 20,
+                "lineEnd": 124,
                 "columnEnd": 26
               }
             }
@@ -5746,22 +4036,634 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 137,
-        "columnBegin": 29,
-        "lineEnd": 137,
-        "columnEnd": 29
+        "lineBegin": 125,
+        "columnBegin": 13,
+        "lineEnd": 125,
+        "columnEnd": 18
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
+            "key": "scip-python python python-stdlib 3.11 random/__init__:"
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
+                "lineBegin": 125,
+                "columnBegin": 13,
+                "lineEnd": 125,
+                "columnEnd": 18
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 125,
+        "columnBegin": 20,
+        "lineEnd": 125,
+        "columnEnd": 26
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 random/randint."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 125,
+                "columnBegin": 20,
+                "lineEnd": 125,
+                "columnEnd": 26
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 126,
+        "columnBegin": 9,
+        "lineEnd": 126,
+        "columnEnd": 12
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/food." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 126,
+                "columnBegin": 9,
+                "lineEnd": 126,
+                "columnEnd": 12
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 126,
+        "columnBegin": 14,
+        "lineEnd": 126,
+        "columnEnd": 17
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#goto()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 126,
+                "columnBegin": 14,
+                "lineEnd": 126,
+                "columnEnd": 17
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 126,
+        "columnBegin": 19,
+        "lineEnd": 126,
+        "columnEnd": 19
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/x." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 126,
+                "columnBegin": 19,
+                "lineEnd": 126,
+                "columnEnd": 19
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 126,
+        "columnBegin": 22,
+        "lineEnd": 126,
+        "columnEnd": 22
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/y." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 126,
+                "columnBegin": 22,
+                "lineEnd": 126,
+                "columnEnd": 22
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 129,
+        "columnBegin": 23,
+        "lineEnd": 129,
+        "columnEnd": 28
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/__init__:"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 129,
+                "columnBegin": 23,
+                "lineEnd": 129,
+                "columnEnd": 28
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 129,
+        "columnBegin": 30,
+        "lineEnd": 129,
+        "columnEnd": 35
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/Turtle#"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 129,
+                "columnBegin": 30,
+                "lineEnd": 129,
+                "columnEnd": 35
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 130,
+        "columnBegin": 9,
+        "lineEnd": 130,
+        "columnEnd": 19
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/new_segment." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 130,
+                "columnBegin": 9,
+                "lineEnd": 130,
+                "columnEnd": 19
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 130,
+        "columnBegin": 21,
+        "lineEnd": 130,
+        "columnEnd": 25
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TPen#speed()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 130,
+                "columnBegin": 21,
+                "lineEnd": 130,
+                "columnEnd": 25
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 131,
+        "columnBegin": 9,
+        "lineEnd": 131,
+        "columnEnd": 19
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/new_segment." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 131,
+                "columnBegin": 9,
+                "lineEnd": 131,
+                "columnEnd": 19
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 131,
+        "columnBegin": 21,
+        "lineEnd": 131,
+        "columnEnd": 25
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#shape()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 131,
+                "columnBegin": 21,
+                "lineEnd": 131,
+                "columnEnd": 25
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 132,
+        "columnBegin": 9,
+        "lineEnd": 132,
+        "columnEnd": 19
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/new_segment." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 132,
+                "columnBegin": 9,
+                "lineEnd": 132,
+                "columnEnd": 19
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 132,
+        "columnBegin": 21,
+        "lineEnd": 132,
+        "columnEnd": 25
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TPen#color()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 132,
+                "columnBegin": 21,
+                "lineEnd": 132,
+                "columnEnd": 25
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 133,
+        "columnBegin": 9,
+        "lineEnd": 133,
+        "columnEnd": 19
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/new_segment." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 133,
+                "columnBegin": 9,
+                "lineEnd": 133,
+                "columnEnd": 19
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 133,
+        "columnBegin": 21,
+        "lineEnd": 133,
+        "columnEnd": 25
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TPen#penup()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 133,
+                "columnBegin": 21,
+                "lineEnd": 133,
+                "columnEnd": 25
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 134,
+        "columnBegin": 9,
+        "lineEnd": 134,
+        "columnEnd": 16
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/segments." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 134,
+                "columnBegin": 9,
+                "lineEnd": 134,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 134,
+        "columnBegin": 18,
+        "lineEnd": 134,
+        "columnEnd": 23
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 builtins/list#append()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 134,
+                "columnBegin": 18,
+                "lineEnd": 134,
+                "columnEnd": 23
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 134,
+        "columnBegin": 25,
+        "lineEnd": 134,
+        "columnEnd": 35
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/new_segment." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 134,
+                "columnBegin": 25,
+                "lineEnd": 134,
+                "columnEnd": 35
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 135,
+        "columnBegin": 9,
+        "lineEnd": 135,
+        "columnEnd": 13
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/delay." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 135,
+                "columnBegin": 9,
+                "lineEnd": 135,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 136,
+        "columnBegin": 9,
+        "lineEnd": 136,
+        "columnEnd": 13
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/score." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 136,
+                "columnBegin": 9,
+                "lineEnd": 136,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 137,
+        "columnBegin": 12,
+        "lineEnd": 137,
+        "columnEnd": 16
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/score." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
                 "lineBegin": 137,
-                "columnBegin": 29,
+                "columnBegin": 12,
+                "lineEnd": 137,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 137,
+        "columnBegin": 20,
+        "lineEnd": 137,
+        "columnEnd": 29
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/high_score." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 137,
+                "columnBegin": 20,
                 "lineEnd": 137,
                 "columnEnd": 29
               }
@@ -5776,23 +4678,48 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 138,
-        "columnBegin": 5,
+        "columnBegin": 13,
         "lineEnd": 138,
-        "columnEnd": 8
+        "columnEnd": 22
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/move()."
-          },
+          "symbol": { "key": "scip-python python . test example/high_score." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 138,
-                "columnBegin": 5,
+                "columnBegin": 13,
                 "lineEnd": 138,
-                "columnEnd": 8
+                "columnEnd": 22
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 138,
+        "columnBegin": 26,
+        "lineEnd": 138,
+        "columnEnd": 30
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/score." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 138,
+                "columnBegin": 26,
+                "lineEnd": 138,
+                "columnEnd": 30
               }
             }
           }
@@ -5807,13 +4734,11 @@
         "lineBegin": 139,
         "columnBegin": 9,
         "lineEnd": 139,
-        "columnEnd": 15
+        "columnEnd": 11
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-          },
+          "symbol": { "key": "scip-python python . test example/pen." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -5821,7 +4746,7 @@
                 "lineBegin": 139,
                 "columnBegin": 9,
                 "lineEnd": 139,
-                "columnEnd": 15
+                "columnEnd": 11
               }
             }
           }
@@ -5834,23 +4759,23 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 139,
-        "columnBegin": 20,
+        "columnBegin": 13,
         "lineEnd": 139,
-        "columnEnd": 27
+        "columnEnd": 17
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 139,
-                "columnBegin": 20,
+                "columnBegin": 13,
                 "lineEnd": 139,
-                "columnEnd": 27
+                "columnEnd": 17
               }
             }
           }
@@ -5863,23 +4788,21 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 140,
-        "columnBegin": 12,
+        "columnBegin": 9,
         "lineEnd": 140,
-        "columnEnd": 18
+        "columnEnd": 11
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-          },
+          "symbol": { "key": "scip-python python . test example/pen." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 140,
-                "columnBegin": 12,
+                "columnBegin": 9,
                 "lineEnd": 140,
-                "columnEnd": 18
+                "columnEnd": 11
               }
             }
           }
@@ -5892,52 +4815,23 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 140,
-        "columnBegin": 29,
-        "lineEnd": 140,
-        "columnEnd": 32
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 140,
-                "columnBegin": 29,
-                "lineEnd": 140,
-                "columnEnd": 32
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 141,
         "columnBegin": 13,
-        "lineEnd": 141,
-        "columnEnd": 16
+        "lineEnd": 140,
+        "columnEnd": 17
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 time/__init__:"
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 141,
+                "lineBegin": 140,
                 "columnBegin": 13,
-                "lineEnd": 141,
-                "columnEnd": 16
+                "lineEnd": 140,
+                "columnEnd": 17
               }
             }
           }
@@ -5950,23 +4844,48 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 141,
-        "columnBegin": 18,
+        "columnBegin": 50,
         "lineEnd": 141,
-        "columnEnd": 22
+        "columnEnd": 54
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 time/sleep()."
-          },
+          "symbol": { "key": "scip-python python . test example/score." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 141,
-                "columnBegin": 18,
+                "columnBegin": 50,
                 "lineEnd": 141,
-                "columnEnd": 22
+                "columnEnd": 54
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 141,
+        "columnBegin": 57,
+        "lineEnd": 141,
+        "columnEnd": 66
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/high_score." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 141,
+                "columnBegin": 57,
+                "lineEnd": 141,
+                "columnEnd": 66
               }
             }
           }
@@ -5981,12 +4900,12 @@
         "lineBegin": 142,
         "columnBegin": 13,
         "lineEnd": 142,
-        "columnEnd": 16
+        "columnEnd": 17
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
           },
           "location": {
             "key": {
@@ -5995,36 +4914,7 @@
                 "lineBegin": 142,
                 "columnBegin": 13,
                 "lineEnd": 142,
-                "columnEnd": 16
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 142,
-        "columnBegin": 18,
-        "lineEnd": 142,
-        "columnEnd": 21
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#goto()."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 142,
-                "columnBegin": 18,
-                "lineEnd": 142,
-                "columnEnd": 21
+                "columnEnd": 17
               }
             }
           }
@@ -6044,7 +4934,7 @@
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
           },
           "location": {
             "key": {
@@ -6065,198 +4955,24 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 144,
-        "columnBegin": 13,
-        "lineEnd": 144,
-        "columnEnd": 18
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 144,
-                "columnBegin": 13,
-                "lineEnd": 144,
-                "columnEnd": 18
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 144,
-        "columnBegin": 22,
-        "lineEnd": 144,
-        "columnEnd": 27
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 144,
-                "columnBegin": 22,
-                "lineEnd": 144,
-                "columnEnd": 27
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 144,
-        "columnBegin": 29,
-        "lineEnd": 144,
-        "columnEnd": 34
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/choice."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 144,
-                "columnBegin": 29,
-                "lineEnd": 144,
-                "columnEnd": 34
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 145,
-        "columnBegin": 13,
-        "lineEnd": 145,
-        "columnEnd": 18
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 145,
-                "columnBegin": 13,
-                "lineEnd": 145,
-                "columnEnd": 18
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 145,
-        "columnBegin": 22,
-        "lineEnd": 145,
-        "columnEnd": 27
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/__init__:"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 145,
-                "columnBegin": 22,
-                "lineEnd": 145,
-                "columnEnd": 27
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 145,
-        "columnBegin": 29,
-        "lineEnd": 145,
-        "columnEnd": 34
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 random/choice."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 145,
-                "columnBegin": 29,
-                "lineEnd": 145,
-                "columnEnd": 34
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
         "lineBegin": 146,
-        "columnBegin": 17,
+        "columnBegin": 18,
         "lineEnd": 146,
-        "columnEnd": 23
+        "columnEnd": 22
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
+            "key": "scip-python python python-stdlib 3.11 builtins/range#"
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 146,
-                "columnBegin": 17,
+                "columnBegin": 18,
                 "lineEnd": 146,
-                "columnEnd": 23
+                "columnEnd": 22
               }
             }
           }
@@ -6275,9 +4991,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
+          "symbol": { "key": "scip-python python . test example/segments." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -6298,23 +5012,102 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 147,
-        "columnBegin": 17,
+        "columnBegin": 9,
         "lineEnd": 147,
-        "columnEnd": 23
+        "columnEnd": 9
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-          },
+          "symbol": { "key": "scip-python python . test example/x." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 147,
-                "columnBegin": 17,
+                "columnBegin": 9,
                 "lineEnd": 147,
-                "columnEnd": 23
+                "columnEnd": 9
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 147,
+        "columnBegin": 13,
+        "lineEnd": 147,
+        "columnEnd": 20
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/segments." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 147,
+                "columnBegin": 13,
+                "lineEnd": 147,
+                "columnEnd": 20
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 147,
+        "columnBegin": 22,
+        "lineEnd": 147,
+        "columnEnd": 26
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/index." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 147,
+                "columnBegin": 22,
+                "lineEnd": 147,
+                "columnEnd": 26
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 148,
+        "columnBegin": 9,
+        "lineEnd": 148,
+        "columnEnd": 9
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/y." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 148,
+                "columnBegin": 9,
+                "lineEnd": 148,
+                "columnEnd": 9
               }
             }
           }
@@ -6333,9 +5126,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-          },
+          "symbol": { "key": "scip-python python . test example/segments." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -6362,9 +5153,7 @@
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 typing/MutableSequence#clear()."
-          },
+          "symbol": { "key": "scip-python python . test example/index." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -6384,24 +5173,157 @@
     "key": {
       "file": { "key": "example.py" },
       "range": {
-        "lineBegin": 150,
-        "columnBegin": 13,
-        "lineEnd": 150,
-        "columnEnd": 17
+        "lineBegin": 149,
+        "columnBegin": 9,
+        "lineEnd": 149,
+        "columnEnd": 16
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-          },
+          "symbol": { "key": "scip-python python . test example/segments." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 149,
+                "columnBegin": 9,
+                "lineEnd": 149,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 149,
+        "columnBegin": 18,
+        "lineEnd": 149,
+        "columnEnd": 22
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/index." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 149,
+                "columnBegin": 18,
+                "lineEnd": 149,
+                "columnEnd": 22
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 149,
+        "columnBegin": 30,
+        "lineEnd": 149,
+        "columnEnd": 30
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/x." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 149,
+                "columnBegin": 30,
+                "lineEnd": 149,
+                "columnEnd": 30
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 149,
+        "columnBegin": 33,
+        "lineEnd": 149,
+        "columnEnd": 33
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/y." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 149,
+                "columnBegin": 33,
+                "lineEnd": 149,
+                "columnEnd": 33
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 150,
+        "columnBegin": 12,
+        "lineEnd": 150,
+        "columnEnd": 19
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/segments." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 150,
-                "columnBegin": 13,
+                "columnBegin": 12,
                 "lineEnd": 150,
-                "columnEnd": 17
+                "columnEnd": 19
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 151,
+        "columnBegin": 9,
+        "lineEnd": 151,
+        "columnEnd": 9
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/x." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 151,
+                "columnBegin": 9,
+                "lineEnd": 151,
+                "columnEnd": 9
               }
             }
           }
@@ -6416,13 +5338,11 @@
         "lineBegin": 151,
         "columnBegin": 13,
         "lineEnd": 151,
-        "columnEnd": 17
+        "columnEnd": 16
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -6430,7 +5350,63 @@
                 "lineBegin": 151,
                 "columnBegin": 13,
                 "lineEnd": 151,
-                "columnEnd": 17
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 151,
+        "columnBegin": 18,
+        "lineEnd": 151,
+        "columnEnd": 21
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#xcor()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 151,
+                "columnBegin": 18,
+                "lineEnd": 151,
+                "columnEnd": 21
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 152,
+        "columnBegin": 9,
+        "lineEnd": 152,
+        "columnEnd": 9
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/y." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 152,
+                "columnBegin": 9,
+                "lineEnd": 152,
+                "columnEnd": 9
               }
             }
           }
@@ -6445,13 +5421,11 @@
         "lineBegin": 152,
         "columnBegin": 13,
         "lineEnd": 152,
-        "columnEnd": 15
+        "columnEnd": 16
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
+          "symbol": { "key": "scip-python python . test example/head." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
@@ -6459,7 +5433,7 @@
                 "lineBegin": 152,
                 "columnBegin": 13,
                 "lineEnd": 152,
-                "columnEnd": 15
+                "columnEnd": 16
               }
             }
           }
@@ -6472,21 +5446,21 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 152,
-        "columnBegin": 17,
+        "columnBegin": 18,
         "lineEnd": 152,
         "columnEnd": 21
       },
       "xref": {
         "key": {
           "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#ycor()."
           },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 152,
-                "columnBegin": 17,
+                "columnBegin": 18,
                 "lineEnd": 152,
                 "columnEnd": 21
               }
@@ -6501,23 +5475,21 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 153,
-        "columnBegin": 13,
+        "columnBegin": 9,
         "lineEnd": 153,
-        "columnEnd": 15
+        "columnEnd": 16
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-          },
+          "symbol": { "key": "scip-python python . test example/segments." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 153,
-                "columnBegin": 13,
+                "columnBegin": 9,
                 "lineEnd": 153,
-                "columnEnd": 15
+                "columnEnd": 16
               }
             }
           }
@@ -6530,23 +5502,48 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 153,
-        "columnBegin": 17,
+        "columnBegin": 26,
         "lineEnd": 153,
-        "columnEnd": 21
+        "columnEnd": 26
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
-          },
+          "symbol": { "key": "scip-python python . test example/x." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 153,
-                "columnBegin": 17,
+                "columnBegin": 26,
                 "lineEnd": 153,
-                "columnEnd": 21
+                "columnEnd": 26
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 153,
+        "columnBegin": 29,
+        "lineEnd": 153,
+        "columnEnd": 29
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/y." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 153,
+                "columnBegin": 29,
+                "lineEnd": 153,
+                "columnEnd": 29
               }
             }
           }
@@ -6559,138 +5556,20 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 154,
-        "columnBegin": 17,
-        "lineEnd": 154,
-        "columnEnd": 21
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 154,
-                "columnBegin": 17,
-                "lineEnd": 154,
-                "columnEnd": 21
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 154,
-        "columnBegin": 24,
-        "lineEnd": 154,
-        "columnEnd": 33
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 154,
-                "columnBegin": 24,
-                "lineEnd": 154,
-                "columnEnd": 33
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 154,
-        "columnBegin": 37,
-        "lineEnd": 154,
-        "columnEnd": 41
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 154,
-                "columnBegin": 37,
-                "lineEnd": 154,
-                "columnEnd": 41
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 154,
-        "columnBegin": 53,
-        "lineEnd": 154,
-        "columnEnd": 56
-      },
-      "xref": {
-        "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
-          },
-          "location": {
-            "key": {
-              "file": { "key": "example.py" },
-              "range": {
-                "lineBegin": 154,
-                "columnBegin": 53,
-                "lineEnd": 154,
-                "columnEnd": 56
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "example.py" },
-      "range": {
-        "lineBegin": 155,
         "columnBegin": 5,
-        "lineEnd": 155,
+        "lineEnd": 154,
         "columnEnd": 8
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 time/__init__:"
-          },
+          "symbol": { "key": "scip-python python . test example/move()." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
-                "lineBegin": 155,
+                "lineBegin": 154,
                 "columnBegin": 5,
-                "lineEnd": 155,
+                "lineEnd": 154,
                 "columnEnd": 8
               }
             }
@@ -6704,23 +5583,21 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 155,
-        "columnBegin": 10,
+        "columnBegin": 9,
         "lineEnd": 155,
-        "columnEnd": 14
+        "columnEnd": 15
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python python-stdlib 3.11 time/sleep()."
-          },
+          "symbol": { "key": "scip-python python . test example/segment." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 155,
-                "columnBegin": 10,
+                "columnBegin": 9,
                 "lineEnd": 155,
-                "columnEnd": 14
+                "columnEnd": 15
               }
             }
           }
@@ -6733,22 +5610,885 @@
       "file": { "key": "example.py" },
       "range": {
         "lineBegin": 155,
-        "columnBegin": 16,
+        "columnBegin": 20,
         "lineEnd": 155,
-        "columnEnd": 20
+        "columnEnd": 27
       },
       "xref": {
         "key": {
-          "symbol": {
-            "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-          },
+          "symbol": { "key": "scip-python python . test example/segments." },
           "location": {
             "key": {
               "file": { "key": "example.py" },
               "range": {
                 "lineBegin": 155,
-                "columnBegin": 16,
+                "columnBegin": 20,
                 "lineEnd": 155,
+                "columnEnd": 27
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 156,
+        "columnBegin": 12,
+        "lineEnd": 156,
+        "columnEnd": 18
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/segment." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 156,
+                "columnBegin": 12,
+                "lineEnd": 156,
+                "columnEnd": 18
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 156,
+        "columnBegin": 29,
+        "lineEnd": 156,
+        "columnEnd": 32
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/head." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 156,
+                "columnBegin": 29,
+                "lineEnd": 156,
+                "columnEnd": 32
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 157,
+        "columnBegin": 13,
+        "lineEnd": 157,
+        "columnEnd": 16
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 time/__init__:"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 157,
+                "columnBegin": 13,
+                "lineEnd": 157,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 157,
+        "columnBegin": 18,
+        "lineEnd": 157,
+        "columnEnd": 22
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 time/sleep()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 157,
+                "columnBegin": 18,
+                "lineEnd": 157,
+                "columnEnd": 22
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 158,
+        "columnBegin": 13,
+        "lineEnd": 158,
+        "columnEnd": 16
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/head." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 158,
+                "columnBegin": 13,
+                "lineEnd": 158,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 158,
+        "columnBegin": 18,
+        "lineEnd": 158,
+        "columnEnd": 21
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/TNavigator#goto()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 158,
+                "columnBegin": 18,
+                "lineEnd": 158,
+                "columnEnd": 21
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 159,
+        "columnBegin": 13,
+        "lineEnd": 159,
+        "columnEnd": 16
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/head." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 159,
+                "columnBegin": 13,
+                "lineEnd": 159,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 160,
+        "columnBegin": 13,
+        "lineEnd": 160,
+        "columnEnd": 18
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/colors." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 160,
+                "columnBegin": 13,
+                "lineEnd": 160,
+                "columnEnd": 18
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 160,
+        "columnBegin": 22,
+        "lineEnd": 160,
+        "columnEnd": 27
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 random/__init__:"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 160,
+                "columnBegin": 22,
+                "lineEnd": 160,
+                "columnEnd": 27
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 160,
+        "columnBegin": 29,
+        "lineEnd": 160,
+        "columnEnd": 34
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 random/choice."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 160,
+                "columnBegin": 29,
+                "lineEnd": 160,
+                "columnEnd": 34
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 161,
+        "columnBegin": 13,
+        "lineEnd": 161,
+        "columnEnd": 18
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/shapes." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 161,
+                "columnBegin": 13,
+                "lineEnd": 161,
+                "columnEnd": 18
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 161,
+        "columnBegin": 22,
+        "lineEnd": 161,
+        "columnEnd": 27
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 random/__init__:"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 161,
+                "columnBegin": 22,
+                "lineEnd": 161,
+                "columnEnd": 27
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 161,
+        "columnBegin": 29,
+        "lineEnd": 161,
+        "columnEnd": 34
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 random/choice."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 161,
+                "columnBegin": 29,
+                "lineEnd": 161,
+                "columnEnd": 34
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 162,
+        "columnBegin": 17,
+        "lineEnd": 162,
+        "columnEnd": 23
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/segment." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 162,
+                "columnBegin": 17,
+                "lineEnd": 162,
+                "columnEnd": 23
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 162,
+        "columnBegin": 28,
+        "lineEnd": 162,
+        "columnEnd": 35
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/segments." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 162,
+                "columnBegin": 28,
+                "lineEnd": 162,
+                "columnEnd": 35
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 163,
+        "columnBegin": 17,
+        "lineEnd": 163,
+        "columnEnd": 23
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/segment." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 163,
+                "columnBegin": 17,
+                "lineEnd": 163,
+                "columnEnd": 23
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 164,
+        "columnBegin": 13,
+        "lineEnd": 164,
+        "columnEnd": 20
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/segments." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 164,
+                "columnBegin": 13,
+                "lineEnd": 164,
+                "columnEnd": 20
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 164,
+        "columnBegin": 22,
+        "lineEnd": 164,
+        "columnEnd": 26
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 typing/MutableSequence#clear()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 164,
+                "columnBegin": 22,
+                "lineEnd": 164,
+                "columnEnd": 26
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 166,
+        "columnBegin": 13,
+        "lineEnd": 166,
+        "columnEnd": 17
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/score." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 166,
+                "columnBegin": 13,
+                "lineEnd": 166,
+                "columnEnd": 17
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 167,
+        "columnBegin": 13,
+        "lineEnd": 167,
+        "columnEnd": 17
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/delay." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 167,
+                "columnBegin": 13,
+                "lineEnd": 167,
+                "columnEnd": 17
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 168,
+        "columnBegin": 13,
+        "lineEnd": 168,
+        "columnEnd": 15
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/pen." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 168,
+                "columnBegin": 13,
+                "lineEnd": 168,
+                "columnEnd": 15
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 168,
+        "columnBegin": 17,
+        "lineEnd": 168,
+        "columnEnd": 21
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#clear()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 168,
+                "columnBegin": 17,
+                "lineEnd": 168,
+                "columnEnd": 21
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 169,
+        "columnBegin": 13,
+        "lineEnd": 169,
+        "columnEnd": 15
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/pen." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 169,
+                "columnBegin": 13,
+                "lineEnd": 169,
+                "columnEnd": 15
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 169,
+        "columnBegin": 17,
+        "lineEnd": 169,
+        "columnEnd": 21
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 169,
+                "columnBegin": 17,
+                "lineEnd": 169,
+                "columnEnd": 21
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 170,
+        "columnBegin": 54,
+        "lineEnd": 170,
+        "columnEnd": 58
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/score." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 170,
+                "columnBegin": 54,
+                "lineEnd": 170,
+                "columnEnd": 58
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 170,
+        "columnBegin": 61,
+        "lineEnd": 170,
+        "columnEnd": 70
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/high_score." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 170,
+                "columnBegin": 61,
+                "lineEnd": 170,
+                "columnEnd": 70
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 171,
+        "columnBegin": 17,
+        "lineEnd": 171,
+        "columnEnd": 21
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(align)"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 171,
+                "columnBegin": 17,
+                "lineEnd": 171,
+                "columnEnd": 21
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 172,
+        "columnBegin": 17,
+        "lineEnd": 172,
+        "columnEnd": 20
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 turtle/RawTurtle#write().(font)"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 172,
+                "columnBegin": 17,
+                "lineEnd": 172,
+                "columnEnd": 20
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 174,
+        "columnBegin": 5,
+        "lineEnd": 174,
+        "columnEnd": 8
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 time/__init__:"
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 174,
+                "columnBegin": 5,
+                "lineEnd": 174,
+                "columnEnd": 8
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 174,
+        "columnBegin": 10,
+        "lineEnd": 174,
+        "columnEnd": 14
+      },
+      "xref": {
+        "key": {
+          "symbol": {
+            "key": "scip-python python python-stdlib 3.11 time/sleep()."
+          },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 174,
+                "columnBegin": 10,
+                "lineEnd": 174,
+                "columnEnd": 14
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.py" },
+      "range": {
+        "lineBegin": 174,
+        "columnBegin": 16,
+        "lineEnd": 174,
+        "columnEnd": 20
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "scip-python python . test example/delay." },
+          "location": {
+            "key": {
+              "file": { "key": "example.py" },
+              "range": {
+                "lineBegin": 174,
+                "columnBegin": 16,
+                "lineEnd": 174,
                 "columnEnd": 20
               }
             }

--- a/glean/lang/python-scip/tests/cases/xrefs/Symbol.out
+++ b/glean/lang/python-scip/tests/cases/xrefs/Symbol.out
@@ -1,68 +1,26 @@
 [
   "@generated",
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/__init__:"
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/godown()."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goleft()."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goright()."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/group()."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/move()."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-  },
-  {
-    "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-  },
+  { "key": "scip-python python . test example/__init__:" },
+  { "key": "scip-python python . test example/colors." },
+  { "key": "scip-python python . test example/delay." },
+  { "key": "scip-python python . test example/food." },
+  { "key": "scip-python python . test example/godown()." },
+  { "key": "scip-python python . test example/goleft()." },
+  { "key": "scip-python python . test example/goright()." },
+  { "key": "scip-python python . test example/group()." },
+  { "key": "scip-python python . test example/head." },
+  { "key": "scip-python python . test example/high_score." },
+  { "key": "scip-python python . test example/index." },
+  { "key": "scip-python python . test example/move()." },
+  { "key": "scip-python python . test example/new_segment." },
+  { "key": "scip-python python . test example/pen." },
+  { "key": "scip-python python . test example/score." },
+  { "key": "scip-python python . test example/segment." },
+  { "key": "scip-python python . test example/segments." },
+  { "key": "scip-python python . test example/shapes." },
+  { "key": "scip-python python . test example/wn." },
+  { "key": "scip-python python . test example/x." },
+  { "key": "scip-python python . test example/y." },
   { "key": "scip-python python python-stdlib 3.11 builtins/list#append()." },
   { "key": "scip-python python python-stdlib 3.11 builtins/range#" },
   { "key": "scip-python python python-stdlib 3.11 random/__init__:" },

--- a/glean/lang/python-scip/tests/cases/xrefs/SymbolDocumentation.out
+++ b/glean/lang/python-scip/tests/cases/xrefs/SymbolDocumentation.out
@@ -2,153 +2,115 @@
   "@generated",
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/__init__:"
-      },
+      "symbol": { "key": "scip-python python . test example/__init__:" },
       "docs": { "key": "(module) example" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-      },
+      "symbol": { "key": "scip-python python . test example/colors." },
       "docs": { "key": "```python\u000abuiltins.str\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-      },
+      "symbol": { "key": "scip-python python . test example/delay." },
       "docs": { "key": "```python\u000abuiltins.float\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
+      "symbol": { "key": "scip-python python . test example/food." },
       "docs": { "key": "```python\u000aturtle.Turtle\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/godown()."
-      },
+      "symbol": { "key": "scip-python python . test example/godown()." },
       "docs": { "key": "```python\u000adef godown(): # -> None:\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goleft()."
-      },
+      "symbol": { "key": "scip-python python . test example/goleft()." },
       "docs": { "key": "```python\u000adef goleft(): # -> None:\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goright()."
-      },
+      "symbol": { "key": "scip-python python . test example/goright()." },
       "docs": { "key": "```python\u000adef goright(): # -> None:\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/group()."
-      },
+      "symbol": { "key": "scip-python python . test example/group()." },
       "docs": { "key": "```python\u000adef group(): # -> None:\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "docs": { "key": "```python\u000aturtle.Turtle\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-      },
+      "symbol": { "key": "scip-python python . test example/high_score." },
       "docs": { "key": "```python\u000abuiltins.int\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/move()."
-      },
+      "symbol": { "key": "scip-python python . test example/move()." },
       "docs": { "key": "```python\u000adef move(): # -> None:\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-      },
+      "symbol": { "key": "scip-python python . test example/new_segment." },
       "docs": { "key": "```python\u000aturtle.Turtle\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
+      "symbol": { "key": "scip-python python . test example/pen." },
       "docs": { "key": "```python\u000aturtle.Turtle\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
+      "symbol": { "key": "scip-python python . test example/score." },
       "docs": { "key": "```python\u000abuiltins.int\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
+      "symbol": { "key": "scip-python python . test example/segments." },
       "docs": { "key": "```python\u000abuiltins.list\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-      },
+      "symbol": { "key": "scip-python python . test example/shapes." },
       "docs": { "key": "```python\u000abuiltins.str\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
+      "symbol": { "key": "scip-python python . test example/wn." },
       "docs": { "key": "```python\u000aturtle._Screen\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-      },
+      "symbol": { "key": "scip-python python . test example/x." },
       "docs": { "key": "```python\u000abuiltins.int\u000a```" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-      },
+      "symbol": { "key": "scip-python python . test example/y." },
       "docs": { "key": "```python\u000abuiltins.int\u000a```" }
     }
   }

--- a/glean/lang/python-scip/tests/cases/xrefs/SymbolKind.out
+++ b/glean/lang/python-scip/tests/cases/xrefs/SymbolKind.out
@@ -2,161 +2,121 @@
   "@generated",
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-      },
+      "symbol": { "key": "scip-python python . test example/colors." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-      },
+      "symbol": { "key": "scip-python python . test example/delay." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
+      "symbol": { "key": "scip-python python . test example/food." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/godown()."
-      },
+      "symbol": { "key": "scip-python python . test example/godown()." },
       "kind": 5
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goleft()."
-      },
+      "symbol": { "key": "scip-python python . test example/goleft()." },
       "kind": 5
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goright()."
-      },
+      "symbol": { "key": "scip-python python . test example/goright()." },
       "kind": 5
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/group()."
-      },
+      "symbol": { "key": "scip-python python . test example/group()." },
       "kind": 5
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-      },
+      "symbol": { "key": "scip-python python . test example/high_score." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-      },
+      "symbol": { "key": "scip-python python . test example/index." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/move()."
-      },
+      "symbol": { "key": "scip-python python . test example/move()." },
       "kind": 5
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-      },
+      "symbol": { "key": "scip-python python . test example/new_segment." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
+      "symbol": { "key": "scip-python python . test example/pen." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
+      "symbol": { "key": "scip-python python . test example/score." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-      },
+      "symbol": { "key": "scip-python python . test example/segment." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
+      "symbol": { "key": "scip-python python . test example/segments." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-      },
+      "symbol": { "key": "scip-python python . test example/shapes." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
+      "symbol": { "key": "scip-python python . test example/wn." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-      },
+      "symbol": { "key": "scip-python python . test example/x." },
       "kind": 12
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-      },
+      "symbol": { "key": "scip-python python . test example/y." },
       "kind": 12
     }
   },

--- a/glean/lang/python-scip/tests/cases/xrefs/SymbolName.out
+++ b/glean/lang/python-scip/tests/cases/xrefs/SymbolName.out
@@ -2,169 +2,127 @@
   "@generated",
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/__init__:"
-      },
+      "symbol": { "key": "scip-python python . test example/__init__:" },
       "name": { "key": "example/__init__" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/colors."
-      },
+      "symbol": { "key": "scip-python python . test example/colors." },
       "name": { "key": "example/colors" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/delay."
-      },
+      "symbol": { "key": "scip-python python . test example/delay." },
       "name": { "key": "example/delay" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/food."
-      },
+      "symbol": { "key": "scip-python python . test example/food." },
       "name": { "key": "example/food" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/godown()."
-      },
+      "symbol": { "key": "scip-python python . test example/godown()." },
       "name": { "key": "example/godown()" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goleft()."
-      },
+      "symbol": { "key": "scip-python python . test example/goleft()." },
       "name": { "key": "example/goleft()" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/goright()."
-      },
+      "symbol": { "key": "scip-python python . test example/goright()." },
       "name": { "key": "example/goright()" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/group()."
-      },
+      "symbol": { "key": "scip-python python . test example/group()." },
       "name": { "key": "example/group()" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/head."
-      },
+      "symbol": { "key": "scip-python python . test example/head." },
       "name": { "key": "example/head" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/high_score."
-      },
+      "symbol": { "key": "scip-python python . test example/high_score." },
       "name": { "key": "example/high_score" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/index."
-      },
+      "symbol": { "key": "scip-python python . test example/index." },
       "name": { "key": "example/index" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/move()."
-      },
+      "symbol": { "key": "scip-python python . test example/move()." },
       "name": { "key": "example/move()" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/new_segment."
-      },
+      "symbol": { "key": "scip-python python . test example/new_segment." },
       "name": { "key": "example/new_segment" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/pen."
-      },
+      "symbol": { "key": "scip-python python . test example/pen." },
       "name": { "key": "example/pen" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/score."
-      },
+      "symbol": { "key": "scip-python python . test example/score." },
       "name": { "key": "example/score" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segment."
-      },
+      "symbol": { "key": "scip-python python . test example/segment." },
       "name": { "key": "example/segment" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/segments."
-      },
+      "symbol": { "key": "scip-python python . test example/segments." },
       "name": { "key": "example/segments" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/shapes."
-      },
+      "symbol": { "key": "scip-python python . test example/shapes." },
       "name": { "key": "example/shapes" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/wn."
-      },
+      "symbol": { "key": "scip-python python . test example/wn." },
       "name": { "key": "example/wn" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/x."
-      },
+      "symbol": { "key": "scip-python python . test example/x." },
       "name": { "key": "example/x" }
     }
   },
   {
     "key": {
-      "symbol": {
-        "key": "scip-python python . 6335acee62d20004204dfbeb99f4bc2066268b3c example/y."
-      },
+      "symbol": { "key": "scip-python python . test example/y." },
       "name": { "key": "example/y" }
     }
   },


### PR DESCRIPTION
… identifier in python-scip symbols

Without this it defaults to the git commit hash, which varies on every run ==> not a stable symbol identifier.

Test plan:
`cabal test glean-snapshot-python-scip`

Fixes: https://github.com/facebookincubator/Glean/actions/runs/6975204422/job/18981977680 