### PR TITLE
Regen oss test outputs

### DIFF
--- a/glean/lang/typescript/tests/cases/xrefs/localname.out
+++ b/glean/lang/typescript/tests/cases/xrefs/localname.out
@@ -157,7 +157,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es2022.error.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es2022.error.d.ts`/Error#"
       },
       "name": { "key": "lib/`lib.es2022.error.d.ts`/Error" }
     }
@@ -165,7 +165,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es5.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es5.d.ts`/Error#"
       },
       "name": { "key": "lib/`lib.es5.d.ts`/Error" }
     }
@@ -173,7 +173,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es5.d.ts`/Error."
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es5.d.ts`/Error."
       },
       "name": { "key": "lib/`lib.es5.d.ts`/Error" }
     }

--- a/glean/lang/typescript/tests/cases/xrefs/references.out
+++ b/glean/lang/typescript/tests/cases/xrefs/references.out
@@ -127,7 +127,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es2022.error.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es2022.error.d.ts`/Error#"
       },
       "location": {
         "key": {
@@ -145,7 +145,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es2022.error.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es2022.error.d.ts`/Error#"
       },
       "location": {
         "key": {
@@ -163,7 +163,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es5.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es5.d.ts`/Error#"
       },
       "location": {
         "key": {
@@ -181,7 +181,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es5.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es5.d.ts`/Error#"
       },
       "location": {
         "key": {
@@ -199,7 +199,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es5.d.ts`/Error."
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es5.d.ts`/Error."
       },
       "location": {
         "key": {
@@ -217,7 +217,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es5.d.ts`/Error."
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es5.d.ts`/Error."
       },
       "location": {
         "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/symbol.out
+++ b/glean/lang/typescript/tests/cases/xrefs/symbol.out
@@ -28,8 +28,8 @@
   { "key": "scip-typescript npm . . `example.ts`/silent3:" },
   { "key": "scip-typescript npm . . `example.ts`/silent4:" },
   {
-    "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es2022.error.d.ts`/Error#"
+    "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es2022.error.d.ts`/Error#"
   },
-  { "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es5.d.ts`/Error#" },
-  { "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es5.d.ts`/Error." }
+  { "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es5.d.ts`/Error#" },
+  { "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es5.d.ts`/Error." }
 ]

--- a/glean/lang/typescript/tests/cases/xrefs/symbolkind.out
+++ b/glean/lang/typescript/tests/cases/xrefs/symbolkind.out
@@ -85,7 +85,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es2022.error.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es2022.error.d.ts`/Error#"
       },
       "kind": 4
     }
@@ -93,7 +93,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es5.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es5.d.ts`/Error#"
       },
       "kind": 4
     }
@@ -101,7 +101,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.5.2 lib/`lib.es5.d.ts`/Error."
+        "key": "scip-typescript npm typescript 5.5.3 lib/`lib.es5.d.ts`/Error."
       },
       "kind": 12
     }


### PR DESCRIPTION
Summary: I believe the typescript package manager is getting updated automatically causing these scip symbol version bumps. It's slightly annoying.

Differential Revision: D59361756
