### PR TITLE
Migrate OSS project to handle protocol split

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1707,10 +1707,16 @@ library bench-lib
 --     include-dirs: .
 --     cxx-sources:
 --         glean/schema/gen-cpp2/glean_test_types.cpp
+--         glean/schema/gen-cpp2/glean_test_types_compact.cpp
+--         glean/schema/gen-cpp2/glean_test_types_binary.cpp
 --         glean/schema/gen-cpp2/glean_test_data.cpp
 --         glean/schema/gen-cpp2/builtin_types.cpp
+--         glean/schema/gen-cpp2/builtin_types_compact.cpp
+--         glean/schema/gen-cpp2/builtin_types_binary.cpp
 --         glean/schema/gen-cpp2/builtin_data.cpp
 --         glean/schema/gen-cpp2/sys_types.cpp
+--         glean/schema/gen-cpp2/sys_types_compact.cpp
+--         glean/schema/gen-cpp2/sys_types_binary.cpp
 --         glean/schema/gen-cpp2/sys_data.cpp
 --         ... etc.
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/CacheLib/pull/386

X-link: https://github.com/facebook/fb303/pull/67

fbthrift has moved compact/binary protocol instantiation outside _types.cpp (to _types_compact.cpp and _types_binary.cpp). We need to add these two files to the build system.

Differential Revision: D74687663


