### PR TITLE
cabal: turn off C++ `-Wnullability-completeness` warning

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -52,7 +52,7 @@ common fb-haskell
      ghc-options: -O2
 
 common fb-cpp
-  cxx-options: -std=c++17
+  cxx-options: -std=c++17 -Wno-nullability-completeness
   if !flag(clang)
      cxx-options: -fcoroutines
   if arch(x86_64)


### PR DESCRIPTION
This stops the C++ compiler from spitting out a little over 18,000 lines of C++ warnings about pointer nullability, which makes the GitHub logs actually unusable.