### PR TITLE
Fix missing folly::init() link error

### DIFF
--- a/glean/github/Glean/Init.hsc
+++ b/glean/github/Glean/Init.hsc
@@ -35,7 +35,7 @@ import TestRunner
 import Mangle.TH
 
 $(mangle
-  "void folly::init(int*, char***, bool)"
+  "void folly::unsafe_unscoped_init(int*, char***, bool)"
   [d|
     foreign import ccall unsafe
       c_follyInit


### PR DESCRIPTION
Adapt to upstream changes in https://github.com/facebook/folly/commit/588c02a867783f1db21dce8c66463ec89f9f739d