### PR TITLE
[new-hs-indexer #16] Index type signatures

### DIFF
--- a/glean/lang/haskell/tests/code/hsSigDecl.out
+++ b/glean/lang/haskell/tests/code/hsSigDecl.out
@@ -1,0 +1,88 @@
+[
+  "@generated",
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 9, "start": 571 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "zero", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 11, "start": 370 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 15, "start": 591 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "f", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+        "span": { "length": 10, "start": 279 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "b", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+        "span": { "length": 11, "start": 315 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "r", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsSigDecl.query
+++ b/glean/lang/haskell/tests/code/hsSigDecl.query
@@ -1,0 +1,4 @@
+# ValBinds that have a signature
+query: |
+  Val.sig.just? where Val : hs.ValBind
+transform: [normord, []]

--- a/glean/schema/source/hs.angle
+++ b/glean/schema/source/hs.angle
@@ -121,6 +121,7 @@ predicate Type:
 
 # Declarations / definitions
 
+# A declaration, which may or may not define a Name.
 type Declaration =
   {
     val: ValBind |
@@ -135,14 +136,15 @@ type Declaration =
     patBind: PatBind |
     tyVarBind: TyVarBind |
     field: RecordFieldDecl |
+    sig: SigDecl |
   }
 
+# Go from a Name to its definition, or vice versa.
 predicate DeclarationOfName:
   {
     name: Name,
     decl: Declaration,
   }
-  # maybe store this? Turns 12 lookups into 1 lookup.
   { N, { val = { name = N }}} |
   { N, { typeFamily = { name = N }}} |
   { N, { type_ = { name = N }}} |
@@ -161,7 +163,13 @@ predicate ValBind:
     name: Name,
     ty: maybe Type,
     # fixity
-    # location of signature
+    sig: maybe SigDecl
+  }
+
+predicate SigDecl:
+  {
+    name: Name,
+    loc: src.FileLocation,
   }
 
 predicate TypeFamilyDecl:
@@ -233,6 +241,7 @@ predicate RecordFieldDecl:
     # type
   }
 
+# From a Name to the location of its defining declaration
 predicate DeclarationLocation:
   {
     name: Name,
@@ -240,10 +249,27 @@ predicate DeclarationLocation:
     span: src.ByteSpan
   }
 
+# From a Declaration to its location
+predicate DeclarationSpan:
+  {
+    decl: Declaration,
+    loc: src.FileLocation,
+  }
+  { Decl, Loc } where
+    # it's either a definition, or it has a location
+    (
+      DeclarationOfName { Name, Decl };
+      DeclarationLocation { Name, File, Span };
+      Loc = { File, Span };
+    ) | (
+      Decl.sig?.loc = Loc;
+    )
+
 predicate ModuleDeclarations:
   {
     module: Module,
     names: set Name,
+    # TODO: decls: [Declaration],
     exports: set Name,
   }
 
@@ -257,7 +283,7 @@ type RefSpan =
 
 # It's useful to be able to distinguish import/export refs from code refs,
 # because e.g. dead code can still have import/export refs.
-type RefKind = enum { importref | exportref | coderef | tydecl }
+type RefKind = enum { importref | exportref | coderef | tydecl | instbind }
 
 type RefTarget =
   {


### PR DESCRIPTION
From a ValBind we can go to the SigDecl, so we can support "jump to type
definition" type operations.
