### PR TITLE
Angle DSL: add type signature to the query result 

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1795,6 +1795,17 @@ test-suite angle-test-misc
     main-is: Angle/MiscTest.hs
     ghc-options: -main-is Angle.MiscTest
 
+test-suite api
+    import: test
+    type: exitcode-stdio-1.0
+    main-is: ApiTest.hs
+    ghc-options: -main-is ApiTest
+    build-depends:
+        glean:stubs,
+        glean:core,
+        glean:if-glean-hs,
+        glean:schema
+
 test-suite cppexception
     import: test
     type: exitcode-stdio-1.0

--- a/glean/hs/Glean/Query/Angle.hs
+++ b/glean/hs/Glean/Query/Angle.hs
@@ -146,7 +146,10 @@ build (Angle m) =
 -- >                 end)
 -- >      ]
 query :: (Type t) => Angle t -> Query t
-query = Thrift.angleData . display
+query = Thrift.angleData . display . sig
+  -- adding a type signature ensures that our type matches the type
+  -- Glean infers. Otherwise these could diverge, leading to
+  -- deserialization errors or just wrong data.
 
 class AngleVars f r where
   -- | Use `vars` to batch up a series of nested `var` calls:


### PR DESCRIPTION
Avoids some cases where the Glean inferred type can diverge from the
type expected at the call site.