### PR TITLE
Default unbound HasTy

### DIFF
--- a/glean/db/Glean/Query/Typecheck.hs
+++ b/glean/db/Glean/Query/Typecheck.hs
@@ -92,6 +92,7 @@ typecheck dbSchema opts rtsType query = do
       modify $ \s -> s { tcVisible = varsQuery query mempty }
       q@(TcQuery retTy _ _ _ _) <- inferQuery ContextPat query
         <* freeVariablesAreErrors <* unboundVariablesAreErrors
+      resolvePromote
       subst <- gets tcSubst
       whenDebug $ liftIO $ hPutStrLn stderr $ show $
         vcat [
@@ -101,7 +102,6 @@ typecheck dbSchema opts rtsType query = do
             ]),
           "query: " <> displayDefault q
         ]
-      resolvePromote
       zonkVars
       zonkTcQuery q
         `catchError` \_ -> do

--- a/glean/test/tests/Angle/AngleTest.hs
+++ b/glean/test/tests/Angle/AngleTest.hs
@@ -999,6 +999,21 @@ angleTypeTest = dbTestCase $ \env repo -> do
   print r
   assertEqual "angle - inference 6" 1 (length r)
 
+  -- default unbound hasTy
+  r <- runQuery_ env repo $ angleData @Text
+    [s|
+      "ok" where {} = {}
+    |]
+  print r
+  assertEqual "angle - inference 7" 1 (length r)
+
+  r <- runQuery_ env repo $ angleData @Text
+    [s|
+      "ok" where {a=2} = Y; Y.a?=2
+    |]
+  print r
+  assertEqual "angle - inference 8" 1 (length r)
+
 angleSetTest :: Test
 angleSetTest = dbTestCase $ \env repo -> do
   r <- runQuery_ env repo $ angleData @Glean.Test.Predicate


### PR DESCRIPTION
Summary:
If a record or sum type was not fully constrained, we could get
confusing errors about ambiguous types.

Before:

```
tmp> 3 where {} = {}
query has ambiguous type
    type: nat

1 |  3 where {} = {}
     ^
```

After: works

Reviewed By: donsbot

Differential Revision: D67144005


