### PR TITLE
[oss] Better error message for no --db-root/--service

### DIFF
--- a/glean/util/Glean/Impl/ThriftService.hs
+++ b/glean/util/Glean/Impl/ThriftService.hs
@@ -33,7 +33,7 @@ newtype ThriftService p = ThriftService
 deriving instance Show (ThriftService p)
 
 instance IsThriftService ThriftService where
-  mkThriftService (HostPort h p) ThriftServiceOptions{..} = ThriftService
+  mkThriftService (HostPort h p) ThriftServiceOptions{..} = Just $ ThriftService
     { headerConfig = headerConfig
     }
     where
@@ -46,7 +46,7 @@ instance IsThriftService ThriftService where
       , headerSendTimeout = timeout
       , headerRecvTimeout = timeout
       }
-  mkThriftService _ _ = error "basic-thriftservice does not support Tier"
+  mkThriftService _ _ = Nothing
 
   thriftServiceWithDbShard t _ = t  -- shards are irrelevant if we have host/port
 
@@ -84,7 +84,7 @@ newtype ThriftService p = ThriftService
 deriving instance Show (ThriftService p)
 
 instance IsThriftService ThriftService where
-  mkThriftService (HostPort h p) ThriftServiceOptions{..} = ThriftService
+  mkThriftService (HostPort h p) ThriftServiceOptions{..} = Just $ ThriftService
     { httpConfig = httpConfig
     }
     where
@@ -95,7 +95,7 @@ instance IsThriftService ThriftService where
       , httpResponseTimeout =
           Just $ round (fromMaybe 30 processingTimeout * 1000000)
       }
-  mkThriftService _ _ = error "basic-thriftservice does not support Tier"
+  mkThriftService _ _ = Nothing
 
   thriftServiceWithDbShard t _ = t
     -- shards are irrelevant if we have host/port

--- a/glean/util/Glean/Util/ThriftService.hs
+++ b/glean/util/Glean/Util/ThriftService.hs
@@ -37,13 +37,14 @@ type DbShard = Text -- should be a number, I think
 
 -- | A Thrift service that can be called
 class IsThriftService t where
-  mkThriftService :: Service -> ThriftServiceOptions -> t s
+  -- | Nothing means this Service is not supported.
+  mkThriftService :: Service -> ThriftServiceOptions -> Maybe (t s)
   -- | Request a node with a specific Db
   thriftServiceWithDbShard :: t s -> Maybe DbShard -> t s
   runThrift :: EventBaseDataplane -> t s -> Thrift s a -> IO a
   getSelection :: EventBaseDataplane -> t s -> Int -> IO [(HostName,PortNumber)]
 
-thriftService :: IsThriftService t => Service -> t s
+thriftService :: IsThriftService t => Service -> Maybe (t s)
 thriftService svc = mkThriftService svc def
 
 runThriftInefficiently :: IsThriftService t => t s -> Thrift s a -> IO a


### PR DESCRIPTION
```
dist-newstyle/build/x86_64-linux/ghc-9.4.7/glean-0.1.0.0/x/glean/build/glean/glean shell
glean: No default Glean service. To use local DBs, specify --db-root <dir>, or to connect to a server use --service <host>:<port>
```