### PR TITLE
Fix type checking of `[..]` and `elements`

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1777,6 +1777,12 @@ test-suite angle-test-derived
     main-is: Angle/DerivedTest.hs
     ghc-options: -main-is Angle.DerivedTest
 
+test-suite angle-test-set
+    import: test, angle-test
+    type: exitcode-stdio-1.0
+    main-is: Angle/SetTest.hs
+    ghc-options: -main-is Angle.SetTest
+
 test-suite angle-test-stored
     import: test, angle-test
     type: exitcode-stdio-1.0

--- a/glean/test/tests/Angle/SetTest.hs
+++ b/glean/test/tests/Angle/SetTest.hs
@@ -146,6 +146,9 @@ setSemanticsTest = TestList
   , TestLabel "element syntax for set" $ dbTestCase $ \env repo -> do
       r <- runQuery_ env repo $ angleData @Nat [s| (all (1|2))[..] |]
       assertEqual "results" [Nat 1, Nat 2] (sort r)
+  , TestLabel "element syntax for set 2" $ dbTestCase $ \env repo -> do
+      r <- runQuery_ env repo $ angleData @Nat [s| (all (1|2))[..] : nat |]
+      assertEqual "results" [Nat 1, Nat 2] (sort r)
   , TestLabel "multiple set results" $ dbTestCase $ \env repo -> do
       r <- runQuery_ env repo $ angleData @(Set Nat) [s| all X where X= (1|2) |]
       assertEqual "results" 2 (length r)


### PR DESCRIPTION
Bug #1: `X[..]` behaved differently depending on whether we were inferring or checking types. When checking types we forced `X` to have an array type, whereas when inferring types we allowed `X` to be either an array or a set. This led to some very confusing behaviour.

Bug #2: the type checking of `elements X` when expecting a predicate type was wrong, due to the ordering of pattern matches in `typecheckPattern`. This also led to some very confusing behavoiur.