### PR TITLE
Make --replace-all work for OSS

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1469,6 +1469,7 @@ library regression-test-lib
         Glean.Regression.Snapshot.Result
         Glean.Regression.Snapshot.Transform
         Glean.Regression.Test
+    ghc-options: -DOSS=1
     build-depends:
         glean:client-hs,
         glean:client-hs-local,

--- a/glean/test/regression/Glean/Regression/Snapshot/Options.hs
+++ b/glean/test/regression/Glean/Regression/Snapshot/Options.hs
@@ -7,6 +7,7 @@
 -}
 
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE CPP #-}
 module Glean.Regression.Snapshot.Options
   ( Config(..)
   , options
@@ -77,7 +78,11 @@ optionsWith other = O.info (O.helper <*> ((,) <$> parser <*> other)) O.fullDesc
       replace <-
         if replaceAll
         then do
+#if OSS
+          src <- pure (cfgProjectRoot </> root)
+#else
           src <- sourcePath root
+#endif
           putStrLn src
           return (Just src)
         else mapM makeAbsolute cfgReplace


### PR DESCRIPTION
Updating test output is a bit of a pain with Cabal,  because you have to look up the test root (which is already set by the test) and pass it as an argument to `--replace`. With Buck this is all handled by `-c glean.test=replace` but we don't have that for Cabal.

This makes `--replace-all` just use the root provided by the test in the OSS build.

To update test output, e.g.

```
cabal run glean-snapshot-typescript -- --replace-all
```