### PR TITLE
cabal: add `-rtsopts` to executables

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -63,7 +63,7 @@ common fb-cpp
   CXX_EXTRA_LIB_DIRS
 
 common exe
-  ghc-options: -threaded
+  ghc-options: -threaded -rtsopts
 
 flag clang
      default: False


### PR DESCRIPTION
Makes it easier to control various options, obviously.