### PR TITLE
[glean][rust] non-determininstic failures in rust-lsif and rust-scip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         # External hh_server hasn't caught up with the internal
         # version yet so the test output differs. Disable the Hack
         # tests temporarily.
-        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal test glean:tests -f-hack-tests -f-rust-tests
+        run: env DOTNET_ROOT="$HOME/.dotnet" LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal test glean:tests -f-hack-tests -f-rust-tests
 
   # check the vscode extension builds
   vscode:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         # External hh_server hasn't caught up with the internal
         # version yet so the test output differs. Disable the Hack
         # tests temporarily.
-        run: env DOTNET_ROOT="$HOME/.dotnet" LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal test glean:tests -f-hack-tests -f-rust-tests
+        run: env DOTNET_ROOT="$HOME/.dotnet" LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal test glean:tests -f-hack-tests -f-rust-tests -f-python-tests
 
   # check the vscode extension builds
   vscode:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         # External hh_server hasn't caught up with the internal
         # version yet so the test output differs. Disable the Hack
         # tests temporarily.
-        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal test glean:tests -f-hack-tests
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal test glean:tests -f-hack-tests -f-rust-tests
 
   # check the vscode extension builds
   vscode:

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -2423,19 +2423,6 @@ test-suite glass-regression-hack
     if !flag(hack-tests)
         buildable: False
 
-test-suite glass-regression-python-scip
-    import: glass-regression-deps, fb-haskell, deps
-    type: exitcode-stdio-1.0
-    main-is: Glean/Glass/Regression/PythonScip/Main.hs
-    ghc-options: -main-is Glean.Glass.Regression.PythonScip.Main
-    other-modules: Glean.Glass.Regression.PythonScip
-    build-depends:
-        glean:client-hs,
-        glean:indexers,
-        glean:util,
-    if !flag(python-tests)
-        buildable: False
-
 test-suite glass-regression-dotnet-scip
     import: glass-regression-deps, fb-haskell, deps
     type: exitcode-stdio-1.0

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -2423,19 +2423,6 @@ test-suite glass-regression-hack
     if !flag(hack-tests)
         buildable: False
 
-test-suite glass-regression-dotnet-scip
-    import: glass-regression-deps, fb-haskell, deps
-    type: exitcode-stdio-1.0
-    main-is: Glean/Glass/Regression/DotnetScip/Main.hs
-    ghc-options: -main-is Glean.Glass.Regression.DotnetScip.Main
-    other-modules: Glean.Glass.Regression.DotnetScip
-    build-depends:
-        glean:client-hs,
-        glean:indexers,
-        glean:util,
-    if !flag(dotnet-tests)
-        buildable: False
-
 test-suite glass-regression-typescript
     import: glass-regression-deps, fb-haskell, deps
     type: exitcode-stdio-1.0


### PR DESCRIPTION
Sensitive to OS versions/libc versions/compiler versions now, with different types and docs shown depending on local libs. Just disable for now as these are net negative and we have tons of existing SCIP tests