### PR TITLE
Fix m4 failure in glean.cabal.in

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -2232,7 +2232,7 @@ test-suite glean-snapshot-hack
         buildable: False
 
 -- The Haskell indexer tests *only* work when run using Cabal with
--- `cabal run` or `cabal test`, because Cabal puts the `hie-indexer`
+-- 'cabal run' or 'cabal test', because Cabal puts the 'hie-indexer'
 -- binary in the PATH.
 test-suite glean-snapshot-haskell
     import: fb-haskell, fb-cpp, deps, exe, haskell-indexer


### PR DESCRIPTION
Didn't notice this because for some reason it doesn't cause a build failure, it just omitted a lot of the tests from glean.cabal.