### PR TITLE
Add `import: exe` to test-suite stanzas

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1498,7 +1498,7 @@ library regression-test-lib
         yaml
 
 library clang-derive-lib
-    import: fb-haskell, fb-cpp, deps, exe
+    import: fb-haskell, fb-cpp, deps
     hs-source-dirs: glean/lang/clang
     build-depends:
         ghc-compact,
@@ -1522,7 +1522,7 @@ library clang-derive-lib
         Derive.Types
 
 test-suite clang-test-regression
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, exe
     hs-source-dirs:
        glean/lang/clang/tests,
        glean/lang/clang/tests/github
@@ -1539,7 +1539,7 @@ test-suite clang-test-regression
         buildable: False
 
 test-suite clang-test-derivefamilies
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, exe
     hs-source-dirs:
        glean/lang/clang/tests,
        glean/lang/clang/tests/github
@@ -1561,7 +1561,7 @@ test-suite clang-test-derivefamilies
         buildable: False
 
 test-suite clang-test-deriveattributes
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, exe
     hs-source-dirs:
        glean/lang/clang/tests,
        glean/lang/clang/tests/github
@@ -1583,7 +1583,7 @@ test-suite clang-test-deriveattributes
         buildable: False
 
 test-suite clang-test-derivefuncalls
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, exe
     hs-source-dirs:
        glean/lang/clang/tests,
        glean/lang/clang/tests/github
@@ -1605,7 +1605,7 @@ test-suite clang-test-derivefuncalls
         buildable: False
 
 test-suite clang-test-deriveobjcinherit
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, exe
     hs-source-dirs:
        glean/lang/clang/tests,
        glean/lang/clang/tests/github
@@ -1627,7 +1627,7 @@ test-suite clang-test-deriveobjcinherit
         buildable: False
 
 test-suite clang-test-codemarkup
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, exe
     hs-source-dirs:
        glean/lang/clang/tests,
        glean/lang/clang/tests/github
@@ -1649,7 +1649,7 @@ test-suite clang-test-codemarkup
         buildable: False
 
 test-suite hack-derive-test
-    import: fb-haskell, fb-cpp, deps
+    import: fb-haskell, fb-cpp, deps, exe
     hs-source-dirs: glean/lang/hack/tests
     type: exitcode-stdio-1.0
     main-is: Main.hs
@@ -1826,7 +1826,7 @@ test-suite jsonwrite
         glean:schema,
 
 test-suite BinaryTest
-    import: fb-cpp
+    import: fb-cpp, exe
     type: exitcode-stdio-1.0
     main-is: glean/rts/tests/BinaryTest.cpp
     ghc-options: -no-hs-main
@@ -2110,7 +2110,7 @@ test-suite glass-range
 -- Glean snapshot regression tests, these require the indexers installed
 --
 test-suite glean-snapshot-flow
-    import: fb-haskell, deps
+    import: fb-haskell, deps, exe
     hs-source-dirs: glean/lang/codemarkup/tests/flow
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/Flow/Main.hs
@@ -2122,7 +2122,7 @@ test-suite glean-snapshot-flow
         buildable: False
 
 test-suite glean-snapshot-hack
-    import: fb-haskell, deps
+    import: fb-haskell, deps, exe
     hs-source-dirs: glean/lang/codemarkup/tests/hack
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/Hack/Main.hs
@@ -2147,7 +2147,7 @@ test-suite glean-snapshot-rust-lsif
         buildable: False
 
 test-suite glean-snapshot-rust-scip
-    import: fb-haskell, deps
+    import: fb-haskell, deps, exe
     hs-source-dirs: glean/lang/rust-scip/tests
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/RustScip/Main.hs
@@ -2159,7 +2159,7 @@ test-suite glean-snapshot-rust-scip
         buildable: False
 
 test-suite glean-snapshot-python-scip
-    import: fb-haskell, deps
+    import: fb-haskell, deps, exe
     hs-source-dirs: glean/lang/python-scip/tests
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/PythonScip/Main.hs
@@ -2171,7 +2171,7 @@ test-suite glean-snapshot-python-scip
         buildable: False
 
 test-suite glean-snapshot-dotnet-scip
-    import: fb-haskell, deps
+    import: fb-haskell, deps, exe
     hs-source-dirs: glean/lang/dotnet-scip/tests
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/DotnetScip/Main.hs
@@ -2183,7 +2183,7 @@ test-suite glean-snapshot-dotnet-scip
         buildable: False
 
 test-suite glean-snapshot-typescript
-    import: fb-haskell, deps
+    import: fb-haskell, deps, exe
     hs-source-dirs: glean/lang/codemarkup/tests/typescript
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/TypeScript/Main.hs
@@ -2195,7 +2195,7 @@ test-suite glean-snapshot-typescript
         buildable: False
 
 test-suite glean-snapshot-go
-    import: fb-haskell, deps
+    import: fb-haskell, deps, exe
     hs-source-dirs: glean/lang/codemarkup/tests/go/
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/Go/Main.hs
@@ -2207,7 +2207,7 @@ test-suite glean-snapshot-go
         buildable: False
 
 test-suite glean-snapshot-java-lsif
-    import: fb-haskell, deps
+    import: fb-haskell, deps, exe
     hs-source-dirs: glean/lang/java-lsif/tests
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/JavaLsif/Main.hs
@@ -2219,7 +2219,7 @@ test-suite glean-snapshot-java-lsif
         buildable: False
 
 test-suite glean-snapshot-lsif
-    import: fb-haskell, deps
+    import: fb-haskell, deps, exe
     hs-source-dirs: glean/lang/codemarkup/tests/lsif/
     type: exitcode-stdio-1.0
     main-is: Glean/Regression/Lsif/Main.hs
@@ -2264,14 +2264,14 @@ common glass-regression-deps
         glean:regression-test-lib,
 
 test-suite glass-regression-buck
-    import: glass-regression-deps, fb-haskell, deps
+    import: glass-regression-deps, fb-haskell, deps, exe
     type: exitcode-stdio-1.0
     main-is: Glean/Glass/Regression/Buck.hs
     ghc-options: -main-is Glean.Glass.Regression.Buck
     buildable: False
 
 test-suite glass-regression-cpp
-   import: glass-regression-deps, fb-haskell, deps
+   import: glass-regression-deps, fb-haskell, deps, exe
    type: exitcode-stdio-1.0
    hs-source-dirs:
      glean/glass/test/regression,
@@ -2298,7 +2298,7 @@ test-suite glass-regression-cpp
         buildable: False
 
 test-suite glass-regression-flow
-    import: glass-regression-deps, fb-haskell, deps
+    import: glass-regression-deps, fb-haskell, deps, exe
     type: exitcode-stdio-1.0
     main-is: Glean/Glass/Regression/Flow/Main.hs
     ghc-options: -main-is Glean.Glass.Regression.Flow.Main
@@ -2311,7 +2311,7 @@ test-suite glass-regression-flow
         buildable: False
 
 test-suite glass-regression-hack
-    import: glass-regression-deps, fb-haskell, deps
+    import: glass-regression-deps, fb-haskell, deps, exe
     type: exitcode-stdio-1.0
     main-is: Glean/Glass/Regression/Hack/Main.hs
     ghc-options: -main-is Glean.Glass.Regression.Hack.Main
@@ -2324,7 +2324,7 @@ test-suite glass-regression-hack
         buildable: False
 
 test-suite glass-regression-typescript
-    import: glass-regression-deps, fb-haskell, deps
+    import: glass-regression-deps, fb-haskell, deps, exe
     type: exitcode-stdio-1.0
     main-is: Glean/Glass/Regression/TypeScript/Main.hs
     ghc-options: -main-is Glean.Glass.Regression.TypeScript.Main
@@ -2336,7 +2336,7 @@ test-suite glass-regression-typescript
         buildable: False
 
 test-suite glass-regression-go
-    import: glass-regression-deps, fb-haskell, deps
+    import: glass-regression-deps, fb-haskell, deps, exe
     type: exitcode-stdio-1.0
     main-is: Glean/Glass/Regression/Go/Main.hs
     ghc-options: -main-is Glean.Glass.Regression.Go.Main
@@ -2348,7 +2348,7 @@ test-suite glass-regression-go
         buildable: False
 
 test-suite glass-regression-rust-lsif
-    import: glass-regression-deps, fb-haskell, deps
+    import: glass-regression-deps, fb-haskell, deps, exe
     type: exitcode-stdio-1.0
     main-is: Glean/Glass/Regression/RustLsif/Main.hs
     ghc-options: -main-is Glean.Glass.Regression.RustLsif.Main
@@ -2360,7 +2360,7 @@ test-suite glass-regression-rust-lsif
         buildable: False
 
 test-suite glass-regression-java-lsif
-    import: glass-regression-deps, fb-haskell, deps
+    import: glass-regression-deps, fb-haskell, deps, exe
     type: exitcode-stdio-1.0
     main-is: Glean/Glass/Regression/JavaLsif/Main.hs
     ghc-options: -main-is Glean.Glass.Regression.JavaLsif.Main
@@ -2372,14 +2372,14 @@ test-suite glass-regression-java-lsif
         buildable: False
 
 test-suite glass-regression-python
-    import: glass-regression-deps, fb-haskell, deps
+    import: glass-regression-deps, fb-haskell, deps, exe
     type: exitcode-stdio-1.0
     main-is: Glean/Glass/Regression/Python.hs
     ghc-options: -main-is Glean.Glass.Regression.Python
     buildable: False
 
 test-suite glass-regression-thrift
-    import: glass-regression-deps, fb-haskell, deps
+    import: glass-regression-deps, fb-haskell, deps, exe
     type: exitcode-stdio-1.0
     main-is: Glean/Glass/Regression/Thrift.hs
     ghc-options: -main-is Glean.Glass.Regression.Thrift


### PR DESCRIPTION
We were missing `-threaded` from many tests. Luckily the current tests all still worked, but this caused a very hard to debug deadlock in a new test I was working on.