### PR TITLE
Add Python to languages supported by codemarkup for SCIP

### DIFF
--- a/glean/glass/Glean/Glass/SymbolId.hs
+++ b/glean/glass/Glean/Glass/SymbolId.hs
@@ -352,6 +352,7 @@ instance Symbol Code.Entity where
       Scip.Entity_java se -> toSymbolWithPath se p
       Scip.Entity_kotlin se -> toSymbolWithPath se p
       Scip.Entity_swift se -> toSymbolWithPath se p
+      Scip.Entity_python se -> toSymbolWithPath se p
       Scip.Entity_EMPTY -> throwM $ SymbolError "Unknown SCIP language"
 
     _ -> throwM $ SymbolError "Language not supported"
@@ -411,6 +412,7 @@ entityToAngle e = case e of
       Scip.Entity_java x -> Right $ alt @"java" (toAngle x)
       Scip.Entity_kotlin x -> Right $ alt @"kotlin" (toAngle x)
       Scip.Entity_swift x -> Right $ alt @"swift" (toAngle x)
+      Scip.Entity_python x -> Right $ alt @"python" (toAngle x)
       Scip.Entity_EMPTY -> Left "toAngle: Unknown SCIP language"
 
   _ -> Left $
@@ -454,6 +456,7 @@ instance ToQName Code.Entity where
       Scip.Entity_java x -> toQName x
       Scip.Entity_kotlin x -> toQName x
       Scip.Entity_swift x -> toQName x
+      Scip.Entity_python x -> toQName x
       Scip.Entity_EMPTY -> pure $ Left "SCIP: language unsupported"
     _ -> pure $ Left ("Language unsupported: " <> textShow (entityLanguage e))
 

--- a/glean/glass/Glean/Glass/SymbolSig.hs
+++ b/glean/glass/Glean/Glass/SymbolSig.hs
@@ -147,6 +147,7 @@ instance ToSymbolSignature Code.Entity where
       Scip.Entity_java x -> SCIP.prettyScipSignature opts x
       Scip.Entity_kotlin x -> SCIP.prettyScipSignature opts x
       Scip.Entity_swift x -> SCIP.prettyScipSignature opts x
+      Scip.Entity_python x -> SCIP.prettyScipSignature opts x
       Scip.Entity_EMPTY -> pure Nothing
     -- lsif languages, just enumerate completely to stay total
     Code.Entity_lsif e -> case e of

--- a/glean/schema/source/code.scip.angle
+++ b/glean/schema/source/code.scip.angle
@@ -12,6 +12,7 @@ type Entity =
     java : scip.SomeEntity |
     kotlin : scip.SomeEntity |
     swift: scip.SomeEntity |
+    python: scip.SomeEntity |
   }
 
 type SymbolId = scip.Symbol

--- a/glean/schema/source/scip.angle
+++ b/glean/schema/source/scip.angle
@@ -194,6 +194,7 @@ type Entity =
     java: SomeEntity |
     kotlin: SomeEntity |
     swift: SomeEntity |
+    python: SomeEntity |
   }
 
 # entities are scip.Definitions
@@ -216,6 +217,7 @@ predicate TagDefinition:
     ( TypeScript = Language; { typescript = SomeEntity }) |
     ( Swift = Language; { swift = SomeEntity }) |
     ( Java = Language; { java = SomeEntity }) |
+    ( Python = Language; { python = SomeEntity }) |
     ( Kotlin = Language; { kotlin = SomeEntity }) = Entity;
 
 # eliminate entity language tags. inverse of TagDefinition


### PR DESCRIPTION
Test Plan:
Index some Python code with `glean index python-scip`

Then query for `codemarkup.FileEntityLocations _`. Before it produced nothing, after this diff it produces results.