### PR TITLE
Fix a case where the repo hash could be empty

### DIFF
--- a/glean/test/regression/Glean/Regression/Snapshot.hs
+++ b/glean/test/regression/Glean/Regression/Snapshot.hs
@@ -140,7 +140,7 @@ executeTest cfg driver driverOpts base_group group diff subdir =
   let test = TestConfig
         { testRepo =
             let hash = map (\c -> if c == '/' then '_' else c) subdir
-            in Repo "test" (Text.pack hash)
+            in Repo "test" (if null hash then "0" else Text.pack hash)
         , testOutput =
             outdir </> (if null group then id else (group </>)) subdir
         , testRoot = cfgRoot cfg </> subdir


### PR DESCRIPTION
In regression tests, if the test was not in a subdir then we would end up with an empty DB hash. Surprisingly it mostly worked, but it was impossible to examine the DB later because the directory structure was wrong.