### PR TITLE
Install the schema and don't require a `--schema` flag

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -17,6 +17,9 @@ build-type:          Simple
 extra-source-files:  CHANGELOG.md
 CXX_EXTRA_SOURCE_FILES
 
+data-files:
+    glean/schema/source/**/*.angle
+
 common fb-haskell
     default-language: Haskell2010
     default-extensions:
@@ -470,6 +473,7 @@ library db
     visibility: public
     hs-source-dirs: glean/db
     default-extensions: CPP
+    ghc-options: -DOSS=1
 
     exposed-modules:
         Glean.Database.Backup
@@ -542,6 +546,9 @@ library db
         Glean.Backend.Logging
         Glean.Dump
         Glean.Logger
+
+    other-modules:
+        Paths_glean
 
     build-depends:
         split,

--- a/glean/config/server/server_config.thrift
+++ b/glean/config/server/server_config.thrift
@@ -152,6 +152,27 @@ union ShardingPolicy {
   4: ShardManagerMostRecentPolicy shard_manager_most_recent;
 }
 
+union SchemaLocation {
+  // schema source files (*.angle) in a directory. The string `$datadir` is
+  // replaced by the Cabal datadir, if this is a Cabal build.
+  1: string dir;
+
+  // A single file containing concatenated schema files. The string `$datadir` is
+  // replaced by the Cabal datadir, if this is a Cabal build.
+  2: string file;
+
+  // A schema index (referencing multiple schema versions) in a
+  // file. The string `$datadir` is replaced by the Cabal datadir,
+  // if this is a Cabal build.
+  3: string index;
+
+  // A single file containing concatenated schema files in a config location.
+  4: string config;
+
+  // A schema index in a config location.
+  5: string indexconfig;
+}
+
 // Configeration for Glean Servers
 struct Config {
   1: DatabaseRetentionPolicy retention;
@@ -279,6 +300,10 @@ struct Config {
   // server, which would otherwise manifest as an obscure failure such
   // as a deserialization error later.
   35: bool check_write_schema_id = true;
+
+  // Where to find the schema by default. This can be overridden by the
+  // `--schema` flag on the command line.
+  36: optional SchemaLocation schema_location;
 }
 
 // The following were automatically generated and may benefit from renaming.

--- a/glean/github/Glean/DefaultConfigs.hs
+++ b/glean/github/Glean/DefaultConfigs.hs
@@ -7,9 +7,9 @@
 -}
 
 module Glean.DefaultConfigs (
+    defaultSchemaLocation,
     defaultClientConfigSource,
     serverConfigPath,
-    legacySchemaConfigPath,
     schemaConfigPath,
   ) where
 
@@ -17,18 +17,20 @@ import Data.Text (Text)
 
 import Glean.Util.ThriftSource
 import Glean.ClientConfig.Types
+import Glean.ServerConfig.Types
 
+-- | Where do we find the schema by default?
+defaultSchemaLocation :: SchemaLocation
+defaultSchemaLocation = SchemaLocation_dir "$datadir/glean/schema/source"
+
+-- | Path under ~/.config/glean where the default client config lives
 defaultClientConfigSource :: ThriftSource ClientConfig
 defaultClientConfigSource = configDefault "client"
 
--- | Path in configerator where the server configs live
+-- | Path under ~/.config/glean where the server config lives
 serverConfigPath :: String
 serverConfigPath = "server"
 
--- | config path to the (old) schema definition
-legacySchemaConfigPath :: Text
-legacySchemaConfigPath = "schema"
-
--- | config path to the schema index
+-- | Path under ~/.config/glean where the schema lives if we use `--schema indexconfig`
 schemaConfigPath :: Text
 schemaConfigPath = "schema-index"

--- a/glean/shell/Glean/Shell.hs
+++ b/glean/shell/Glean/Shell.hs
@@ -79,7 +79,7 @@ import Glean.Database.Schema.Types ( SchemaSelector(..) )
 import Glean.Database.Schema.ComputeIds (
   emptyHashedSchema, HashedSchema(..), RefTargetId )
 import Glean.Database.Config (parseSchemaDir, SchemaIndex(..),
-  ProcessedSchema(..))
+  ProcessedSchema(..), SchemaLocation(..), schemaLocation)
 import qualified Glean.Database.Config as DB (Config(..))
 import Glean.Database.Storage (describe)
 import Glean.Database.Types (Env(..))
@@ -95,6 +95,7 @@ import Glean.Shell.Terminal
 import Glean.Shell.Types
 import Glean.Shell.Error (Ann, BadQuery(..), prettyBadQuery)
 import qualified Glean.Types as Thrift
+import Glean.Util.ConfigProvider
 #if GLEAN_FACEBOOK
 import Glean.Util.CxxXRef
 #endif
@@ -1348,74 +1349,71 @@ parseAndTypecheckSchema env dir = do
   return parsed
 
 setupLocalSchema
-  :: Glean.Service
+  :: ConfigProvider cfg
+  => cfg
+  -> Glean.Service
   -> IO (Glean.Service, Maybe (Eval ()), Maybe String)
-setupLocalSchema service = do
+setupLocalSchema cfgAPI service = do
   case service of
     Remote{} -> return (service, Nothing, Nothing)
-    Local dbConfig logging -> case DB.cfgSchemaDir dbConfig of
-      Nothing -> return (service, Nothing, Nothing)
-      Just dir -> do
-        r <- try $ parseAndTypecheckSchema Nothing dir
-        (schema, maybeErr) <- case r of
-          Right schema -> return (schema, Nothing)
-          Left (ErrorCall err) -> do
-            let proc = ProcessedSchema
-                  (SourceSchemas (AngleVersion 0) [] [])
-                  (ResolvedSchemas Nothing [])
-                  emptyHashedSchema
-            return (SchemaIndex proc [], Just err)
-        (schemaTS, update) <- ThriftSource.mutable schema
-        let
-          updateSchema :: Eval ()
-          updateSchema = do
-            be <- backend <$> getState
-            case backendKind be of
-              BackendThrift{} -> return ()
-              BackendEnv env -> do
-                new <- liftIO $ parseAndTypecheckSchema (Just env) dir
-                liftIO $ update (const new)
-                let current = schemaIndexCurrent new
+    Local dbConfig logging -> do
+      server_config <- ThriftSource.load cfgAPI (DB.cfgServerConfig dbConfig)
+      loc <- schemaLocation dbConfig server_config
+      case loc of
+        SchemaLocation_dir dir -> do
+          r <- try $ parseAndTypecheckSchema Nothing (Text.unpack dir)
+          (schema, maybeErr) <- case r of
+            Right schema -> return (schema, Nothing)
+            Left (ErrorCall err) -> do
+              let proc = ProcessedSchema
+                    (SourceSchemas (AngleVersion 0) [] [])
+                    (ResolvedSchemas Nothing [])
+                    emptyHashedSchema
+              return (SchemaIndex proc [], Just err)
+          (schemaTS, update) <- ThriftSource.mutable schema
+          let
+            updateSchema :: Eval ()
+            updateSchema = do
+              be <- backend <$> getState
+              case backendKind be of
+                BackendThrift{} -> return ()
+                BackendEnv env -> do
+                  new <- liftIO $ parseAndTypecheckSchema (Just env) (Text.unpack dir)
+                  liftIO $ update (const new)
+                  let current = schemaIndexCurrent new
+        
+                  -- Update all the schemas for open DBs. This would
+                  -- normally be done in the background by the schema
+                  -- updater thread, but we're doing it manually and
+                  -- disabling the auto-update so that we can
+                  -- synchronously check for errors and update our local
+                  -- view of the schema in the monad.
+                  liftIO $ schemaUpdated env Nothing
+        
+                  state <- getState
+                  whenJust (repo state) $ \r -> do
+                    info <- liftIO $
+                      Glean.getSchemaInfo env (Just r)
+                        def { Thrift.getSchemaInfo_select = useSchemaId state }
 
-                -- Update all the schemas for open DBs. This would
-                -- normally be done in the background by the schema
-                -- updater thread, but we're doing it manually and
-                -- disabling the auto-update so that we can
-                -- synchronously check for errors and update our local
-                -- view of the schema in the monad.
-                liftIO $ schemaUpdated env Nothing
+                    Eval $ State.modify $ \s ->
+                      s { schemaInfo = Just info, schemas = Just current }
 
-                state <- getState
-                whenJust (repo state) $ \r -> do
-                  info <- liftIO $
-                    Glean.getSchemaInfo env (Just r)
-                      def { Thrift.getSchemaInfo_select = useSchemaId state }
+                  let
+                    numSchemas = length (srcSchemas (procSchemaSource current))
+                    numPredicates = HashMap.size (hashedPreds
+                      (procSchemaHashed current))
+                  output $ "reloading schema [" <>
+                    pretty numSchemas <> " schemas, " <>
+                    pretty numPredicates <> " predicates]"
+          return
+            ( Local dbConfig {
+                DB.cfgSchemaHook = \_ -> (schemaTS, False) } logging
+            , Just updateSchema
+            , maybeErr
+            )
 
-                  Eval $ State.modify $ \s ->
-                    s { schemaInfo = Just info, schemas = Just current }
-
-                let
-                  numSchemas = length (srcSchemas (procSchemaSource current))
-                  numPredicates = HashMap.size (hashedPreds
-                    (procSchemaHashed current))
-                output $ "reloading schema [" <>
-                  pretty numSchemas <> " schemas, " <>
-                  pretty numPredicates <> " predicates]"
-
-          -- When using --schema, we also set --db-schema-override. This
-          -- allows the local schema to override whatever was in the DB,
-          -- and also allows the local schema to take effect when the
-          -- DB is writable.
-          dbConfig' = dbConfig {
-            DB.cfgSchemaSource = schemaTS,
-            DB.cfgUpdateSchema = False
-          }
-
-        return
-          ( Local dbConfig' logging
-          , Just updateSchema
-          , maybeErr
-          )
+        _other -> return (service, Nothing, Nothing)
 
 type ShellCommand = Config
 
@@ -1427,7 +1425,7 @@ instance Plugin ShellCommand where
     | otherwise = "--minloglevel=2" : args
 
   withService evb cfgAPI service cfg = do
-    (service', updateSchema, maybeErr) <- setupLocalSchema service
+    (service', updateSchema, maybeErr) <- setupLocalSchema cfgAPI service
     Glean.withBackendWithDefaultOptions evb cfgAPI
       service' Nothing $ \backend -> do
     withSystemTempFile "scratch-query.angle" $ \q handle -> do

--- a/glean/test/regression/Glean/Regression/Indexer.hs
+++ b/glean/test/regression/Glean/Regression/Indexer.hs
@@ -12,6 +12,7 @@ module Glean.Regression.Indexer
   ) where
 
 import Data.Maybe
+import qualified Data.Text as Text
 import System.FilePath
 
 import Glean.Database.Config
@@ -30,7 +31,7 @@ withTestBackend test action =
   withTestEnv settings (action . Some)
   where
   settings = [ setRoot $ testOutput test </> "db" ] <>
-    map (setSchemaSource . schemaSourceFilesFromDir)
+    map (setSchemaLocation . SchemaLocation_dir . Text.pack)
       (maybeToList (testSchema test))
 
 runIndexerForTest :: Some LocalOrRemote -> RunIndexer -> TestConfig -> IO ()

--- a/glean/test/tests/BackupTest.hs
+++ b/glean/test/tests/BackupTest.hs
@@ -108,7 +108,7 @@ withTestEnv dbs init_server_cfg action evb cfgAPI backupdir = do
   (l, events) <- recorder
   let config = def
         { cfgDataStore = tmpDataStore
-        , cfgSchemaSource = schemaSourceFiles
+        , cfgSchemaLocation = Just schemaLocationFiles
         , cfgServerConfig = server_cfg
         , cfgReadOnly = False
         , cfgMockWrites = False

--- a/glean/test/tests/DatabaseJanitorTest.hs
+++ b/glean/test/tests/DatabaseJanitorTest.hs
@@ -247,7 +247,7 @@ makeFakeCloudDB schema backupDir repo dbtime completeness opts = do
 dbConfig :: FilePath -> ServerTypes.Config -> Glean.Database.Config.Config
 dbConfig dbdir serverConfig = def
   { cfgDataStore = fileDataStore dbdir
-  , cfgSchemaSource = schemaSourceFiles
+  , cfgSchemaLocation = Just schemaLocationFiles
   , cfgServerConfig = ThriftSource.value serverConfig
   , cfgReadOnly = False
       -- If we set cfgReadOnly=True, then backing up a DB will fail

--- a/glean/test/tests/Schema/Basic.hs
+++ b/glean/test/tests/Schema/Basic.hs
@@ -352,8 +352,7 @@ changeSchemaTest = TestCase $ do
         let
           dbConfig = def
             { cfgDataStore = tmpDataStore
-            , cfgSchemaSource = ThriftSource.configWithDeserializer
-                fakeSchemaKey (processOneSchema Nothing)
+            , cfgSchemaLocation = Just (SchemaLocation_config fakeSchemaKey)
             , cfgServerConfig = ThriftSource.value def
                 { ServerConfig.config_db_rocksdb_cache_mb = 0 }
             }


### PR DESCRIPTION
I wanted to make the OSS build install the schema under `$datadir` and to look for it there by default. This meant that the default schema location is an `IO` operation (because `getDataDir` is in `IO`), which needed some refactoring. While I was there I noticed that the way schema flags work was a bit of a mess, and that we had no way to specify the schema location in the server config which is weird when everything else is configurable that way.

So the main changes here are:
* OSS builds install the schema in `$datadir`, and binaries no longer require a `--schema` flag if you just want the default schema.
* New type `SchemaLocation` in `server_config.thrift`
* New field `optional SchemaLocation schema_location` in `ServerConfig`
* Change from `cfgSchemaSource :: ThriftSource SchemaIndex` to `cfgSchemaLocation :: SchemaLocation` in `Config`.

and various consequential changes as a result.

NOTE: when importing this change you will need to update the internal `Glean.DefaultConfigs` to add `defaultSchemalocation`, should be something like

```
defaultSchemaLocation :: SchemaLocation
defaultSchemaLocation = SchemaLocation_indexconfig schemaConfigPath
```