### PR TITLE
[glass] Runtime config for RepoMapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,7 @@ THRIFT_GLEAN= \
 	glean/config/server/server_config.thrift \
 	glean/config/service.thrift \
 	glean/config/client/client_config.thrift \
+	glean/config/glass/repomapping.thrift \
 	thrift/annotation/cpp.thrift \
 	thrift/annotation/hack.thrift \
 	thrift/annotation/rust.thrift \

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -1284,7 +1284,9 @@ library glass-lib
     import: fb-haskell, fb-cpp, deps, thrift-server
     visibility: public
     default-extensions: CPP
-    hs-source-dirs: glean/glass
+    hs-source-dirs:
+        glean/glass
+        glean/config/glass/gen-hs2
     exposed-modules:
         Glean.Glass.Annotations
         Glean.Glass.Attributes
@@ -1320,6 +1322,7 @@ library glass-lib
         Glean.Glass.Query.Cxx
         Glean.Glass.Range
         Glean.Glass.RepoMapping
+        Glean.Glass.Repomapping.Types
         Glean.Glass.Repos
         Glean.Glass.Search
         Glean.Glass.Search.Angle

--- a/glean/config/glass/repomapping.thrift
+++ b/glean/config/glass/repomapping.thrift
@@ -1,0 +1,15 @@
+namespace hs Glean.Glass
+
+typedef string RepoName
+typedef string GleanDBName
+typedef string Language
+
+struct DbSelector {
+  1: GleanDBName name
+  2: Language language
+  3: optional string branch
+} (hs.prefix = "")
+
+struct RepoMapping {
+  1: map<RepoName,list<DbSelector>> indices
+} (hs.prefix = "")

--- a/glean/glass/Glean/Glass/Base.hs
+++ b/glean/glass/Glean/Glass/Base.hs
@@ -15,6 +15,7 @@ module Glean.Glass.Base
   , GleanDBSelector(..)
   ) where
 
+import Data.Default
 import Data.Function
 import Data.Hashable
 import Data.List.NonEmpty(NonEmpty(..))
@@ -100,3 +101,6 @@ data RepoMapping = RepoMapping
     -- This pairs attribute Glean dbs with a key type to index the ToAttribute
     -- class, that in turns knowns how to query and marshal the attributes
   }
+
+instance Default RepoMapping where
+  def = RepoMapping { gleanIndices = def, gleanAttrIndices = def }

--- a/glean/glass/Glean/Glass/Main.hs
+++ b/glean/glass/Glean/Glass/Main.hs
@@ -103,7 +103,7 @@ withEnv Glass.Config{..} gleanDB f =
   withLatestRepos backend scm (Just logger)
     (if isRemote gleanService then listDatabasesRetry else Nothing) refreshFreq
     $ \latestGleanRepos -> do
-      repoMapping <- getRepoMapping
+      repoMapping <- getRepoMapping cfgapi
       f Glass.Env
         { gleanBackend = Some backend
         , gleanDB = gleanDB
@@ -148,7 +148,7 @@ assignHeaders _ _ = []
 -- | Perform an operation with the latest RepoMapping
 withCurrentRepoMapping :: Glass.Env -> (Glass.Env -> IO a) -> IO a
 withCurrentRepoMapping env0 fn = do
-  current <- getRepoMapping
+  current <- getRepoMapping (Glass.cfgapi env0)
   fn (env0 { Glass.repoMapping = current })
 
 withRequestTracing :: Env' GlassTraceWithId -> (Env -> IO b) -> IO b


### PR DESCRIPTION
Right now with the open source build it's impossible to use Glass, because RepoMapping is fixed at compile-time. This moves it into a runtime config.

Tested with the following in `~/.config/glean/glass/repomapping`:

```
{
  "indices": {
    "stackage": [
      {
        "name": "stackage",
        "language": "hs"
      }
    ],
    "haxl": [
      {
        "name": "haxl",
        "language": "hs"
      }
    ]
  }
}
```

It defaults to an empty repomapping if one isn't provided. We'll probably need to fix up the react demo.