### PR TITLE
Add `[[noreturn]]` to 1 file inc glean/rts/binary.h

### DIFF
--- a/glean/rts/binary.h
+++ b/glean/rts/binary.h
@@ -109,7 +109,7 @@ struct Input {
       : buf(static_cast<const unsigned char*>(start),
             static_cast<const unsigned char*>(finish)) {}
 
-  void wantError(size_t n) const {
+  [[noreturn]] void wantError(size_t n) const {
     rts::error("truncated input: expected {} bytes, got {}", n, buf.size());
   }
 


### PR DESCRIPTION
Summary: LLVM-15 has a warning `-Wno-return` which can be used to identify functions that do not return. Qualifying these functions with `[[noreturn]]` is a perf optimization.

Differential Revision: D53815455


