### PR TITLE
Regen typescript and dotnet test outputs

### DIFF
--- a/glean/glass/test/regression/Glean/Glass/Regression/TypeScript/Main.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/TypeScript/Main.hs
@@ -14,4 +14,4 @@ import qualified Glean.Glass.Regression.TypeScript as Glass
 main :: IO ()
 main = getArgs >>= \args -> withArgs (["--root", path] ++ args) Glass.main
   where
-    path = "glean/lang/typescript/tests/cases/xrefs"
+    path = "glean/lang/typescript-lsif/tests/cases/xrefs"

--- a/glean/glass/test/regression/tests/typescript/documentSymbolIndex.out
+++ b/glean/glass/test/regression/tests/typescript/documentSymbolIndex.out
@@ -3,7 +3,7 @@
     {
         "referenced_file_digests": {},
         "revision": "testhash",
-        "size": 30,
+        "size": 43,
         "symbols": {
             "1": [
                 {
@@ -119,6 +119,32 @@
                 {
                     "attributes": {
                         "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "6"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar res: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 14,
+                        "lineBegin": 16,
+                        "lineEnd": 16
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/6"
+                },
+                {
+                    "attributes": {
+                        "symbolKind": {
                             "aInteger": 10
                         },
                         "symbolLanguage": {
@@ -197,6 +223,158 @@
                         "lineEnd": 16
                     },
                     "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent0:"
+                }
+            ],
+            "17": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "6"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar res: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 9,
+                        "columnEnd": 12,
+                        "lineBegin": 17,
+                        "lineEnd": 17
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/6",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 11,
+                            "columnEnd": 14,
+                            "lineBegin": 16,
+                            "lineEnd": 16
+                        },
+                        "repository": "test"
+                    }
+                }
+            ],
+            "18": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "6"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar res: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 52,
+                        "columnEnd": 55,
+                        "lineBegin": 18,
+                        "lineEnd": 18
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/6",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 11,
+                            "columnEnd": 14,
+                            "lineBegin": 16,
+                            "lineEnd": 16
+                        },
+                        "repository": "test"
+                    }
+                }
+            ],
+            "19": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "6"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar res: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 14,
+                        "lineBegin": 19,
+                        "lineEnd": 19
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/6",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 11,
+                            "columnEnd": 14,
+                            "lineBegin": 16,
+                            "lineEnd": 16
+                        },
+                        "repository": "test"
+                    }
+                }
+            ],
+            "20": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "6"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar res: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 14,
+                        "lineBegin": 20,
+                        "lineEnd": 20
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/6",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 11,
+                            "columnEnd": 14,
+                            "lineBegin": 16,
+                            "lineEnd": 16
+                        },
+                        "repository": "test"
+                    }
                 }
             ],
             "24": [
@@ -565,6 +743,32 @@
                 {
                     "attributes": {
                         "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "9"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar addRes: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 17,
+                        "lineBegin": 35,
+                        "lineEnd": 35
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/9"
+                },
+                {
+                    "attributes": {
+                        "symbolKind": {
                             "aInteger": 10
                         },
                         "symbolLanguage": {
@@ -643,6 +847,158 @@
                         "lineEnd": 35
                     },
                     "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2Fsilent4:"
+                }
+            ],
+            "36": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "9"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar addRes: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 9,
+                        "columnEnd": 15,
+                        "lineBegin": 36,
+                        "lineEnd": 36
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/9",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 11,
+                            "columnEnd": 17,
+                            "lineBegin": 35,
+                            "lineEnd": 35
+                        },
+                        "repository": "test"
+                    }
+                }
+            ],
+            "37": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "9"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar addRes: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 51,
+                        "columnEnd": 57,
+                        "lineBegin": 37,
+                        "lineEnd": 37
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/9",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 11,
+                            "columnEnd": 17,
+                            "lineBegin": 35,
+                            "lineEnd": 35
+                        },
+                        "repository": "test"
+                    }
+                }
+            ],
+            "38": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "9"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar addRes: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 17,
+                        "lineBegin": 38,
+                        "lineEnd": 38
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/9",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 11,
+                            "columnEnd": 17,
+                            "lineBegin": 35,
+                            "lineEnd": 35
+                        },
+                        "repository": "test"
+                    }
+                }
+            ],
+            "39": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "9"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar addRes: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 17,
+                        "lineBegin": 39,
+                        "lineEnd": 39
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/9",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 11,
+                            "columnEnd": 17,
+                            "lineBegin": 35,
+                            "lineEnd": 35
+                        },
+                        "repository": "test"
+                    }
                 }
             ],
             "46": [
@@ -761,7 +1117,97 @@
                     "sym": "test/ts/scip-typescript/npm/././%60example.ts%60%2FcreateTempRepo%28%29.typeLiteral10:repoDir."
                 }
             ],
+            "47": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "13"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar repoDir: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 9,
+                        "columnEnd": 16,
+                        "lineBegin": 47,
+                        "lineEnd": 47
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/13"
+                }
+            ],
             "49": [
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "13"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar repoDir: any\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 23,
+                        "columnEnd": 30,
+                        "lineBegin": 49,
+                        "lineEnd": 49
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/13",
+                    "target": {
+                        "filepath": "example.ts",
+                        "range": {
+                            "columnBegin": 9,
+                            "columnEnd": 16,
+                            "lineBegin": 47,
+                            "lineEnd": 47
+                        },
+                        "repository": "test"
+                    }
+                },
+                {
+                    "attributes": {
+                        "symbolKind": {
+                            "aInteger": 15
+                        },
+                        "symbolLanguage": {
+                            "aInteger": 13
+                        },
+                        "symbolName": {
+                            "aString": "16"
+                        },
+                        "symbolParent": {
+                            "aString": ""
+                        },
+                        "symbolSignature": {
+                            "aString": "```ts\nvar git: Git\n```"
+                        }
+                    },
+                    "range": {
+                        "columnBegin": 9,
+                        "columnEnd": 12,
+                        "lineBegin": 49,
+                        "lineEnd": 49
+                    },
+                    "sym": "test/ts/example.ts%2Flocal/16"
+                },
                 {
                     "attributes": {
                         "symbolKind": {

--- a/glean/glass/test/regression/tests/typescript/documentSymbolListX.out
+++ b/glean/glass/test/regression/tests/typescript/documentSymbolListX.out
@@ -6,6 +6,170 @@
                 "attributes": [
                     {
                         "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "13"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar repoDir: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 9,
+                    "columnEnd": 16,
+                    "lineBegin": 47,
+                    "lineEnd": 47
+                },
+                "sym": "test/ts/example.ts%2Flocal/13"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "16"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar git: Git\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 9,
+                    "columnEnd": 12,
+                    "lineBegin": 49,
+                    "lineEnd": 49
+                },
+                "sym": "test/ts/example.ts%2Flocal/16"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "6"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar res: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 11,
+                    "columnEnd": 14,
+                    "lineBegin": 16,
+                    "lineEnd": 16
+                },
+                "sym": "test/ts/example.ts%2Flocal/6"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "9"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar addRes: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 11,
+                    "columnEnd": 17,
+                    "lineBegin": 35,
+                    "lineEnd": 35
+                },
+                "sym": "test/ts/example.ts%2Flocal/9"
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
                             "aInteger": 1
                         },
                         "key": "symbolKind"
@@ -806,6 +970,465 @@
         ],
         "referenced_file_digests": {},
         "references": [
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "13"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar repoDir: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 23,
+                    "columnEnd": 30,
+                    "lineBegin": 49,
+                    "lineEnd": 49
+                },
+                "sym": "test/ts/example.ts%2Flocal/13",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 9,
+                        "columnEnd": 16,
+                        "lineBegin": 47,
+                        "lineEnd": 47
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "6"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar res: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 9,
+                    "columnEnd": 12,
+                    "lineBegin": 17,
+                    "lineEnd": 17
+                },
+                "sym": "test/ts/example.ts%2Flocal/6",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 14,
+                        "lineBegin": 16,
+                        "lineEnd": 16
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "6"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar res: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 52,
+                    "columnEnd": 55,
+                    "lineBegin": 18,
+                    "lineEnd": 18
+                },
+                "sym": "test/ts/example.ts%2Flocal/6",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 14,
+                        "lineBegin": 16,
+                        "lineEnd": 16
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "6"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar res: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 11,
+                    "columnEnd": 14,
+                    "lineBegin": 19,
+                    "lineEnd": 19
+                },
+                "sym": "test/ts/example.ts%2Flocal/6",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 14,
+                        "lineBegin": 16,
+                        "lineEnd": 16
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "6"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar res: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 11,
+                    "columnEnd": 14,
+                    "lineBegin": 20,
+                    "lineEnd": 20
+                },
+                "sym": "test/ts/example.ts%2Flocal/6",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 14,
+                        "lineBegin": 16,
+                        "lineEnd": 16
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "9"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar addRes: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 9,
+                    "columnEnd": 15,
+                    "lineBegin": 36,
+                    "lineEnd": 36
+                },
+                "sym": "test/ts/example.ts%2Flocal/9",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 17,
+                        "lineBegin": 35,
+                        "lineEnd": 35
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "9"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar addRes: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 51,
+                    "columnEnd": 57,
+                    "lineBegin": 37,
+                    "lineEnd": 37
+                },
+                "sym": "test/ts/example.ts%2Flocal/9",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 17,
+                        "lineBegin": 35,
+                        "lineEnd": 35
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "9"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar addRes: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 11,
+                    "columnEnd": 17,
+                    "lineBegin": 38,
+                    "lineEnd": 38
+                },
+                "sym": "test/ts/example.ts%2Flocal/9",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 17,
+                        "lineBegin": 35,
+                        "lineEnd": 35
+                    },
+                    "repository": "test"
+                }
+            },
+            {
+                "attributes": [
+                    {
+                        "attribute": {
+                            "aInteger": 15
+                        },
+                        "key": "symbolKind"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "9"
+                        },
+                        "key": "symbolName"
+                    },
+                    {
+                        "attribute": {
+                            "aString": ""
+                        },
+                        "key": "symbolParent"
+                    },
+                    {
+                        "attribute": {
+                            "aString": "```ts\nvar addRes: any\n```"
+                        },
+                        "key": "symbolSignature"
+                    },
+                    {
+                        "attribute": {
+                            "aInteger": 13
+                        },
+                        "key": "symbolLanguage"
+                    }
+                ],
+                "range": {
+                    "columnBegin": 11,
+                    "columnEnd": 17,
+                    "lineBegin": 39,
+                    "lineEnd": 39
+                },
+                "sym": "test/ts/example.ts%2Flocal/9",
+                "target": {
+                    "filepath": "example.ts",
+                    "range": {
+                        "columnBegin": 11,
+                        "columnEnd": 17,
+                        "lineBegin": 35,
+                        "lineEnd": 35
+                    },
+                    "repository": "test"
+                }
+            },
             {
                 "attributes": [
                     {

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/Definition.out
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/Definition.out
@@ -2,6 +2,54 @@
   "@generated",
   {
     "key": {
+      "symbol": { "key": "Program.cs/local 0" },
+      "location": {
+        "key": {
+          "file": { "key": "Program.cs" },
+          "range": {
+            "lineBegin": 62,
+            "columnBegin": 13,
+            "lineEnd": 62,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 1" },
+      "location": {
+        "key": {
+          "file": { "key": "Program.cs" },
+          "range": {
+            "lineBegin": 65,
+            "columnBegin": 13,
+            "lineEnd": 65,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 2" },
+      "location": {
+        "key": {
+          "file": { "key": "Program.cs" },
+          "range": {
+            "lineBegin": 68,
+            "columnBegin": 13,
+            "lineEnd": 68,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
       "symbol": { "key": "scip-dotnet nuget . . ``/Dog#" },
       "location": {
         "key": {

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/Definition.perf
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/Definition.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Definition.1": 16 },
+  "facts_searched": { "scip.Definition.1": 19 },
   "full_scans": [ "scip.Definition.1" ]
 }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/DefinitionLocation.out
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/DefinitionLocation.out
@@ -439,5 +439,86 @@
         }
       }
     }
+  },
+  {
+    "key": {
+      "file": { "key": "Program.cs" },
+      "range": {
+        "lineBegin": 62,
+        "columnBegin": 13,
+        "lineEnd": 62,
+        "columnEnd": 13
+      },
+      "defn": {
+        "key": {
+          "symbol": { "key": "Program.cs/local 0" },
+          "location": {
+            "key": {
+              "file": { "key": "Program.cs" },
+              "range": {
+                "lineBegin": 62,
+                "columnBegin": 13,
+                "lineEnd": 62,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "Program.cs" },
+      "range": {
+        "lineBegin": 65,
+        "columnBegin": 13,
+        "lineEnd": 65,
+        "columnEnd": 13
+      },
+      "defn": {
+        "key": {
+          "symbol": { "key": "Program.cs/local 1" },
+          "location": {
+            "key": {
+              "file": { "key": "Program.cs" },
+              "range": {
+                "lineBegin": 65,
+                "columnBegin": 13,
+                "lineEnd": 65,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "Program.cs" },
+      "range": {
+        "lineBegin": 68,
+        "columnBegin": 13,
+        "lineEnd": 68,
+        "columnEnd": 13
+      },
+      "defn": {
+        "key": {
+          "symbol": { "key": "Program.cs/local 2" },
+          "location": {
+            "key": {
+              "file": { "key": "Program.cs" },
+              "range": {
+                "lineBegin": 68,
+                "columnBegin": 13,
+                "lineEnd": 68,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
   }
 ]

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/DefinitionLocation.perf
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/DefinitionLocation.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.DefinitionLocation.1": 16 },
+  "facts_searched": { "scip.DefinitionLocation.1": 19 },
   "full_scans": [ "scip.DefinitionLocation.1" ]
 }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/LocalName.out
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/LocalName.out
@@ -40,5 +40,8 @@
   { "key": "``/Mammal#`.ctor`(+1).(numberOfLegs" },
   { "key": "``/Mammal#`.ctor`(+1).(specie" },
   { "key": "``/Mammal#numberOfLegs" },
-  { "key": "``/Mammal#specie" }
+  { "key": "``/Mammal#specie" },
+  { "key": "local 0" },
+  { "key": "local 1" },
+  { "key": "local 2" }
 ]

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/LocalName.perf
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/LocalName.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.LocalName.1": 41 },
+  "facts_searched": { "scip.LocalName.1": 44 },
   "full_scans": [ "scip.LocalName.1" ]
 }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/Reference.out
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/Reference.out
@@ -2,6 +2,102 @@
   "@generated",
   {
     "key": {
+      "symbol": { "key": "Program.cs/local 0" },
+      "location": {
+        "key": {
+          "file": { "key": "Program.cs" },
+          "range": {
+            "lineBegin": 63,
+            "columnBegin": 30,
+            "lineEnd": 63,
+            "columnEnd": 30
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 0" },
+      "location": {
+        "key": {
+          "file": { "key": "Program.cs" },
+          "range": {
+            "lineBegin": 63,
+            "columnBegin": 45,
+            "lineEnd": 63,
+            "columnEnd": 45
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 1" },
+      "location": {
+        "key": {
+          "file": { "key": "Program.cs" },
+          "range": {
+            "lineBegin": 66,
+            "columnBegin": 30,
+            "lineEnd": 66,
+            "columnEnd": 30
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 1" },
+      "location": {
+        "key": {
+          "file": { "key": "Program.cs" },
+          "range": {
+            "lineBegin": 66,
+            "columnBegin": 45,
+            "lineEnd": 66,
+            "columnEnd": 45
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 2" },
+      "location": {
+        "key": {
+          "file": { "key": "Program.cs" },
+          "range": {
+            "lineBegin": 69,
+            "columnBegin": 30,
+            "lineEnd": 69,
+            "columnEnd": 30
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 2" },
+      "location": {
+        "key": {
+          "file": { "key": "Program.cs" },
+          "range": {
+            "lineBegin": 69,
+            "columnBegin": 45,
+            "lineEnd": 69,
+            "columnEnd": 45
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
       "symbol": { "key": "scip-dotnet nuget . . Collections/" },
       "location": {
         "key": {

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/Reference.perf
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/Reference.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Reference.1": 82 },
+  "facts_searched": { "scip.Reference.1": 88 },
   "full_scans": [ "scip.Reference.1" ]
 }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/ReferenceLocation.out
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/ReferenceLocation.out
@@ -393,6 +393,33 @@
       "file": { "key": "Program.cs" },
       "range": {
         "lineBegin": 63,
+        "columnBegin": 30,
+        "lineEnd": 63,
+        "columnEnd": 30
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "Program.cs/local 0" },
+          "location": {
+            "key": {
+              "file": { "key": "Program.cs" },
+              "range": {
+                "lineBegin": 63,
+                "columnBegin": 30,
+                "lineEnd": 63,
+                "columnEnd": 30
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "Program.cs" },
+      "range": {
+        "lineBegin": 63,
         "columnBegin": 32,
         "lineEnd": 63,
         "columnEnd": 37
@@ -408,6 +435,33 @@
                 "columnBegin": 32,
                 "lineEnd": 63,
                 "columnEnd": 37
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "Program.cs" },
+      "range": {
+        "lineBegin": 63,
+        "columnBegin": 45,
+        "lineEnd": 63,
+        "columnEnd": 45
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "Program.cs/local 0" },
+          "location": {
+            "key": {
+              "file": { "key": "Program.cs" },
+              "range": {
+                "lineBegin": 63,
+                "columnBegin": 45,
+                "lineEnd": 63,
+                "columnEnd": 45
               }
             }
           }
@@ -532,6 +586,33 @@
       "file": { "key": "Program.cs" },
       "range": {
         "lineBegin": 66,
+        "columnBegin": 30,
+        "lineEnd": 66,
+        "columnEnd": 30
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "Program.cs/local 1" },
+          "location": {
+            "key": {
+              "file": { "key": "Program.cs" },
+              "range": {
+                "lineBegin": 66,
+                "columnBegin": 30,
+                "lineEnd": 66,
+                "columnEnd": 30
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "Program.cs" },
+      "range": {
+        "lineBegin": 66,
         "columnBegin": 32,
         "lineEnd": 66,
         "columnEnd": 37
@@ -547,6 +628,33 @@
                 "columnBegin": 32,
                 "lineEnd": 66,
                 "columnEnd": 37
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "Program.cs" },
+      "range": {
+        "lineBegin": 66,
+        "columnBegin": 45,
+        "lineEnd": 66,
+        "columnEnd": 45
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "Program.cs/local 1" },
+          "location": {
+            "key": {
+              "file": { "key": "Program.cs" },
+              "range": {
+                "lineBegin": 66,
+                "columnBegin": 45,
+                "lineEnd": 66,
+                "columnEnd": 45
               }
             }
           }
@@ -671,6 +779,33 @@
       "file": { "key": "Program.cs" },
       "range": {
         "lineBegin": 69,
+        "columnBegin": 30,
+        "lineEnd": 69,
+        "columnEnd": 30
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "Program.cs/local 2" },
+          "location": {
+            "key": {
+              "file": { "key": "Program.cs" },
+              "range": {
+                "lineBegin": 69,
+                "columnBegin": 30,
+                "lineEnd": 69,
+                "columnEnd": 30
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "Program.cs" },
+      "range": {
+        "lineBegin": 69,
         "columnBegin": 32,
         "lineEnd": 69,
         "columnEnd": 37
@@ -686,6 +821,33 @@
                 "columnBegin": 32,
                 "lineEnd": 69,
                 "columnEnd": 37
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "Program.cs" },
+      "range": {
+        "lineBegin": 69,
+        "columnBegin": 45,
+        "lineEnd": 69,
+        "columnEnd": 45
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "Program.cs/local 2" },
+          "location": {
+            "key": {
+              "file": { "key": "Program.cs" },
+              "range": {
+                "lineBegin": 69,
+                "columnBegin": 45,
+                "lineEnd": 69,
+                "columnEnd": 45
               }
             }
           }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/ReferenceLocation.perf
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/ReferenceLocation.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.ReferenceLocation.1": 82 },
+  "facts_searched": { "scip.ReferenceLocation.1": 88 },
   "full_scans": [ "scip.ReferenceLocation.1" ]
 }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/Symbol.out
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/Symbol.out
@@ -1,5 +1,8 @@
 [
   "@generated",
+  { "key": "Program.cs/local 0" },
+  { "key": "Program.cs/local 1" },
+  { "key": "Program.cs/local 2" },
   { "key": "scip-dotnet nuget . . Collections/" },
   { "key": "scip-dotnet nuget . . Generic/" },
   { "key": "scip-dotnet nuget . . Http/" },

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/Symbol.perf
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/Symbol.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Symbol.1": 41 },
+  "facts_searched": { "scip.Symbol.1": 44 },
   "full_scans": [ "scip.Symbol.1" ]
 }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolDocumentation.out
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolDocumentation.out
@@ -2,6 +2,24 @@
   "@generated",
   {
     "key": {
+      "symbol": { "key": "Program.cs/local 0" },
+      "docs": { "key": "```cs\u000aMammal? m\u000a```" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 1" },
+      "docs": { "key": "```cs\u000aDog? d\u000a```" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 2" },
+      "docs": { "key": "```cs\u000aHuman? h\u000a```" }
+    }
+  },
+  {
+    "key": {
       "symbol": { "key": "scip-dotnet nuget . . ``/Dog#" },
       "docs": { "key": "```cs\u000aclass Dog\u000a```" }
     }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolDocumentation.perf
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolDocumentation.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.SymbolDocumentation.1": 16 },
+  "facts_searched": { "scip.SymbolDocumentation.1": 19 },
   "full_scans": [ "scip.SymbolDocumentation.1" ]
 }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolKind.out
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolKind.out
@@ -1,5 +1,8 @@
 [
   "@generated",
+  { "key": { "symbol": { "key": "Program.cs/local 0" }, "kind": 12 } },
+  { "key": { "symbol": { "key": "Program.cs/local 1" }, "kind": 12 } },
+  { "key": { "symbol": { "key": "Program.cs/local 2" }, "kind": 12 } },
   {
     "key": {
       "symbol": { "key": "scip-dotnet nuget . . Collections/" },

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolKind.perf
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolKind.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.SymbolKind.1": 41 },
+  "facts_searched": { "scip.SymbolKind.1": 44 },
   "full_scans": [ "scip.SymbolKind.1" ]
 }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolName.out
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolName.out
@@ -2,6 +2,24 @@
   "@generated",
   {
     "key": {
+      "symbol": { "key": "Program.cs/local 0" },
+      "name": { "key": "local 0" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 1" },
+      "name": { "key": "local 1" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "Program.cs/local 2" },
+      "name": { "key": "local 2" }
+    }
+  },
+  {
+    "key": {
       "symbol": { "key": "scip-dotnet nuget . . Collections/" },
       "name": { "key": "Collections" }
     }

--- a/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolName.perf
+++ b/glean/lang/dotnet-scip/tests/cases/xrefs/SymbolName.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.SymbolName.1": 41 },
+  "facts_searched": { "scip.SymbolName.1": 44 },
   "full_scans": [ "scip.SymbolName.1" ]
 }

--- a/glean/lang/typescript-lsif/tests/cases/xrefs/example.ts
+++ b/glean/lang/typescript-lsif/tests/cases/xrefs/example.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import shell from 'shelljs';
+
+class Git {
+  constructor(private dir: string) {
+    const res = shell.exec('git init', {cwd: dir, silent: true});
+    if (res.code !== 0) {
+      throw new Error(`git init exited with code ${res.code}.
+stderr: ${res.stderr}
+stdout: ${res.stdout}`);
+    }
+    // Doesn't matter currently
+    shell.exec('git config user.email "test@jc-verse.com"', {
+      cwd: dir,
+      silent: true,
+    });
+    shell.exec('git config user.name "Test"', {cwd: dir, silent: true});
+
+    shell.exec('git commit --allow-empty -m "First commit"', {
+      cwd: dir,
+      silent: true,
+    });
+  }
+  commit(msg: string, date: string, author: string): void {
+    const addRes = shell.exec('git add .', {cwd: this.dir, silent: true});
+    if (addRes.code !== 0) {
+      throw new Error(`git add exited with code ${addRes.code}.
+stderr: ${addRes.stderr}
+stdout: ${addRes.stdout}`);
+    }
+    }
+  }
+}
+
+// This function is sync so the same mock repo can be shared across tests
+export function createTempRepo(): {repoDir: string; git: Git} {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-test-repo'));
+
+  const git = new Git(repoDir);
+
+  return {repoDir, git};
+}

--- a/glean/lang/typescript-lsif/tests/cases/xrefs/tsconfig.json
+++ b/glean/lang/typescript-lsif/tests/cases/xrefs/tsconfig.json
@@ -1,0 +1,47 @@
+{
+  "compilerOptions": {
+    /* Emit */
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ESNext", "DOM"],
+    "declaration": true,
+    "declarationMap": false,
+    "jsx": "react",
+    "importHelpers": true,
+    "noEmitHelpers": true,
+
+    /* Strict Type-Checking Options */
+    "allowUnreachableCode": false,
+    // Too hard to turn on
+    "exactOptionalPropertyTypes": false,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    // `process.env` is usually accessed as property
+    "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": true,
+    /* strict family */
+    "strict": true,
+    "alwaysStrict": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "useUnknownInCatchVariables": true,
+    /* Handled by ESLint */
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "importsNotUsedAsValues": "remove",
+
+    /* Module Resolution */
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "skipLibCheck": true // @types/webpack and webpack/types.d.ts are not the same thing
+  }
+}

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityinfo.out
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityinfo.out
@@ -6,6 +6,106 @@
         "typescript": {
           "defn": {
             "key": {
+              "symbol": { "key": "example.ts/local 13" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 47,
+                    "columnBegin": 9,
+                    "lineEnd": 47,
+                    "columnEnd": 15
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "info": { "kind": 14, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 16" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 49,
+                    "columnBegin": 9,
+                    "lineEnd": 49,
+                    "columnEnd": 11
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "info": { "kind": 14, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "info": { "kind": 14, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "info": { "kind": 14, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
               "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
               "location": {
                 "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityinfo.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityinfo.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Definition.1": 21, "scip.SymbolKind.1": 11 },
+  "facts_searched": { "scip.Definition.1": 25, "scip.SymbolKind.1": 15 },
   "full_scans": [ "scip.Definition.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_entitylocation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_entitylocation.out
@@ -6,6 +6,154 @@
         "typescript": {
           "defn": {
             "key": {
+              "symbol": { "key": "example.ts/local 13" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 47,
+                    "columnBegin": 9,
+                    "lineEnd": 47,
+                    "columnEnd": 15
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "location": {
+        "name": "local 13",
+        "file": { "key": "example.ts" },
+        "location": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 47,
+            "columnBegin": 9,
+            "lineEnd": 47,
+            "columnEnd": 15
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 16" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 49,
+                    "columnBegin": 9,
+                    "lineEnd": 49,
+                    "columnEnd": 11
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "location": {
+        "name": "local 16",
+        "file": { "key": "example.ts" },
+        "location": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 49,
+            "columnBegin": 9,
+            "lineEnd": 49,
+            "columnEnd": 11
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "location": {
+        "name": "local 6",
+        "file": { "key": "example.ts" },
+        "location": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 16,
+            "columnBegin": 11,
+            "lineEnd": 16,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "location": {
+        "name": "local 9",
+        "file": { "key": "example.ts" },
+        "location": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 35,
+            "columnBegin": 11,
+            "lineEnd": 35,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
               "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
               "location": {
                 "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_entitylocation.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_entitylocation.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Definition.1": 21, "scip.SymbolName.1": 21 },
+  "facts_searched": { "scip.Definition.1": 25, "scip.SymbolName.1": 25 },
   "full_scans": [ "scip.Definition.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityuses.out
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityuses.out
@@ -6,6 +6,294 @@
         "typescript": {
           "defn": {
             "key": {
+              "symbol": { "key": "example.ts/local 13" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 47,
+                    "columnBegin": 9,
+                    "lineEnd": 47,
+                    "columnEnd": 15
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "example.ts" },
+      "range": {
+        "file": { "key": "example.ts" },
+        "lineBegin": 49,
+        "columnBegin": 23,
+        "lineEnd": 49,
+        "columnEnd": 29
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "example.ts" },
+      "range": {
+        "file": { "key": "example.ts" },
+        "lineBegin": 17,
+        "columnBegin": 9,
+        "lineEnd": 17,
+        "columnEnd": 11
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "example.ts" },
+      "range": {
+        "file": { "key": "example.ts" },
+        "lineBegin": 18,
+        "columnBegin": 52,
+        "lineEnd": 18,
+        "columnEnd": 54
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "example.ts" },
+      "range": {
+        "file": { "key": "example.ts" },
+        "lineBegin": 19,
+        "columnBegin": 11,
+        "lineEnd": 19,
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "example.ts" },
+      "range": {
+        "file": { "key": "example.ts" },
+        "lineBegin": 20,
+        "columnBegin": 11,
+        "lineEnd": 20,
+        "columnEnd": 13
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "example.ts" },
+      "range": {
+        "file": { "key": "example.ts" },
+        "lineBegin": 36,
+        "columnBegin": 9,
+        "lineEnd": 36,
+        "columnEnd": 14
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "example.ts" },
+      "range": {
+        "file": { "key": "example.ts" },
+        "lineBegin": 37,
+        "columnBegin": 51,
+        "lineEnd": 37,
+        "columnEnd": 56
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "example.ts" },
+      "range": {
+        "file": { "key": "example.ts" },
+        "lineBegin": 38,
+        "columnBegin": 11,
+        "lineEnd": 38,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "file": { "key": "example.ts" },
+      "range": {
+        "file": { "key": "example.ts" },
+        "lineBegin": 39,
+        "columnBegin": 11,
+        "lineEnd": 39,
+        "columnEnd": 16
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "typescript": {
+          "defn": {
+            "key": {
               "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
               "location": {
                 "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityuses.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_entityuses.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Definition.1": 21, "scip.Reference.1": 9 },
+  "facts_searched": { "scip.Definition.1": 25, "scip.Reference.1": 18 },
   "full_scans": [ "scip.Definition.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_fileentityxrefs.out
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_fileentityxrefs.out
@@ -456,5 +456,446 @@
         }
       }
     }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "xref": {
+        "target": {
+          "name": "local 13",
+          "file": { "key": "example.ts" },
+          "location": {
+            "range": {
+              "file": { "key": "example.ts" },
+              "lineBegin": 47,
+              "columnBegin": 9,
+              "lineEnd": 47,
+              "columnEnd": 15
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 49,
+            "columnBegin": 23,
+            "lineEnd": 49,
+            "columnEnd": 29
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 13" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 47,
+                    "columnBegin": 9,
+                    "lineEnd": 47,
+                    "columnEnd": 15
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "xref": {
+        "target": {
+          "name": "local 6",
+          "file": { "key": "example.ts" },
+          "location": {
+            "range": {
+              "file": { "key": "example.ts" },
+              "lineBegin": 16,
+              "columnBegin": 11,
+              "lineEnd": 16,
+              "columnEnd": 13
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 17,
+            "columnBegin": 9,
+            "lineEnd": 17,
+            "columnEnd": 11
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "xref": {
+        "target": {
+          "name": "local 6",
+          "file": { "key": "example.ts" },
+          "location": {
+            "range": {
+              "file": { "key": "example.ts" },
+              "lineBegin": 16,
+              "columnBegin": 11,
+              "lineEnd": 16,
+              "columnEnd": 13
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 18,
+            "columnBegin": 52,
+            "lineEnd": 18,
+            "columnEnd": 54
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "xref": {
+        "target": {
+          "name": "local 6",
+          "file": { "key": "example.ts" },
+          "location": {
+            "range": {
+              "file": { "key": "example.ts" },
+              "lineBegin": 16,
+              "columnBegin": 11,
+              "lineEnd": 16,
+              "columnEnd": 13
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 19,
+            "columnBegin": 11,
+            "lineEnd": 19,
+            "columnEnd": 13
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "xref": {
+        "target": {
+          "name": "local 6",
+          "file": { "key": "example.ts" },
+          "location": {
+            "range": {
+              "file": { "key": "example.ts" },
+              "lineBegin": 16,
+              "columnBegin": 11,
+              "lineEnd": 16,
+              "columnEnd": 13
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 20,
+            "columnBegin": 11,
+            "lineEnd": 20,
+            "columnEnd": 13
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "xref": {
+        "target": {
+          "name": "local 9",
+          "file": { "key": "example.ts" },
+          "location": {
+            "range": {
+              "file": { "key": "example.ts" },
+              "lineBegin": 35,
+              "columnBegin": 11,
+              "lineEnd": 35,
+              "columnEnd": 16
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 36,
+            "columnBegin": 9,
+            "lineEnd": 36,
+            "columnEnd": 14
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "xref": {
+        "target": {
+          "name": "local 9",
+          "file": { "key": "example.ts" },
+          "location": {
+            "range": {
+              "file": { "key": "example.ts" },
+              "lineBegin": 35,
+              "columnBegin": 11,
+              "lineEnd": 35,
+              "columnEnd": 16
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 37,
+            "columnBegin": 51,
+            "lineEnd": 37,
+            "columnEnd": 56
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "xref": {
+        "target": {
+          "name": "local 9",
+          "file": { "key": "example.ts" },
+          "location": {
+            "range": {
+              "file": { "key": "example.ts" },
+              "lineBegin": 35,
+              "columnBegin": 11,
+              "lineEnd": 35,
+              "columnEnd": 16
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 38,
+            "columnBegin": 11,
+            "lineEnd": 38,
+            "columnEnd": 16
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "xref": {
+        "target": {
+          "name": "local 9",
+          "file": { "key": "example.ts" },
+          "location": {
+            "range": {
+              "file": { "key": "example.ts" },
+              "lineBegin": 35,
+              "columnBegin": 11,
+              "lineEnd": 35,
+              "columnEnd": 16
+            }
+          }
+        },
+        "source": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 39,
+            "columnBegin": 11,
+            "lineEnd": 39,
+            "columnEnd": 16
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   }
 ]

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_fileentityxrefs.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_fileentityxrefs.perf
@@ -1,10 +1,10 @@
 {
   "@generated": null,
   "facts_searched": {
-    "scip.Definition.1": 9,
-    "scip.FileLanguage.1": 9,
-    "scip.ReferenceLocation.1": 15,
-    "scip.SymbolName.1": 9
+    "scip.Definition.1": 18,
+    "scip.FileLanguage.1": 18,
+    "scip.ReferenceLocation.1": 36,
+    "scip.SymbolName.1": 18
   },
   "full_scans": [ "scip.ReferenceLocation.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_resolvelocation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_resolvelocation.out
@@ -804,5 +804,153 @@
         }
       }
     }
+  },
+  {
+    "key": {
+      "location": {
+        "name": "local 13",
+        "file": { "key": "example.ts" },
+        "location": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 47,
+            "columnBegin": 9,
+            "lineEnd": 47,
+            "columnEnd": 15
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 13" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 47,
+                    "columnBegin": 9,
+                    "lineEnd": 47,
+                    "columnEnd": 15
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "location": {
+        "name": "local 16",
+        "file": { "key": "example.ts" },
+        "location": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 49,
+            "columnBegin": 9,
+            "lineEnd": 49,
+            "columnEnd": 11
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 16" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 49,
+                    "columnBegin": 9,
+                    "lineEnd": 49,
+                    "columnEnd": 11
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "location": {
+        "name": "local 6",
+        "file": { "key": "example.ts" },
+        "location": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 16,
+            "columnBegin": 11,
+            "lineEnd": 16,
+            "columnEnd": 13
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "location": {
+        "name": "local 9",
+        "file": { "key": "example.ts" },
+        "location": {
+          "range": {
+            "file": { "key": "example.ts" },
+            "lineBegin": 35,
+            "columnBegin": 11,
+            "lineEnd": 35,
+            "columnEnd": 16
+          }
+        }
+      },
+      "entity": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   }
 ]

--- a/glean/lang/typescript/tests/cases/xrefs/codemarkup_resolvelocation.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/codemarkup_resolvelocation.perf
@@ -1,9 +1,9 @@
 {
   "@generated": null,
   "facts_searched": {
-    "scip.DefinitionLocation.1": 21,
+    "scip.DefinitionLocation.1": 25,
     "scip.FileLanguage.1": 1,
-    "scip.SymbolName.1": 21
+    "scip.SymbolName.1": 25
   },
   "full_scans": [ "scip.FileLanguage.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/definition.out
+++ b/glean/lang/typescript/tests/cases/xrefs/definition.out
@@ -2,6 +2,70 @@
   "@generated",
   {
     "key": {
+      "symbol": { "key": "example.ts/local 13" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 47,
+            "columnBegin": 9,
+            "lineEnd": 47,
+            "columnEnd": 15
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 16" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 49,
+            "columnBegin": 9,
+            "lineEnd": 49,
+            "columnEnd": 11
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 6" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 16,
+            "columnBegin": 11,
+            "lineEnd": 16,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 9" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 11,
+            "lineEnd": 35,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
       "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
       "location": {
         "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/definition.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/definition.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Definition.1": 21 },
+  "facts_searched": { "scip.Definition.1": 25 },
   "full_scans": [ "scip.Definition.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/definitionlocation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/definitionlocation.out
@@ -117,6 +117,33 @@
       "file": { "key": "example.ts" },
       "range": {
         "lineBegin": 16,
+        "columnBegin": 11,
+        "lineEnd": 16,
+        "columnEnd": 13
+      },
+      "defn": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "range": {
+        "lineBegin": 16,
         "columnBegin": 41,
         "lineEnd": 16,
         "columnEnd": 43
@@ -449,6 +476,33 @@
       "file": { "key": "example.ts" },
       "range": {
         "lineBegin": 35,
+        "columnBegin": 11,
+        "lineEnd": 35,
+        "columnEnd": 16
+      },
+      "defn": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "range": {
+        "lineBegin": 35,
         "columnBegin": 45,
         "lineEnd": 35,
         "columnEnd": 47
@@ -578,6 +632,60 @@
                 "columnBegin": 53,
                 "lineEnd": 46,
                 "columnEnd": 55
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "range": {
+        "lineBegin": 47,
+        "columnBegin": 9,
+        "lineEnd": 47,
+        "columnEnd": 15
+      },
+      "defn": {
+        "key": {
+          "symbol": { "key": "example.ts/local 13" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 47,
+                "columnBegin": 9,
+                "lineEnd": 47,
+                "columnEnd": 15
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "example.ts" },
+      "range": {
+        "lineBegin": 49,
+        "columnBegin": 9,
+        "lineEnd": 49,
+        "columnEnd": 11
+      },
+      "defn": {
+        "key": {
+          "symbol": { "key": "example.ts/local 16" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 49,
+                "columnBegin": 9,
+                "lineEnd": 49,
+                "columnEnd": 11
               }
             }
           }

--- a/glean/lang/typescript/tests/cases/xrefs/definitionlocation.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/definitionlocation.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.DefinitionLocation.1": 21 },
+  "facts_searched": { "scip.DefinitionLocation.1": 25 },
   "full_scans": [ "scip.DefinitionLocation.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/definitionuse.out
+++ b/glean/lang/typescript/tests/cases/xrefs/definitionuse.out
@@ -4,6 +4,330 @@
     "key": {
       "target": {
         "key": {
+          "symbol": { "key": "example.ts/local 13" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 47,
+                "columnBegin": 9,
+                "lineEnd": 47,
+                "columnEnd": 15
+              }
+            }
+          }
+        }
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 13" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 49,
+                "columnBegin": 23,
+                "lineEnd": 49,
+                "columnEnd": 29
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 17,
+                "columnBegin": 9,
+                "lineEnd": 17,
+                "columnEnd": 11
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 18,
+                "columnBegin": 52,
+                "lineEnd": 18,
+                "columnEnd": 54
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 19,
+                "columnBegin": 11,
+                "lineEnd": 19,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 20,
+                "columnBegin": 11,
+                "lineEnd": 20,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 36,
+                "columnBegin": 9,
+                "lineEnd": 36,
+                "columnEnd": 14
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 37,
+                "columnBegin": 51,
+                "lineEnd": 37,
+                "columnEnd": 56
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 38,
+                "columnBegin": 11,
+                "lineEnd": 38,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      },
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 39,
+                "columnBegin": 11,
+                "lineEnd": 39,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "target": {
+        "key": {
           "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
           "location": {
             "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/definitionuse.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/definitionuse.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Definition.1": 21, "scip.Reference.1": 9 },
+  "facts_searched": { "scip.Definition.1": 25, "scip.Reference.1": 18 },
   "full_scans": [ "scip.Definition.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/defn_documentation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/defn_documentation.out
@@ -4,6 +4,90 @@
     "key": {
       "defn": {
         "key": {
+          "symbol": { "key": "example.ts/local 13" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 47,
+                "columnBegin": 9,
+                "lineEnd": 47,
+                "columnEnd": 15
+              }
+            }
+          }
+        }
+      },
+      "docs": { "key": "```ts\u000avar repoDir: any\u000a```" }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
+          "symbol": { "key": "example.ts/local 16" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 49,
+                "columnBegin": 9,
+                "lineEnd": 49,
+                "columnEnd": 11
+              }
+            }
+          }
+        }
+      },
+      "docs": { "key": "```ts\u000avar git: Git\u000a```" }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      },
+      "docs": { "key": "```ts\u000avar res: any\u000a```" }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      },
+      "docs": { "key": "```ts\u000avar addRes: any\u000a```" }
+    }
+  },
+  {
+    "key": {
+      "defn": {
+        "key": {
           "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
           "location": {
             "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/defn_documentation.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/defn_documentation.perf
@@ -1,8 +1,8 @@
 {
   "@generated": null,
   "facts_searched": {
-    "scip.Definition.1": 21,
-    "scip.SymbolDocumentation.1": 21
+    "scip.Definition.1": 25,
+    "scip.SymbolDocumentation.1": 25
   },
   "full_scans": [ "scip.Definition.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/documentation.out
+++ b/glean/lang/typescript/tests/cases/xrefs/documentation.out
@@ -2,6 +2,30 @@
   "@generated",
   {
     "key": {
+      "symbol": { "key": "example.ts/local 13" },
+      "docs": { "key": "```ts\u000avar repoDir: any\u000a```" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 16" },
+      "docs": { "key": "```ts\u000avar git: Git\u000a```" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 6" },
+      "docs": { "key": "```ts\u000avar res: any\u000a```" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 9" },
+      "docs": { "key": "```ts\u000avar addRes: any\u000a```" }
+    }
+  },
+  {
+    "key": {
       "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
       "docs": { "key": "```ts\u000amodule \"example.ts\"\u000a```" }
     }

--- a/glean/lang/typescript/tests/cases/xrefs/documentation.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/documentation.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.SymbolDocumentation.1": 21 },
+  "facts_searched": { "scip.SymbolDocumentation.1": 25 },
   "full_scans": [ "scip.SymbolDocumentation.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/entity.out
+++ b/glean/lang/typescript/tests/cases/xrefs/entity.out
@@ -6,6 +6,102 @@
         "typescript": {
           "defn": {
             "key": {
+              "symbol": { "key": "example.ts/local 13" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 47,
+                    "columnBegin": 9,
+                    "lineEnd": 47,
+                    "columnEnd": 15
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "scip": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 16" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 49,
+                    "columnBegin": 9,
+                    "lineEnd": 49,
+                    "columnEnd": 11
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "scip": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 6" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 16,
+                    "columnBegin": 11,
+                    "lineEnd": 16,
+                    "columnEnd": 13
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "scip": {
+        "typescript": {
+          "defn": {
+            "key": {
+              "symbol": { "key": "example.ts/local 9" },
+              "location": {
+                "key": {
+                  "file": { "key": "example.ts" },
+                  "range": {
+                    "lineBegin": 35,
+                    "columnBegin": 11,
+                    "lineEnd": 35,
+                    "columnEnd": 16
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "scip": {
+        "typescript": {
+          "defn": {
+            "key": {
               "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
               "location": {
                 "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/entity.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/entity.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Definition.1": 21 },
+  "facts_searched": { "scip.Definition.1": 25 },
   "full_scans": [ "scip.Definition.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/localname.out
+++ b/glean/lang/typescript/tests/cases/xrefs/localname.out
@@ -2,6 +2,54 @@
   "@generated",
   {
     "key": {
+      "symbol": { "key": "example.ts/local 0" },
+      "name": { "key": "local 0" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 1" },
+      "name": { "key": "local 1" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 13" },
+      "name": { "key": "local 13" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 16" },
+      "name": { "key": "local 16" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 2" },
+      "name": { "key": "local 2" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 3" },
+      "name": { "key": "local 3" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 6" },
+      "name": { "key": "local 6" }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 9" },
+      "name": { "key": "local 9" }
+    }
+  },
+  {
+    "key": {
       "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
       "name": { "key": "`example.ts`" }
     }
@@ -145,7 +193,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es2022.error.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es2022.error.d.ts`/Error#"
       },
       "name": { "key": "lib/`lib.es2022.error.d.ts`/Error" }
     }
@@ -153,7 +201,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es5.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es5.d.ts`/Error#"
       },
       "name": { "key": "lib/`lib.es5.d.ts`/Error" }
     }
@@ -161,7 +209,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es5.d.ts`/Error."
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es5.d.ts`/Error."
       },
       "name": { "key": "lib/`lib.es5.d.ts`/Error" }
     }

--- a/glean/lang/typescript/tests/cases/xrefs/localname.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/localname.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.SymbolName.1": 24 },
+  "facts_searched": { "scip.SymbolName.1": 32 },
   "full_scans": [ "scip.SymbolName.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/references.out
+++ b/glean/lang/typescript/tests/cases/xrefs/references.out
@@ -2,6 +2,342 @@
   "@generated",
   {
     "key": {
+      "symbol": { "key": "example.ts/local 0" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 9,
+            "columnBegin": 8,
+            "lineEnd": 9,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 0" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 47,
+            "columnBegin": 19,
+            "lineEnd": 47,
+            "columnEnd": 20
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 1" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 10,
+            "columnBegin": 8,
+            "lineEnd": 10,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 1" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 47,
+            "columnBegin": 44,
+            "lineEnd": 47,
+            "columnEnd": 45
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 13" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 49,
+            "columnBegin": 23,
+            "lineEnd": 49,
+            "columnEnd": 29
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 2" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 11,
+            "columnBegin": 8,
+            "lineEnd": 11,
+            "columnEnd": 11
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 2" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 47,
+            "columnBegin": 34,
+            "lineEnd": 47,
+            "columnEnd": 37
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 3" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 12,
+            "columnBegin": 8,
+            "lineEnd": 12,
+            "columnEnd": 12
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 3" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 16,
+            "columnBegin": 17,
+            "lineEnd": 16,
+            "columnEnd": 21
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 3" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 23,
+            "columnBegin": 5,
+            "lineEnd": 23,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 3" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 27,
+            "columnBegin": 5,
+            "lineEnd": 27,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 3" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 29,
+            "columnBegin": 5,
+            "lineEnd": 29,
+            "columnEnd": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 3" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 35,
+            "columnBegin": 20,
+            "lineEnd": 35,
+            "columnEnd": 24
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 6" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 17,
+            "columnBegin": 9,
+            "lineEnd": 17,
+            "columnEnd": 11
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 6" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 18,
+            "columnBegin": 52,
+            "lineEnd": 18,
+            "columnEnd": 54
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 6" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 19,
+            "columnBegin": 11,
+            "lineEnd": 19,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 6" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 20,
+            "columnBegin": 11,
+            "lineEnd": 20,
+            "columnEnd": 13
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 9" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 36,
+            "columnBegin": 9,
+            "lineEnd": 36,
+            "columnEnd": 14
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 9" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 37,
+            "columnBegin": 51,
+            "lineEnd": 37,
+            "columnEnd": 56
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 9" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 38,
+            "columnBegin": 11,
+            "lineEnd": 38,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "symbol": { "key": "example.ts/local 9" },
+      "location": {
+        "key": {
+          "file": { "key": "example.ts" },
+          "range": {
+            "lineBegin": 39,
+            "columnBegin": 11,
+            "lineEnd": 39,
+            "columnEnd": 16
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
       "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
       "location": {
         "key": {
@@ -163,7 +499,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es2022.error.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es2022.error.d.ts`/Error#"
       },
       "location": {
         "key": {
@@ -181,7 +517,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es2022.error.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es2022.error.d.ts`/Error#"
       },
       "location": {
         "key": {
@@ -199,7 +535,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es5.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es5.d.ts`/Error#"
       },
       "location": {
         "key": {
@@ -217,7 +553,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es5.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es5.d.ts`/Error#"
       },
       "location": {
         "key": {
@@ -235,7 +571,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es5.d.ts`/Error."
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es5.d.ts`/Error."
       },
       "location": {
         "key": {
@@ -253,7 +589,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es5.d.ts`/Error."
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es5.d.ts`/Error."
       },
       "location": {
         "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/references.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/references.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Reference.1": 15 },
+  "facts_searched": { "scip.Reference.1": 36 },
   "full_scans": [ "scip.Reference.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/referencetarget.out
+++ b/glean/lang/typescript/tests/cases/xrefs/referencetarget.out
@@ -4,6 +4,330 @@
     "key": {
       "xref": {
         "key": {
+          "symbol": { "key": "example.ts/local 13" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 49,
+                "columnBegin": 23,
+                "lineEnd": 49,
+                "columnEnd": 29
+              }
+            }
+          }
+        }
+      },
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 13" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 47,
+                "columnBegin": 9,
+                "lineEnd": 47,
+                "columnEnd": 15
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 17,
+                "columnBegin": 9,
+                "lineEnd": 17,
+                "columnEnd": 11
+              }
+            }
+          }
+        }
+      },
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 18,
+                "columnBegin": 52,
+                "lineEnd": 18,
+                "columnEnd": 54
+              }
+            }
+          }
+        }
+      },
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 19,
+                "columnBegin": 11,
+                "lineEnd": 19,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      },
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 20,
+                "columnBegin": 11,
+                "lineEnd": 20,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      },
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 6" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 16,
+                "columnBegin": 11,
+                "lineEnd": 16,
+                "columnEnd": 13
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 36,
+                "columnBegin": 9,
+                "lineEnd": 36,
+                "columnEnd": 14
+              }
+            }
+          }
+        }
+      },
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 37,
+                "columnBegin": 51,
+                "lineEnd": 37,
+                "columnEnd": 56
+              }
+            }
+          }
+        }
+      },
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 38,
+                "columnBegin": 11,
+                "lineEnd": 38,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      },
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "xref": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 39,
+                "columnBegin": 11,
+                "lineEnd": 39,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      },
+      "target": {
+        "key": {
+          "symbol": { "key": "example.ts/local 9" },
+          "location": {
+            "key": {
+              "file": { "key": "example.ts" },
+              "range": {
+                "lineBegin": 35,
+                "columnBegin": 11,
+                "lineEnd": 35,
+                "columnEnd": 16
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "xref": {
+        "key": {
           "symbol": { "key": "scip-typescript npm . . `example.ts`/Git#" },
           "location": {
             "key": {

--- a/glean/lang/typescript/tests/cases/xrefs/referencetarget.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/referencetarget.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Definition.1": 9, "scip.Reference.1": 15 },
+  "facts_searched": { "scip.Definition.1": 18, "scip.Reference.1": 36 },
   "full_scans": [ "scip.Reference.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/symbol.out
+++ b/glean/lang/typescript/tests/cases/xrefs/symbol.out
@@ -1,5 +1,13 @@
 [
   "@generated",
+  { "key": "example.ts/local 0" },
+  { "key": "example.ts/local 1" },
+  { "key": "example.ts/local 13" },
+  { "key": "example.ts/local 16" },
+  { "key": "example.ts/local 2" },
+  { "key": "example.ts/local 3" },
+  { "key": "example.ts/local 6" },
+  { "key": "example.ts/local 9" },
   { "key": "scip-typescript npm . . `example.ts`/" },
   { "key": "scip-typescript npm . . `example.ts`/Git#" },
   { "key": "scip-typescript npm . . `example.ts`/Git#`<constructor>`()." },
@@ -26,8 +34,8 @@
   { "key": "scip-typescript npm . . `example.ts`/silent3:" },
   { "key": "scip-typescript npm . . `example.ts`/silent4:" },
   {
-    "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es2022.error.d.ts`/Error#"
+    "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es2022.error.d.ts`/Error#"
   },
-  { "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es5.d.ts`/Error#" },
-  { "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es5.d.ts`/Error." }
+  { "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es5.d.ts`/Error#" },
+  { "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es5.d.ts`/Error." }
 ]

--- a/glean/lang/typescript/tests/cases/xrefs/symbol.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/symbol.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.Symbol.1": 24 },
+  "facts_searched": { "scip.Symbol.1": 32 },
   "full_scans": [ "scip.Symbol.1" ]
 }

--- a/glean/lang/typescript/tests/cases/xrefs/symbolkind.out
+++ b/glean/lang/typescript/tests/cases/xrefs/symbolkind.out
@@ -1,5 +1,13 @@
 [
   "@generated",
+  { "key": { "symbol": { "key": "example.ts/local 0" }, "kind": 12 } },
+  { "key": { "symbol": { "key": "example.ts/local 1" }, "kind": 12 } },
+  { "key": { "symbol": { "key": "example.ts/local 13" }, "kind": 12 } },
+  { "key": { "symbol": { "key": "example.ts/local 16" }, "kind": 12 } },
+  { "key": { "symbol": { "key": "example.ts/local 2" }, "kind": 12 } },
+  { "key": { "symbol": { "key": "example.ts/local 3" }, "kind": 12 } },
+  { "key": { "symbol": { "key": "example.ts/local 6" }, "kind": 12 } },
+  { "key": { "symbol": { "key": "example.ts/local 9" }, "kind": 12 } },
   {
     "key": {
       "symbol": { "key": "scip-typescript npm . . `example.ts`/" },
@@ -85,7 +93,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es2022.error.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es2022.error.d.ts`/Error#"
       },
       "kind": 4
     }
@@ -93,7 +101,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es5.d.ts`/Error#"
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es5.d.ts`/Error#"
       },
       "kind": 4
     }
@@ -101,7 +109,7 @@
   {
     "key": {
       "symbol": {
-        "key": "scip-typescript npm typescript 5.7.3 lib/`lib.es5.d.ts`/Error."
+        "key": "scip-typescript npm typescript 5.8.2 lib/`lib.es5.d.ts`/Error."
       },
       "kind": 12
     }

--- a/glean/lang/typescript/tests/cases/xrefs/symbolkind.perf
+++ b/glean/lang/typescript/tests/cases/xrefs/symbolkind.perf
@@ -1,5 +1,5 @@
 {
   "@generated": null,
-  "facts_searched": { "scip.SymbolKind.1": 14 },
+  "facts_searched": { "scip.SymbolKind.1": 22 },
   "full_scans": [ "scip.SymbolKind.1" ]
 }


### PR DESCRIPTION
* Regenerate test outputs for typescript and dotnet after local symbols were added to scip indexer
* Move glass-regression-typescript test results to glean/lang/typescript-lsif to prevent conflicts with glean-snapshot-typescript tests