### PR TITLE
[new-hs-indexer #17] Index instance declarations and class defaults

### DIFF
--- a/glean/lang/haskell/tests/code/A.hs
+++ b/glean/lang/haskell/tests/code/A.hs
@@ -31,6 +31,7 @@ data R a = R { f1 :: Char, f2 :: [a] }
 
 class Eq a => C a where
   m :: a -> Bool
+  m _ = True
 
 instance C Int where
   m x = x == x

--- a/glean/lang/haskell/tests/code/hsClassDecl.out
+++ b/glean/lang/haskell/tests/code/hsClassDecl.out
@@ -2,6 +2,25 @@
   "@generated",
   {
     "key": {
+      "defaults": [
+        {
+          "key": {
+            "loc": {
+              "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+              "span": { "length": 10, "start": 535 }
+            },
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "m", "namespace_": 0 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ],
       "methods": [
         {
           "key": {

--- a/glean/lang/haskell/tests/code/hsDeclarationLocation.out
+++ b/glean/lang/haskell/tests/code/hsDeclarationLocation.out
@@ -27,7 +27,7 @@
           "sort": { "external": { } }
         }
       },
-      "span": { "length": 40, "start": 492 }
+      "span": { "length": 53, "start": 492 }
     }
   },
   {
@@ -189,10 +189,10 @@
             "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
           },
           "occ": { "key": { "name": "a", "namespace_": 2 } },
-          "sort": { "internal": { "length": 15, "start": 591 } }
+          "sort": { "internal": { "length": 15, "start": 604 } }
         }
       },
-      "span": { "length": 15, "start": 591 }
+      "span": { "length": 15, "start": 604 }
     }
   },
   {
@@ -207,7 +207,7 @@
           "sort": { "external": { } }
         }
       },
-      "span": { "length": 68, "start": 607 }
+      "span": { "length": 68, "start": 620 }
     }
   },
   {
@@ -264,10 +264,25 @@
             "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
           },
           "occ": { "key": { "name": "m", "namespace_": 0 } },
-          "sort": { "internal": { "length": 12, "start": 557 } }
+          "sort": { "internal": { "length": 10, "start": 535 } }
         }
       },
-      "span": { "length": 12, "start": 557 }
+      "span": { "length": 10, "start": 535 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "m", "namespace_": 0 } },
+          "sort": { "internal": { "length": 12, "start": 570 } }
+        }
+      },
+      "span": { "length": 12, "start": 570 }
     }
   },
   {
@@ -279,6 +294,36 @@
             "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
           },
           "occ": { "key": { "name": "r", "namespace_": 0 } },
+          "sort": { "internal": { "length": 1, "start": 643 } }
+        }
+      },
+      "span": { "length": 1, "start": 643 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "x", "namespace_": 0 } },
+          "sort": { "internal": { "length": 1, "start": 572 } }
+        }
+      },
+      "span": { "length": 1, "start": 572 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "x", "namespace_": 0 } },
           "sort": { "internal": { "length": 1, "start": 630 } }
         }
       },
@@ -293,41 +338,11 @@
           "mod": {
             "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
           },
-          "occ": { "key": { "name": "x", "namespace_": 0 } },
-          "sort": { "internal": { "length": 1, "start": 559 } }
-        }
-      },
-      "span": { "length": 1, "start": 559 }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
-      "name": {
-        "key": {
-          "mod": {
-            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
-          },
-          "occ": { "key": { "name": "x", "namespace_": 0 } },
-          "sort": { "internal": { "length": 1, "start": 617 } }
-        }
-      },
-      "span": { "length": 1, "start": 617 }
-    }
-  },
-  {
-    "key": {
-      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
-      "name": {
-        "key": {
-          "mod": {
-            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
-          },
           "occ": { "key": { "name": "zero", "namespace_": 0 } },
           "sort": { "external": { } }
         }
       },
-      "span": { "length": 8, "start": 581 }
+      "span": { "length": 8, "start": 594 }
     }
   },
   {

--- a/glean/lang/haskell/tests/code/hsFileXRefs.out
+++ b/glean/lang/haskell/tests/code/hsFileXRefs.out
@@ -9,7 +9,7 @@
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
               { "kind": 0, "span": { "length": 3, "start": 364 } },
-              { "kind": 2, "span": { "length": 3, "start": 651 } }
+              { "kind": 2, "span": { "length": 3, "start": 664 } }
             ],
             "target": {
               "name": {
@@ -83,7 +83,7 @@
             "refs": [
               { "kind": 1, "span": { "length": 1, "start": 279 } },
               { "kind": 2, "span": { "length": 1, "start": 442 } },
-              { "kind": 2, "span": { "length": 1, "start": 579 } }
+              { "kind": 2, "span": { "length": 1, "start": 592 } }
             ],
             "target": {
               "name": {
@@ -103,7 +103,7 @@
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
               { "kind": 1, "span": { "length": 1, "start": 285 } },
-              { "kind": 2, "span": { "length": 1, "start": 603 } }
+              { "kind": 2, "span": { "length": 1, "start": 616 } }
             ],
             "target": {
               "name": {
@@ -123,7 +123,7 @@
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
               { "kind": 1, "span": { "length": 1, "start": 295 } },
-              { "kind": 2, "span": { "length": 1, "start": 596 } }
+              { "kind": 2, "span": { "length": 1, "start": 609 } }
             ],
             "target": {
               "name": {
@@ -143,7 +143,7 @@
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
               { "kind": 1, "span": { "length": 1, "start": 305 } },
-              { "kind": 2, "span": { "length": 1, "start": 543 } }
+              { "kind": 2, "span": { "length": 1, "start": 556 } }
             ],
             "target": {
               "name": {
@@ -163,7 +163,7 @@
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
               { "kind": 1, "span": { "length": 1, "start": 324 } },
-              { "kind": 3, "span": { "length": 1, "start": 591 } }
+              { "kind": 3, "span": { "length": 1, "start": 604 } }
             ],
             "target": {
               "name": {
@@ -183,7 +183,7 @@
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
               { "kind": 1, "span": { "length": 4, "start": 315 } },
-              { "kind": 3, "span": { "length": 4, "start": 571 } }
+              { "kind": 3, "span": { "length": 4, "start": 584 } }
             ],
             "target": {
               "name": {
@@ -256,8 +256,9 @@
           "key": {
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
-              { "kind": 2, "span": { "length": 1, "start": 557 } },
-              { "kind": 2, "span": { "length": 1, "start": 634 } }
+              { "kind": 2, "span": { "length": 1, "start": 535 } },
+              { "kind": 2, "span": { "length": 1, "start": 570 } },
+              { "kind": 2, "span": { "length": 1, "start": 647 } }
             ],
             "target": {
               "name": {
@@ -276,8 +277,8 @@
           "key": {
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
-              { "kind": 2, "span": { "length": 1, "start": 563 } },
-              { "kind": 2, "span": { "length": 1, "start": 568 } }
+              { "kind": 2, "span": { "length": 1, "start": 576 } },
+              { "kind": 2, "span": { "length": 1, "start": 581 } }
             ],
             "target": {
               "name": {
@@ -286,7 +287,7 @@
                     "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
                   },
                   "occ": { "key": { "name": "x", "namespace_": 0 } },
-                  "sort": { "internal": { "length": 1, "start": 559 } }
+                  "sort": { "internal": { "length": 1, "start": 572 } }
                 }
               }
             }
@@ -296,8 +297,8 @@
           "key": {
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
-              { "kind": 2, "span": { "length": 1, "start": 598 } },
-              { "kind": 2, "span": { "length": 1, "start": 605 } }
+              { "kind": 2, "span": { "length": 1, "start": 611 } },
+              { "kind": 2, "span": { "length": 1, "start": 618 } }
             ],
             "target": {
               "name": {
@@ -306,7 +307,7 @@
                     "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
                   },
                   "occ": { "key": { "name": "a", "namespace_": 2 } },
-                  "sort": { "internal": { "length": 15, "start": 591 } }
+                  "sort": { "internal": { "length": 15, "start": 604 } }
                 }
               }
             }
@@ -316,7 +317,7 @@
           "key": {
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
-              { "kind": 2, "span": { "length": 1, "start": 609 } },
+              { "kind": 2, "span": { "length": 1, "start": 622 } },
               { "kind": 2, "span": { "length": 2, "start": 467 } },
               { "kind": 2, "span": { "length": 2, "start": 479 } }
             ],
@@ -336,7 +337,7 @@
         {
           "key": {
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
-            "refs": [ { "kind": 2, "span": { "length": 1, "start": 626 } } ],
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 639 } } ],
             "target": {
               "name": {
                 "key": {
@@ -344,7 +345,7 @@
                     "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
                   },
                   "occ": { "key": { "name": "x", "namespace_": 0 } },
-                  "sort": { "internal": { "length": 1, "start": 617 } }
+                  "sort": { "internal": { "length": 1, "start": 630 } }
                 }
               }
             }
@@ -353,7 +354,7 @@
         {
           "key": {
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
-            "refs": [ { "kind": 2, "span": { "length": 1, "start": 659 } } ],
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 672 } } ],
             "target": {
               "name": {
                 "key": {
@@ -361,7 +362,7 @@
                     "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
                   },
                   "occ": { "key": { "name": "r", "namespace_": 0 } },
-                  "sort": { "internal": { "length": 1, "start": 630 } }
+                  "sort": { "internal": { "length": 1, "start": 643 } }
                 }
               }
             }
@@ -372,8 +373,8 @@
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
               { "kind": 2, "span": { "length": 2, "start": 467 } },
-              { "kind": 2, "span": { "length": 2, "start": 656 } },
-              { "kind": 2, "span": { "length": 2, "start": 663 } }
+              { "kind": 2, "span": { "length": 2, "start": 669 } },
+              { "kind": 2, "span": { "length": 2, "start": 676 } }
             ],
             "target": {
               "name": {
@@ -393,7 +394,7 @@
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
               { "kind": 2, "span": { "length": 2, "start": 479 } },
-              { "kind": 2, "span": { "length": 2, "start": 611 } }
+              { "kind": 2, "span": { "length": 2, "start": 624 } }
             ],
             "target": {
               "name": {
@@ -431,7 +432,7 @@
         {
           "key": {
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
-            "refs": [ { "kind": 2, "span": { "length": 2, "start": 565 } } ],
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 578 } } ],
             "target": {
               "name": {
                 "key": {
@@ -451,7 +452,7 @@
         {
           "key": {
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
-            "refs": [ { "kind": 2, "span": { "length": 2, "start": 623 } } ],
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 636 } } ],
             "target": {
               "name": {
                 "key": {
@@ -468,7 +469,7 @@
         {
           "key": {
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
-            "refs": [ { "kind": 2, "span": { "length": 2, "start": 647 } } ],
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 660 } } ],
             "target": {
               "name": {
                 "key": {
@@ -507,8 +508,8 @@
             "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
             "refs": [
               { "kind": 2, "span": { "length": 3, "start": 412 } },
-              { "kind": 2, "span": { "length": 3, "start": 545 } },
-              { "kind": 2, "span": { "length": 3, "start": 640 } }
+              { "kind": 2, "span": { "length": 3, "start": 558 } },
+              { "kind": 2, "span": { "length": 3, "start": 653 } }
             ],
             "target": {
               "name": {
@@ -560,6 +561,26 @@
                     }
                   },
                   "occ": { "key": { "name": "Bool", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 4, "start": 541 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "True", "namespace_": 1 } },
                   "sort": { "external": { } }
                 }
               }

--- a/glean/lang/haskell/tests/code/hsInstanceDecl.out
+++ b/glean/lang/haskell/tests/code/hsInstanceDecl.out
@@ -1,0 +1,30 @@
+[
+  "@generated",
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 35, "start": 547 }
+      },
+      "methods": [
+        {
+          "key": {
+            "loc": {
+              "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+              "span": { "length": 12, "start": 570 }
+            },
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "m", "namespace_": 0 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsInstanceDecl.query
+++ b/glean/lang/haskell/tests/code/hsInstanceDecl.query
@@ -1,0 +1,3 @@
+# ValBinds that have a signature
+query: hs.InstDecl _
+transform: [normord, []]

--- a/glean/lang/haskell/tests/code/hsModuleDeclarations.out
+++ b/glean/lang/haskell/tests/code/hsModuleDeclarations.out
@@ -248,7 +248,7 @@
               "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
             },
             "occ": { "key": { "name": "a", "namespace_": 2 } },
-            "sort": { "internal": { "length": 15, "start": 591 } }
+            "sort": { "internal": { "length": 15, "start": 604 } }
           }
         },
         {
@@ -293,7 +293,16 @@
               "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
             },
             "occ": { "key": { "name": "m", "namespace_": 0 } },
-            "sort": { "internal": { "length": 12, "start": 557 } }
+            "sort": { "internal": { "length": 10, "start": 535 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "m", "namespace_": 0 } },
+            "sort": { "internal": { "length": 12, "start": 570 } }
           }
         },
         {
@@ -302,25 +311,25 @@
               "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
             },
             "occ": { "key": { "name": "r", "namespace_": 0 } },
+            "sort": { "internal": { "length": 1, "start": 643 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "x", "namespace_": 0 } },
+            "sort": { "internal": { "length": 1, "start": 572 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "x", "namespace_": 0 } },
             "sort": { "internal": { "length": 1, "start": 630 } }
-          }
-        },
-        {
-          "key": {
-            "mod": {
-              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
-            },
-            "occ": { "key": { "name": "x", "namespace_": 0 } },
-            "sort": { "internal": { "length": 1, "start": 559 } }
-          }
-        },
-        {
-          "key": {
-            "mod": {
-              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
-            },
-            "occ": { "key": { "name": "x", "namespace_": 0 } },
-            "sort": { "internal": { "length": 1, "start": 617 } }
           }
         },
         {

--- a/glean/lang/haskell/tests/code/hsSigDecl.out
+++ b/glean/lang/haskell/tests/code/hsSigDecl.out
@@ -4,7 +4,7 @@
     "key": {
       "loc": {
         "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
-        "span": { "length": 9, "start": 571 }
+        "span": { "length": 9, "start": 584 }
       },
       "name": {
         "key": {
@@ -38,7 +38,7 @@
     "key": {
       "loc": {
         "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
-        "span": { "length": 15, "start": 591 }
+        "span": { "length": 15, "start": 604 }
       },
       "name": {
         "key": {

--- a/glean/schema/source/hs.angle
+++ b/glean/schema/source/hs.angle
@@ -132,7 +132,7 @@ type Declaration =
     patSyn: PatSynDecl |
     class_: ClassDecl |
     method: MethDecl |
-    instance: InstanceDecl |
+    instance: InstDecl |
     patBind: PatBind |
     tyVarBind: TyVarBind |
     field: RecordFieldDecl |
@@ -153,7 +153,6 @@ predicate DeclarationOfName:
   { N, { patSyn = { name = N }}} |
   { N, { class_ = { name = N }}} |
   { N, { method = { name = N }}} |
-  { N, { instance = { name = N }}} |
   { N, { patBind = { name = N }}} |
   { N, { tyVarBind = { name = N }}} |
   { N, { field = { name = N }}}
@@ -164,6 +163,20 @@ predicate ValBind:
     ty: maybe Type,
     # fixity
     sig: maybe SigDecl
+  }
+
+predicate InstanceBind:
+  {
+    name: Name,
+    # ty: maybe Type,
+    loc: src.FileLocation,
+  }
+
+# Maps an InstanceBind back to its containing decl
+predicate InstanceBindToDecl:
+  {
+    bind: InstanceBind,
+    decl: { inst: InstDecl | class_: ClassDecl }
   }
 
 predicate SigDecl:
@@ -205,7 +218,9 @@ predicate ClassDecl:
     name: Name,
     methods: [MethDecl],
     # superclass constraints
-    # defaults
+    defaults: [InstanceBind],
+    # associated types / datatypes
+    # associated type defaults
   }
 
 predicate MethDecl:
@@ -216,11 +231,12 @@ predicate MethDecl:
     # default decl
   }
 
-predicate InstanceDecl:
+predicate InstDecl:
   {
-    name: Name,
     # class
     # parameters etc.
+    methods: [InstanceBind],
+    loc: src.FileLocation,
   }
 
 predicate PatBind:


### PR DESCRIPTION
We can now, for example, find all the places where a particular method
is defined by an instance.
