### PR TITLE
Make regression tests depend on the schema

### DIFF
--- a/glean/test/regression/Glean/Regression/Config.hs
+++ b/glean/test/regression/Glean/Regression/Config.hs
@@ -26,4 +26,6 @@ data TestConfig = TestConfig
       -- multiple ways, e.g. for different platforms.
   , testSchemaVersion :: Maybe Int
       -- ^ version of 'all' schema to use in test DB
+  , testSchema :: Maybe FilePath
+      -- ^ Directory containing the schema files
   } deriving (Show)

--- a/glean/test/regression/Glean/Regression/Indexer.hs
+++ b/glean/test/regression/Glean/Regression/Indexer.hs
@@ -13,6 +13,7 @@ module Glean.Regression.Indexer
 
 import Control.Exception
 import qualified Data.IntMap as IntMap
+import Data.Maybe
 import System.FilePath
 
 import Glean.Database.Config
@@ -33,7 +34,9 @@ withTestBackend
 withTestBackend test action =
   withTestEnv settings (\env -> setSchema env >>= action . Some)
   where
-  settings = [ setRoot $ testOutput test </> "db" ]
+  settings = [ setRoot $ testOutput test </> "db" ] <>
+    map (setSchemaSource . schemaSourceFilesFromDir)
+      (maybeToList (testSchema test))
   setSchema env = case testSchemaVersion test of
     Nothing -> return env
     Just ver -> do

--- a/glean/test/regression/Glean/Regression/Snapshot.hs
+++ b/glean/test/regression/Glean/Regression/Snapshot.hs
@@ -146,6 +146,7 @@ executeTest cfg driver driverOpts base_group group diff subdir =
         , testRoot = cfgRoot cfg </> subdir
         , testProjectRoot = cfgProjectRoot cfg
         , testGroup = group
+        , testSchema = cfgSchema cfg
         , testSchemaVersion = cfgSchemaVersion cfg
         }
   createDirectoryIfMissing True $ testOutput test

--- a/glean/test/regression/Glean/Regression/Snapshot/Options.hs
+++ b/glean/test/regression/Glean/Regression/Snapshot/Options.hs
@@ -29,6 +29,8 @@ data Config = Config
     -- ^ parent path of *.query results
   , cfgReplace :: Maybe FilePath
     -- ^ when True overwrite golden *.out with query result
+  , cfgSchema :: Maybe FilePath
+    -- ^ Schema directory
   , cfgSchemaVersion :: Maybe Int
     -- ^ version of 'all' schema to use
   , cfgTests :: [String]
@@ -56,6 +58,9 @@ optionsWith other = O.info (O.helper <*> ((,) <$> parser <*> other)) O.fullDesc
       replaceAll <- O.switch $
         O.long "replace-all" <>
         O.help "Generate (overwrite) all golden *.out files instead of testing"
+      cfgSchema <- O.optional $ O.strOption $
+        O.long "schema" <>
+        O.help "Directory containing schema source files"
       cfgSchemaVersion <- O.optional $ O.option O.auto $
         O.long "schema-version" <> O.metavar "INT" <>
         O.help "version of 'all' schema to use for unversioned queries"

--- a/glean/test/regression/Glean/Regression/Test.hs
+++ b/glean/test/regression/Glean/Regression/Test.hs
@@ -76,6 +76,7 @@ createTestConfig repo group outDir cfg =
       , testRoot = cfgRoot cfg
       , testProjectRoot = cfgProjectRoot cfg
       , testGroup = group
+      , testSchema = cfgSchema cfg
       , testSchemaVersion = cfgSchemaVersion cfg
       }
 


### PR DESCRIPTION
Summary:
If the schema changes then we want to re-run regression tests; this
makes the dependency explicit so that CI will trigger the right tests.

Reviewed By: phlalx

Differential Revision: D67199916


