### PR TITLE
Update docs for indexers

### DIFF
--- a/glean/website/docs/indexer/cxx.md
+++ b/glean/website/docs/indexer/cxx.md
@@ -38,29 +38,31 @@ which computes derived facts on the result (e.g. find-references tables).
 
 ## To build the indexer:
 
-> make glean-clang
+The Clang indexer is currently not on Hackage, so you have to [build from the repository](../building.md#building-from-the-repository).
+
+```
+make glean-clang
+```
 
 ## Run the indexer
 
-A simple cmake-based indexer can run via the main `glean` CLI tool.
+Ensure that you have [built and installed Glean](../building.md) and
+the `glean` executable is on your `PATH`.
 
 ```
-> cabal build exe:glean
-```
-
-And index your c++ repository with:
-```
-glean index cpp-cmake DIR --indexer clang-index --deriver clang-derive --db NAME/INSTANCE
+glean index cpp-cmake DIR --indexer clang-index --deriver clang-derive --db-root DB --db NAME/INSTANCE
 ```
 
 where
 
+* `DB` is the directory you want to store your Glean DBs
 * `DIR` is the root directory containing the CMake manifest.
 * and indexer and deriver are the paths to the clang-index and clang-derive binaries
 
 ## In the shell
 
-C++ source in cmake projects can also be indexed directly from the Glean shell:
+C++ source in cmake projects can also be indexed directly from the
+[Glean shell](../shell.md):
 
 ```
 :index cpp-cmake DIR

--- a/glean/website/docs/indexer/dotnet.md
+++ b/glean/website/docs/indexer/dotnet.md
@@ -11,28 +11,24 @@ To index [Dotnet](https://dotnet.microsoft.com/) we use SourceGraph's [SCIP inde
 
 ## Run the indexer
 
-The indexer is run via the main `glean` CLI tool.
+Ensure that you have [built and installed Glean](../building.md) and
+the `glean` executable is on your `PATH`.
+
+You can index a Dotnet repository with:
 
 ```
-> cabal build exe:glean
-```
-
-And index your Dotnet repository with:
-```
-glean index dotnet-scip DIR --db NAME/INSTANCE
+glean index dotnet-scip DIR --db-root DB --db NAME/INSTANCE
 ```
 
 where
 
+* `DB` is the directory you want to store your Glean DBs
 * `DIR` is the root directory containing the Dotnet project
-* `name/hash` is the name of the repository to create
-
-Provide the usual `--db-root` and `--schema` or `--service` arguments
-to `glean`
+* `NAME/INSTANCE` is the name of the repository to create
 
 ## In the shell
 
-Dotnet source can also be indexed directly from the Glean shell:
+Dotnet source can also be indexed directly from the [Glean shell](../shell.md):
 
 ```
 :index dotnet-scip DIR

--- a/glean/website/docs/indexer/flow.md
+++ b/glean/website/docs/indexer/flow.md
@@ -13,24 +13,19 @@ in the [Glean demo Docker image](../trying.md) to try out.
 
 ## Run the indexer
 
-The indexer is run via the main `glean` CLI tool.
+Ensure that you have [built and installed Glean](../building.md) and
+the `glean` executable is on your `PATH`.
 
+You can index your Flow repository with:
 ```
-> cabal build exe:glean
-```
-
-And index your Flow repository with:
-```
-glean index flow DIR --db NAME/INSTANCE
+glean index flow DIR --db-root DB --db NAME/INSTANCE
 ```
 
 where
 
+* `DB` is the directory you want to store your Glean DBs
 * `DIR` is the root directory containing the Flow project (with `.flowconfig`)
-* `name/hash` is the name of the repository to create
-
-Provide the usual `--db-root` and `--schema` or `--service` arguments
-to `glean`
+* `NAME/INSTANCE` is the name of the repository to create
 
 ## Run the indexer (manually)
 
@@ -53,7 +48,7 @@ Several predicates should be derived after indexing. For each `stored` predicate
 
 ## In the shell
 
-Flow source can also be indexed directly from the Glean shell:
+Flow source can also be indexed directly from the [Glean shell](../shell.md):
 
 ```
 :index flow DIR

--- a/glean/website/docs/indexer/hack.md
+++ b/glean/website/docs/indexer/hack.md
@@ -11,28 +11,24 @@ The [Hack](https://hacklang.org/) indexer is built into the [Hack typechecker](h
 
 ## Run the indexer
 
-The indexer is run via the main `glean` CLI tool.
+Ensure that you have [built and installed Glean](../building.md) and
+the `glean` executable is on your `PATH`.
+
+Index your Hack repository with:
 
 ```
-> cabal build exe:glean
-```
-
-And index your Hack repository with:
-```
-glean index hack DIR --db NAME/INSTANCE
+glean index hack DIR --db-root DB --db NAME/INSTANCE
 ```
 
 where
 
+* `DB` is the directory where you want to store your Glean DBs
 * `DIR` is the root directory containing the Hack project (with `.hhconfig`)
-* `name/hash` is the name of the repository to create
-
-Provide the usual `--db-root` and `--schema` or `--service` arguments
-to `glean`
+* `NAME/INSTANCE` is the name of the repository to create
 
 ## In the shell
 
-Hack source can also be indexed directly from the Glean shell:
+Hack source can also be indexed directly from the [Glean shell](../shell.md):
 
 ```
 :index hack DIR

--- a/glean/website/docs/indexer/haskell.md
+++ b/glean/website/docs/indexer/haskell.md
@@ -4,14 +4,35 @@ title: Haskell
 sidebar_label: Haskell
 ---
 
+import {OssOnly, FbInternalOnly} from 'internaldocs-fb-helpers';
+import {SrcFile,SrcFileLink} from '@site/utils';
+
 To index [Haskell](https://haskell.org) Glean consumes `.hie` files produced by the GHC compiler (>=8.8) with the flag `-fwrite-ide-info`.
 
 # Run the indexer
 
-The indexer is run via the main `glean` CLI tool.
+The Haskell indexer uses the `.hie` files produced when the Haskell
+code is compiled with GHC's `-fwrite-ide-info` option, so first you
+need to compile your Haskell code with that flag. For example, using
+Cabal you can do
 
 ```
-BUILD --ghc-options=-fwrite-ide-info
+cabal build --ghc-options=-fwrite-ide-info
+```
+
+To enable `-fwrite-ide-info` more permanently, you can add it to your
+`cabal.project` like this:
+
+```
+program-options
+    ghc-options: -fwrite-ide-info
+```
+
+Ensure that you have [built and installed Glean](../building.md) and
+the `glean` executable is on your `PATH`.  Then you can index your
+Haskell code with:
+
+```
 glean --db-root DBDIR index haskell ROOT --db NAME/INSTANCE
 ```
 
@@ -19,8 +40,8 @@ where
 
 * `BUILD` is a build command such that GHC is called with `-fwrite-ide-info`
 * `DBDIR` is the directory where the Glean db will be created
-* `ROOT` is the root directory containing the build artifacts generated with the `fwrite-ide-info` flag (e.g. `dist` if a Cabal project)
-* `name/hash` is the name of the repository to create
+* `ROOT` is the root directory containing the build artifacts generated with the `fwrite-ide-info` flag (e.g. `dist-newstyle` if a Cabal project)
+* `NAME/INSTANCE` is the name of the repository to create
 
 ## Schema
 

--- a/glean/website/docs/indexer/lsif-go.md
+++ b/glean/website/docs/indexer/lsif-go.md
@@ -11,28 +11,24 @@ To index [Go](https://go.dev/) we use SourceGraph's [LSIF indexer for Go](https:
 
 ## Run the indexer
 
-The indexer is run via the main `glean` CLI tool.
+Ensure that you have [built and installed Glean](../building.md) and
+the `glean` executable is on your `PATH`.
+
+Index your Go repository with:
 
 ```
-> cabal build exe:glean
-```
-
-And index your Go repository with:
-```
-glean index go DIR --db NAME/INSTANCE
+glean index go DIR --db-root DB --db NAME/INSTANCE
 ```
 
 where
 
+* `DB` is the directory where you want to store your Glean DBs
 * `DIR` is the root directory containing the Go project
-* `name/hash` is the name of the repository to create
-
-Provide the usual `--db-root` and `--schema` or `--service` arguments
-to `glean`
+* `NAME/INSTANCE` is the name of the repository to create
 
 ## In the shell
 
-Go source can also be indexed directly from the Glean shell:
+Go source can also be indexed directly from the [Glean shell](../shell.md):
 
 ```
 :index go DIR

--- a/glean/website/docs/indexer/lsif-java.md
+++ b/glean/website/docs/indexer/lsif-java.md
@@ -26,28 +26,23 @@ curl -fLo coursier https://git.io/coursier-cli && chmod +x coursier
 
 ## Run the indexer
 
-The indexer can be run via the main `glean` CLI tool.
+Ensure that you have [built and installed Glean](../building.md) and
+the `glean` executable is on your `PATH`.
 
+Index your Java repository with:
 ```
-> cabal build exe:glean
-```
-
-And index your Java repository with:
-```
-glean index java-lsif DIR --db NAME/INSTANCE
+glean index java-lsif DIR --db-root DB --db NAME/INSTANCE
 ```
 
 where
 
+* `DB` is the directory where you want to store your Glean DBs
 * `DIR` is the root directory containing the Rust project
-* `name/hash` is the name of the repository to create
-
-Provide the usual `--db-root` and `--schema` or `--service` arguments
-to `glean`
+* `NAME/INSTANCE` is the name of the repository to create
 
 ## In the shell
 
-Java source can also be indexed directly from the Glean shell:
+Java source can also be indexed directly from the [Glean shell](../shell.md):
 
 ```
 :index java-lsif DIR

--- a/glean/website/docs/indexer/lsif-rust.md
+++ b/glean/website/docs/indexer/lsif-rust.md
@@ -11,28 +11,23 @@ To index [Rust](https://www.rust-lang.org/) we use [rust-analyzer](https://rust-
 
 ## Run the indexer
 
-The indexer is run via the main `glean` CLI tool.
+Ensure that you have [built and installed Glean](../building.md) and
+the `glean` executable is on your `PATH`.
 
+Index your Rust repository with:
 ```
-> cabal build exe:glean
-```
-
-And index your Rust repository with:
-```
-glean index rust-lsif DIR --db NAME/INSTANCE
+glean index rust-lsif DIR --db-root DB --db NAME/INSTANCE
 ```
 
 where
 
+* `DB` is the directory where you want to store your Glean DBs
 * `DIR` is the root directory containing the Rust project
-* `name/hash` is the name of the repository to create
-
-Provide the usual `--db-root` and `--schema` or `--service` arguments
-to `glean`
+* `NAME/INSTANCE` is the name of the repository to create
 
 ## In the shell
 
-Rust source can also be indexed directly from the Glean shell:
+Rust source can also be indexed directly from the [Glean shell](../shell.md):
 
 ```
 :index rust-lsif DIR

--- a/glean/website/docs/indexer/lsif-typescript.md
+++ b/glean/website/docs/indexer/lsif-typescript.md
@@ -11,30 +11,25 @@ To index [TypeScript](https://www.typescriptlang.org/) we use SourceGraph's [LSI
 
 ## Run the indexer
 
-The indexer is run via the main `glean` CLI tool.
+Ensure that you have [built and installed Glean](../building.md) and
+the `glean` executable is on your `PATH`.
 
+Index your TypeScript repository with:
 ```
-> cabal build exe:glean
-```
-
-And index your TypeScript repository with:
-```
-glean index typescript DIR --db NAME/INSTANCE
+glean index typescript DIR --db-root DB --db NAME/INSTANCE
 ```
 
 where
 
+* `DB` is the directory where you want to store your Glean DBs
 * `DIR` is the root directory containing the TypeScript project
-* `name/hash` is the name of the repository to create
-
-Provide the usual `--db-root` and `--schema` or `--service` arguments
-to `glean`
+* `NAME/INSTANCE` is the name of the repository to create
 
 To index very large TypeScript repositories, it may be necessary to use more heap memory in node.js (or break up the targets into subdirectories). Setting `export NODE_OPTIONS="--max-old-space-size=8192"` in the environment in which the indexer runs may help.
 
 ## In the shell
 
-TypeScript source can also be indexed directly from the Glean shell:
+TypeScript source can also be indexed directly from the [Glean shell](../shell.md):
 
 ```
 :index typescript DIR

--- a/glean/website/docs/indexer/python-scip.md
+++ b/glean/website/docs/indexer/python-scip.md
@@ -11,28 +11,24 @@ To index [Python](https://www.python.org) we use SourceGraph's [SCIP indexer for
 
 ## Run the indexer
 
-The indexer is run via the main `glean` CLI tool.
+Ensure that you have [built and installed Glean](../building.md) and
+the `glean` executable is on your `PATH`.
+
+You can index a Python repository with:
 
 ```
-> cabal build exe:glean
-```
-
-And index your Python repository with:
-```
-glean index python-scip DIR --db NAME/INSTANCE
+glean index python-scip DIR --db-root DB --db NAME/INSTANCE
 ```
 
 where
 
+* `DB` is the directory where you want to store your Glean DBs
 * `DIR` is the root directory containing the Python project
-* `name/hash` is the name of the repository to create
-
-Provide the usual `--db-root` and `--schema` or `--service` arguments
-to `glean`
+* `NAME/INSTANCE` is the name of the repository to create
 
 ## In the shell
 
-Python source can also be indexed directly from the Glean shell:
+Python source can also be indexed directly from the [Glean shell](../shell.md):
 
 ```
 :index python-scip DIR


### PR DESCRIPTION
- Point to the build instructions instead of suggesting `cabal build exe:glean`, since most people will just want to `cabal install glean`.

- Add `--db-root` flags to the examples to make them self contained.

- fix `name/hash` which should be `NAME/INSTANCE`

- update the Haskell indexer instructions, explain how to use it with Cabal

- update the C++ indexer instructions, explain that you have to build the indexer from the repo.

- add hyperlinks