### PR TITLE
Pin the version of the typescript indexer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
         run: npm install -g flow-bin
 
       - name: Install indexer (typescript)
-        run: npm install -g @sourcegraph/scip-typescript
+        # Pin the version because test output depends on it. If you bump
+        # the version here, you probably need to also do:
+        #   cabal run glean-snapshot-typescript -- --replace-all
+        run: npm install -g @sourcegraph/scip-typescript@0.3.15
 
       - name: Install .NET Framework dependencies
         run: apt-get install -y libicu74


### PR DESCRIPTION
The typescript regression test output includes the version number, so to avoid this breaking when the upstream version is bumped we need to pin the version.