### PR TITLE
plugins can customize the server config

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1000,6 +1000,7 @@ library cli-types
         GleanCLI.Types
     build-depends:
         glean:client-hs-local,
+        glean:config,
         glean:db,
         glean:util,
 

--- a/glean/tools/gleancli/plugin/GleanCLI/Types.hs
+++ b/glean/tools/gleancli/plugin/GleanCLI/Types.hs
@@ -19,6 +19,7 @@ import Glean.Database.Env (withDatabases)
 import Glean.LocalOrRemote as Glean
     ( Service(..), LocalOrRemote, withBackendWithDefaultOptions )
 import Glean.Impl.ConfigProvider
+import qualified Glean.ServerConfig.Types as Server
 import Glean.Util.ConfigProvider
 
 #if GLEAN_FACEBOOK
@@ -35,6 +36,11 @@ class Plugin c where
   -- to Gflags. This can be used to add --minloglevel=N for example.
   argTransform :: c -> [String] -> [String]
   argTransform _ = id
+
+  -- | Allows transforming the server config to e.g. disable the janitor.
+  --   Only relevant when using a local DB root and setting a server config
+  serverConfigTransform :: c -> (Server.Config -> Server.Config)
+  serverConfigTransform _ = id
 
   runCommand
     :: (Glean.LocalOrRemote backend, ConfigProvider cfg)


### PR DESCRIPTION
Summary:
This Diff is a pure refactor.

The customization will be used to unconditionally set server config overrides for certain cli plugins, e.g.:

- disable janitor thread
- disable autobackups

Differential Revision: D52964156


