### PR TITLE
Fix bug in binding with negation

### DIFF
--- a/glean/test/tests/Angle/AngleTest.hs
+++ b/glean/test/tests/Angle/AngleTest.hs
@@ -898,6 +898,16 @@ angleNegationTest modify = dbTestCase $ \env repo -> do
   print r
   assertEqual "negation - scope 6" 1 (length r)
 
+  -- Test that we can automatically quantify an unbound variable
+  -- used in a negation.
+  r <- runQuery_ env repo $ modify $ angle @Glean.Test.Node
+    -- nodes that are not parents
+    [s|
+        N where !(glean.test.Edge { parent = N });
+    |]
+  print r
+  assertEqual "negation - scope 7" 4 (length r)
+
   -- a negated query's head is replaced with {}
   r <- runQuery_ env repo $ modify $ angleData @Nat
     [s|
@@ -906,7 +916,6 @@ angleNegationTest modify = dbTestCase $ \env repo -> do
     |]
   print r
   assertEqual "negation -  3" 1 (length r)
-
 
 -- type checking
 angleTypeTest :: Test


### PR DESCRIPTION
A query like this should work:

```
  N where !(hs.NameRefs { target = N })
```

to find names that have no references. But it fails due to a bug in name resolution.

This fixes the bug and adds a test.