### PR TITLE
[oss] TestRunner: nicer failure diagnostics

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -228,7 +228,7 @@ library stubs
         mangle,
         template-haskell,
         tasty,
-        tasty-hunit-adapter
+        tasty-hunit
 
 library logger
     import: fb-haskell, fb-cpp, deps


### PR DESCRIPTION
Before:

```
FAIL
    Exception: HUnitFailure (Just (SrcLoc {srcLocPackage = "glean-0.1.0.0-inplace-regression-test-lib", srcLocModule = "Glean.Regression.Snapshot.Result", srcLocFile = "glean/test/regression/Glean/Regression/Snapshot/Result.hs", srcLocStartLine = 34, srcLocStartCol = 25, srcLocEndLine = 34, srcLocEndCol = 44})) (Reason "filerange.out: unexpected result\n19,29d18\n<         \"columnBegin\": 1,\n<         \"lineEnd\": 53,\n<         \"columnEnd\": 1\n<       }\n<     }\n<   },\n<   {\n<     \"key\": {\n<       \"file\": { \"key\": \"example.ts\" },\n<       \"range\": {\n<         \"lineBegin\": 9,\n74,84d62\n<         \"columnBegin\": 1,\n<         \"lineEnd\": 42,\n<         \"columnEnd\": 3\n<       }\n<     }\n<   },\n<   {\n<     \"key\": {\n<       \"file\": { \"key\": \"example.ts\" },\n<       \"range\": {\n<         \"lineBegin\": 14,\n107,117d84\n<         \"columnBegin\": 3,\n<         \"lineEnd\": 33,\n<         \"columnEnd\": 3\n<       }\n<     }\n<   },\n<   {\n<     \"key\": {\n<       \"file\": { \"key\": \"example.ts\" },\n<       \"range\": {\n<         \"lineBegin\": 15,\n382,392d348\n<         \"columnBegin\": 3,\n<         \"lineEnd\": 41,\n<         \"columnEnd\": 5\n<       }\n<     }\n<   },\n<   {\n<     \"key\": {\n<       \"file\": { \"key\": \"example.ts\" },\n<       \"range\": {\n<         \"lineBegin\": 34,\n528,538d483\n<       }\n<     }\n<   },\n<   {\n<     \"key\": {\n<       \"file\": { \"key\": \"example.ts\" },\n<       \"range\": {\n<         \"lineBegin\": 46,\n<         \"columnBegin\": 1,\n<         \"lineEnd\": 52,\n<         \"columnEnd\": 1\n\nfilerange.perf: unexpected result\n3c3\n<   \"facts_searched\": { \"scip.FileRange.1\": 62 },\n---\n>   \"facts_searched\": { \"scip.FileRange.1\": 57 },\n\n")
```

After:

```
FAIL (4.24s)
    glean/test/regression/Glean/Regression/Snapshot/Result.hs:34:
    filerange.out: unexpected result
    19,29d18
    <         "columnBegin": 1,
    <         "lineEnd": 53,
    <         "columnEnd": 1
    <       }
    <     }
    <   },
    <   {
    <     "key": {
    <       "file": { "key": "example.ts" },
    <       "range": {
    <         "lineBegin": 9,
    74,84d62
    <         "columnBegin": 1,
    <         "lineEnd": 42,
    <         "columnEnd": 3
    <       }
    <     }
    <   },
    <   {
    <     "key": {
    <       "file": { "key": "example.ts" },
    <       "range": {
    <         "lineBegin": 14,
    107,117d84
    <         "columnBegin": 3,
    <         "lineEnd": 33,
    <         "columnEnd": 3
    <       }
    <     }
    <   },
    <   {
    <     "key": {
    <       "file": { "key": "example.ts" },
    <       "range": {
    <         "lineBegin": 15,
    382,392d348
    <         "columnBegin": 3,
    <         "lineEnd": 41,
    <         "columnEnd": 5
    <       }
    <     }
    <   },
    <   {
    <     "key": {
    <       "file": { "key": "example.ts" },
    <       "range": {
    <         "lineBegin": 34,
    528,538d483
    <       }
    <     }
    <   },
    <   {
    <     "key": {
    <       "file": { "key": "example.ts" },
    <       "range": {
    <         "lineBegin": 46,
    <         "columnBegin": 1,
    <         "lineEnd": 52,
    <         "columnEnd": 1

    filerange.perf: unexpected result
    3c3
    <   "facts_searched": { "scip.FileRange.1": 62 },
    ---
    >   "facts_searched": { "scip.FileRange.1": 57 },
```