### PR TITLE
[angle] Fix a missing case in unify

### DIFF
--- a/glean/db/Glean/Query/Typecheck/Unify.hs
+++ b/glean/db/Glean/Query/Typecheck/Unify.hs
@@ -56,18 +56,24 @@ unify a@(SumTy ts) b@(SumTy us)
         if f /= g then unifyError a b else unify t u
 unify (PredicateTy _ (PidRef p _)) (PredicateTy _ (PidRef q _))
   | p == q = return ()
+
 unify (NamedTy _ (ExpandedType n _)) (NamedTy _ (ExpandedType m _))
   | n == m = return ()
 unify (NamedTy _ (ExpandedType _ t)) u = unify t u
 unify t (NamedTy _ (ExpandedType _ u)) = unify t u
+
 unify (MaybeTy t) (MaybeTy u) = unify t u
 unify (MaybeTy t) u@SumTy{} = unify (lowerMaybe t) u
 unify (MaybeTy t) u@HasTy{} = unify (lowerMaybe t) u
 unify t@SumTy{} (MaybeTy u) = unify t (lowerMaybe u)
 unify t@HasTy{} (MaybeTy u) = unify t (lowerMaybe u)
+
 unify (EnumeratedTy ns) (EnumeratedTy ms) | ns == ms = return ()
 unify (EnumeratedTy ns) u@SumTy{} = unify (lowerEnum ns) u
+unify (EnumeratedTy ns) u@HasTy{} = unify (lowerEnum ns) u
 unify t@SumTy{} (EnumeratedTy ns) = unify t (lowerEnum ns)
+unify t@HasTy{} (EnumeratedTy ns) = unify t (lowerEnum ns)
+
 unify BooleanTy BooleanTy = return ()
 
 unify (TyVar x) (TyVar y) | x == y = return ()

--- a/glean/test/tests/Angle/AngleTest.hs
+++ b/glean/test/tests/Angle/AngleTest.hs
@@ -1020,3 +1020,10 @@ angleTypeTest = dbTestCase $ \env repo -> do
     |]
   print r
   assertEqual "angle - inference 8" 1 (length r)
+
+  r <- runQuery_ env repo $ angleData @Text
+    [s|
+      P.string_ where P : glean.test.Predicate; P.enum_ = e
+    |]
+  print r
+  assertEqual "angle - inference 9" 4 (length r)


### PR DESCRIPTION
We weren't unifying enumerated types with HasTy, which led to bogus type errors in some cases. The included test case previously produced:

BadQuery {badQuery_message = "line 2, column 59 - line 2, column 60\ntype error:\n  { e : { }, T0 }\ndoes not match:\n  enum { e | f | g | }"}

but now it works.