### PR TITLE
codemarkup.EntityKind for Haskell

### DIFF
--- a/glean/lang/codemarkup/tests/haskell/code/entity_info.out
+++ b/glean/lang/codemarkup/tests/haskell/code/entity_info.out
@@ -1,0 +1,497 @@
+[
+  "@generated",
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "A", "namespace_": 3 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 1, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "C", "namespace_": 3 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 6, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "C1", "namespace_": 1 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 15, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "C2", "namespace_": 1 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 15, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "C3", "namespace_": 1 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 15, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "R", "namespace_": 1 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 15, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "R", "namespace_": 3 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 1, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "T", "namespace_": 3 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 1, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "a", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 13, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "a", "namespace_": 2 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "internal": { "start": 379, "length": 1 } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 27, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "a", "namespace_": 2 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "internal": { "start": 414, "length": 1 } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 27, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "a", "namespace_": 2 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "internal": { "start": 463, "length": 1 } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 27, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "a", "namespace_": 2 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "internal": { "start": 546, "length": 15 } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 27, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "f", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 13, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "f1", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 9, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "f1", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 13, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "f2", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 9, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "f2", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 13, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "m", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 7, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "m", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "internal": { "start": 512, "length": 12 } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 13, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "r", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "internal": { "start": 585, "length": 1 } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 14, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "x", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "internal": { "start": 514, "length": 1 } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 14, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "x", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "internal": { "start": 572, "length": 1 } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 14, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/A.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "zero", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 13, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/B.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "b", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 13, "isAbstract": false }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/codemarkup/tests/haskell/code/B.hs" },
+      "entity": {
+        "hs": {
+          "name": {
+            "key": {
+              "occ": { "key": { "name": "r", "namespace_": 0 } },
+              "mod": {
+                "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+              },
+              "sort": { "external": { } }
+            }
+          }
+        }
+      },
+      "info": { "kind": 13, "isAbstract": false }
+    }
+  }
+]

--- a/glean/lang/codemarkup/tests/haskell/code/entity_info.perf
+++ b/glean/lang/codemarkup/tests/haskell/code/entity_info.perf
@@ -1,0 +1,18 @@
+{
+  "@generated": null,
+  "facts_searched": {
+    "hs.ClassDecl.3": 1,
+    "hs.ConstrDecl.3": 4,
+    "hs.DataDecl.3": 2,
+    "hs.DeclarationLocation.3": 24,
+    "hs.MethDecl.3": 1,
+    "hs.ModuleDeclarations.3": 2,
+    "hs.PatBind.3": 3,
+    "hs.RecordFieldDecl.3": 2,
+    "hs.SourceModule.3": 2,
+    "hs.TyVarBind.3": 4,
+    "hs.TypeSynDecl.3": 1,
+    "hs.ValBind.3": 8
+  },
+  "full_scans": [ "hs.SourceModule.3" ]
+}

--- a/glean/lang/codemarkup/tests/haskell/code/entity_info.query
+++ b/glean/lang/codemarkup/tests/haskell/code/entity_info.query
@@ -1,0 +1,4 @@
+query: |
+  codemarkup.FileEntityInfos _
+perf: true
+transform: [gensort, []]

--- a/glean/schema/source/codemarkup.angle
+++ b/glean/schema/source/codemarkup.angle
@@ -57,7 +57,8 @@ predicate EntityKind:
     (codemarkup.fbthrift.ThriftEntityKind { E, Kind }; { fbthrift = E } = Entity) |
     (codemarkup.buck.BuckEntityKind { E, Kind }; { buck = E } = Entity) |
     (codemarkup.csharp.CSharpEntityKind { E, Kind }; { csharp = E } = Entity) |
-    (codemarkup.graphql.GraphQLEntityKind { E, Kind }; { graphql = E } = Entity) ;
+    (codemarkup.graphql.GraphQLEntityKind { E, Kind }; { graphql = E } = Entity) |
+    (codemarkup.haskell.HaskellEntityKind { E, Kind }; { hs = E } = Entity) ;
 
 # Retrieve information about an entity
 predicate EntityInfo:
@@ -84,7 +85,9 @@ predicate EntityInfo:
        (codemarkup.csharp.CSharpEntityKind { E, Kind };
         { csharp = E } = Entity) |
        (codemarkup.graphql.GraphQLEntityKind { E, Kind };
-        { graphql = E } = Entity);
+        { graphql = E } = Entity) |
+       (codemarkup.haskell.HaskellEntityKind { E, Kind };
+        { hs = E } = Entity);
       )
     ) |
     (codemarkup.cxx.CxxEntityInfo { E, Info }; { cxx = E } = Entity) |

--- a/glean/schema/source/codemarkup.haskell.angle
+++ b/glean/schema/source/codemarkup.haskell.angle
@@ -132,4 +132,27 @@ predicate HaskellContainsChildEntity:
     (ParentDecl.con?.fields[..]).name = ChildName
   )
 
+#
+# Entity kinds
+#
+
+predicate HaskellEntityKind:
+  {
+    entity: code.hs.Entity,
+    kind: codemarkup.types.SymbolKind,
+  }
+  { {name = Name}, Kind } where
+     hs.DeclarationOfName { name = Name, decl = Decl };
+     ( Decl = { val = _ }; Function = Kind ) |
+     ( Decl = { typeFamily = _ }; Type = Kind ) |
+     ( Decl = { type_ = _ }; Type = Kind ) |
+     ( Decl = { data = _ }; Type = Kind ) |
+     ( Decl = { con = _ }; Constant = Kind ) |
+     ( Decl = { patSyn = _ }; Constant = Kind ) |
+     ( Decl = { class_ = _ }; Class_ = Kind ) |
+     ( Decl = { method = _ }; Method = Kind ) |
+     ( Decl = { patBind = _ }; Variable = Kind ) |
+     ( Decl = { tyVarBind = _ }; TypeParameter = Kind ) |
+     ( Decl = { field = _ }; Field = Kind )
+
 }


### PR DESCRIPTION
Enables the `symbolKind` attributes to be generated by Glass