### PR TITLE
Split Glean.Derive out of glean:lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Build glean-clang
         run: make glean-clang
 
-      - if: matrix.ghc != '8.6.5'
+      - if: matrix.ghc != '8.6.5' && matrix.ghc != '9.4.7'
         name: Build hiedb-indexer
         run: make glean-hiedb
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [8.6.5, 8.8.4, 8.10.7, 9.2.8]
+        ghc: [8.6.5, 8.8.4, 8.10.7, 9.2.8, 9.4.7]
         compiler: [gcc]
         index-state: [2025-04-14T00:00:00Z]
         include:

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -47,9 +47,9 @@ common fb-haskell
         TypeSynonymInstances
         NondecreasingIndentation
 
-  ghc-options: -Wall -Wno-orphans -Wno-name-shadowing
-  if flag(opt)
-     ghc-options: -O2
+    ghc-options: -Wall -Wno-orphans -Wno-name-shadowing
+    if flag(opt)
+       ghc-options: -O2
 
 common fb-cpp
   cxx-options: -std=c++17 -Wno-nullability-completeness
@@ -137,10 +137,11 @@ common deps
         random,
         regex-base,
         regex-pcre,
-        base >=4.11.1 && <4.17,
+        base >=4.11.1 && <4.18,
         array ^>=0.5.2.0,
         async ^>=2.2.1,
         attoparsec >=0.13.2.3 && <0.15,
+        attoparsec-aeson >= 2.1 && < 2.3,
         unordered-containers ^>=0.2.9.0,
         containers,
         contravariant ^>=1.5,
@@ -157,12 +158,12 @@ common deps
         unix ^>=2.7.2.2,
         process ^>=1.6.3.0,
         prettyprinter >=1.2.1 && <1.8,
-        time >=1.8.0.2 && <1.12,
+        time >=1.8.0.2 && <1.13,
         binary ^>=0.8.5.1,
         deepseq ^>=1.4.3.0,
         hashable >=1.2.7.0 && <1.6,
         tar ^>=0.5.1.0,
-        ghc-prim >=0.5.2.0 && <0.9,
+        ghc-prim >=0.5.2.0 && <0.10,
         parsec ^>=3.1.13.0,
         haxl >= 2.1.2.0 && < 2.6,
         hinotify ^>= 0.4.1
@@ -1319,7 +1320,7 @@ library bench-util
         Glean.Util.Benchmark
     build-depends:
         glean:stubs,
-        criterion < 1.6
+        criterion < 1.7
 
 executable query-bench
     import: fb-haskell, fb-cpp, deps, exe
@@ -1338,7 +1339,7 @@ executable query-bench
         glean:schema,
         glean:test-lib,
         glean:util,
-        criterion < 1.6
+        criterion < 1.7
 
 executable rename-bench
     import: fb-haskell, fb-cpp, deps, exe
@@ -1354,7 +1355,7 @@ executable rename-bench
         glean:schema,
         glean:test-lib,
         glean:util,
-        criterion < 1.6
+        criterion < 1.7
 
 executable user-query-bench
     import: fb-haskell, fb-cpp, deps, exe
@@ -1371,7 +1372,7 @@ executable user-query-bench
         glean:schema,
         glean:test-lib,
         glean:util,
-        criterion < 1.6
+        criterion < 1.7
 
 executable makefact-bench
     import: fb-haskell, deps, exe
@@ -1386,7 +1387,7 @@ executable makefact-bench
         glean:core,
         glean:schema,
         glean:test-lib,
-        criterion < 1.6
+        criterion < 1.7
 
 executable compile-bench
     import: fb-haskell, fb-cpp, deps, exe
@@ -1403,7 +1404,7 @@ executable compile-bench
         glean:schema,
         glean:test-lib,
         glean:util,
-        criterion < 1.6,
+        criterion < 1.7,
         criterion-measurement,
         statistics,
         vector-algorithms

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1085,7 +1085,7 @@ executable hack-derive
 -- Haskell indexer via hiedb
 executable hiedb-indexer
     import: deps, fb-haskell, exe
-    if impl(ghc >= 8.8)
+    if impl(ghc >= 8.8 && < 9.4)
       buildable: True
     else
       buildable: False

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -832,12 +832,21 @@ executable gen-bytecode-hs
         glean:bytecode,
         glean:bytecode-instruction
 
-library lib
+library lib-derive
     import: fb-haskell, fb-cpp, deps
     visibility: public
     hs-source-dirs: glean/lib
     exposed-modules:
         Glean.Derive
+    build-depends:
+        glean:client-hs,
+        glean:if-glean-hs
+
+library lib
+    import: fb-haskell, fb-cpp, deps
+    visibility: public
+    hs-source-dirs: glean/lib
+    exposed-modules:
         Glean.Util.CxxXRef
         Glean.Util.Declarations
         Glean.Util.Range
@@ -985,7 +994,7 @@ library indexers
         glean:db,
         glean:handler,
         glean:interprocess,
-        glean:lib,
+        glean:lib-derive,
         glean:lsif,
         glean:scip,
         glean:stubs,
@@ -1031,7 +1040,7 @@ executable glean
         glean:stubs,
         glean:config,
         glean:core,
-        glean:lib,
+        glean:lib-derive,
         glean:util,
         json,
         split,
@@ -1109,6 +1118,7 @@ executable hiedb-indexer
         glean:db,
         glean:if-glean-hs,
         glean:lib,
+        glean:lib-derive,
         glean:schema,
         glean:stubs,
         glean:util,
@@ -1492,6 +1502,7 @@ library clang-derive-lib
         glean:core,
         glean:db,
         glean:lib,
+        glean:lib-derive,
         glean:schema,
         glean:util,
         vector-algorithms
@@ -1985,7 +1996,7 @@ test-suite schematest
         glean:config,
         glean:if-glean-hs,
         glean:if-internal-hs,
-        glean:lib,
+        glean:lib-derive,
         glean:util,
 
 test-suite schemaevolves
@@ -2063,7 +2074,7 @@ test-suite incremental
         glean:core,
         glean:db,
         glean:if-glean-hs,
-        glean:lib,
+        glean:lib-derive,
         glean:schema
     if arch(x86_64)
         buildable: True

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -147,7 +147,7 @@ common deps
         contravariant ^>=1.5,
         text ^>=1.2.3.0,
         bytestring >=0.10.8.2 && <0.12,
-        vector >=0.12.0.1 && <0.13,
+        vector >=0.12.0.1 && <0.14,
         transformers ^>=0.5.6.2,
         network-uri ^>=2.6.1.0,
         stm ^>=2.5.0.0,
@@ -363,6 +363,7 @@ library util
         Glean.Util.TransitiveClosure
         Glean.Util.Trace
         Glean.Util.ValueBuffer
+        Glean.Util.Vector
         Glean.Util.Warden
     build-depends:
         glean:stubs,

--- a/glean/db/Glean/Database/Delete.hs
+++ b/glean/db/Glean/Database/Delete.hs
@@ -107,7 +107,7 @@ asyncDeleteDatabase :: HasCallStack => Env -> Repo -> IO (Async ())
 asyncDeleteDatabase env@Env{..} repo = bracket
   newEmptyTMVarIO
   (\todo -> atomically $ tryPutTMVar todo Nothing) $ \todo -> do
-    remover <- Warden.spawnMask envWarden $ const $ removeDatabase env repo todo
+    remover <- Warden.spawnMask envWarden $ \_ -> removeDatabase env repo todo
     join $ atomically $ do
       active <- HashMap.lookup repo <$> readTVar envActive
       let deleteDB db = do

--- a/glean/hs/Glean/RTS/Foreign/Define.hs
+++ b/glean/hs/Glean/RTS/Foreign/Define.hs
@@ -17,7 +17,6 @@ module Glean.RTS.Foreign.Define
 
 import Control.Exception
 import Control.Monad
-import Data.Coerce (coerce)
 import Data.Default
 import Data.Typeable
 import qualified Data.Vector.Storable as VS
@@ -35,6 +34,7 @@ import Glean.RTS.Foreign.Inventory (Inventory)
 import Glean.RTS.Foreign.Subst (Subst)
 import Glean.RTS.Types (Fid(..), Pid(..), invalidFid)
 import qualified Glean.Types as Thrift
+import Glean.Util.Vector
 
 -- | A reference to a thing we can define facts in
 newtype Define = Define (Ptr Define)
@@ -108,7 +108,7 @@ defineBatch facts inventory batch DefineFlags{..} =
     withIds f
       | Just ids <- Thrift.batch_ids batch =
           if fromIntegral (VS.length ids) == Thrift.batch_count batch
-            then VS.unsafeWith (coerce ids) f
+            then VS.unsafeWith (unsafeCoerceVector ids) f
             else throwIO $
               Thrift.Exception "mismatch between count and ids.size in batch"
       | otherwise = f nullPtr

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -140,6 +140,7 @@ executable clang-derive
         glean:core,
         glean:db,
         glean:lib,
+        glean:lib-derive,
         glean:schema,
         glean:util,
         vector-algorithms

--- a/glean/lang/clang/glean-clang.cabal
+++ b/glean/lang/clang/glean-clang.cabal
@@ -41,7 +41,7 @@ common deps
         ansi-terminal ^>= 0.11,
         array ^>=0.5.2.0,
         async ^>=2.2.1,
-        base >=4.11.1 && <4.17,
+        base >=4.11.1 && <4.18,
         containers,
         data-default,
         deepseq ^>=1.4.3.0,

--- a/glean/lang/lsif/Data/LSIF/Angle.hs
+++ b/glean/lang/lsif/Data/LSIF/Angle.hs
@@ -16,6 +16,7 @@ make developer iteration quicker.
 -}
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 
 module Data.LSIF.Angle (
     factToAngle, Predicate, PredicateMap,
@@ -481,7 +482,11 @@ withResultSet id f g = do
 toName :: Tag -> Value
 toName = string . tagText
 
+#if MIN_VERSION_aeson(2,2,0)
+tagToRange :: KeyValue e a => Tag -> Maybe [a]
+#else
 tagToRange :: KeyValue a => Tag -> Maybe [a]
+#endif
 tagToRange Definition{..} = Just ["fullRange" .= toRange fullRange]
 tagToRange Declaration{..} = Just ["fullRange" .= toRange fullRange]
 tagToRange _ = Nothing

--- a/glean/lang/lsif/Data/LSIF/Gen.hs
+++ b/glean/lang/lsif/Data/LSIF/Gen.hs
@@ -13,6 +13,7 @@ converters
 
 -}
 
+{-# LANGUAGE CPP #-}
 module Data.LSIF.Gen (
 
     Predicate(..),
@@ -83,7 +84,11 @@ predicateId :: Applicative f => Text -> Id -> [Pair] -> f [Predicate]
 predicateId name id_ facts =
   pure [Predicate name [object [factId id_, key facts ]]]
 
+#if MIN_VERSION_aeson(2,2,0)
+key :: KeyValue e kv => [Pair] -> kv
+#else
 key :: KeyValue kv => [Pair] -> kv
+#endif
 key xs = "key" .= object xs
 
 string :: Text -> Value
@@ -95,7 +100,11 @@ srcFile id_ path = Predicate "src.File" [
     object [ factId id_, "key" .= path ]
   ]
 
+#if MIN_VERSION_aeson(2,2,0)
+factId :: KeyValue e kv => Id -> kv
+#else
 factId :: KeyValue kv => Id -> kv
+#endif
 factId (Id id_) = "id" .= id_
 
 -- | Accumulate predicates

--- a/glean/util/Glean/Util/Vector.hs
+++ b/glean/util/Glean/Util/Vector.hs
@@ -1,0 +1,22 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+{-# LANGUAGE CPP #-}
+module Glean.Util.Vector (
+    unsafeCoerceVector
+  ) where
+
+import Data.Vector.Storable
+#if !MIN_VERSION_vector(0,13,0)
+import Data.Coerce
+#endif
+
+#if !MIN_VERSION_vector(0,13,0)
+unsafeCoerceVector :: Coercible a b => Vector a -> Vector b
+unsafeCoerceVector = coerce
+#endif


### PR DESCRIPTION
So that `exe:glean` and `exe:glean-server` don't depend on the schemas.