### PR TITLE
Support multiple output files

### DIFF
--- a/glean/lang/haskell/tests/code/hsClassDecl.out.9.4
+++ b/glean/lang/haskell/tests/code/hsClassDecl.out.9.4
@@ -1,0 +1,59 @@
+[
+  "@generated",
+  {
+    "key": {
+      "defaults": [
+        {
+          "key": {
+            "loc": {
+              "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+              "span": { "length": 10, "start": 535 }
+            },
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "m", "namespace_": 0 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "key": {
+            "class_": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "C", "namespace_": 3 } },
+                "sort": { "external": { } }
+              }
+            },
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "m", "namespace_": 0 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ],
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "C", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsClassDecl.out.9.6
+++ b/glean/lang/haskell/tests/code/hsClassDecl.out.9.6
@@ -1,0 +1,59 @@
+[
+  "@generated",
+  {
+    "key": {
+      "defaults": [
+        {
+          "key": {
+            "loc": {
+              "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+              "span": { "length": 10, "start": 535 }
+            },
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "m", "namespace_": 0 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "key": {
+            "class_": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "C", "namespace_": 3 } },
+                "sort": { "external": { } }
+              }
+            },
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "m", "namespace_": 0 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ],
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "C", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsDataDecl.out.9.4
+++ b/glean/lang/haskell/tests/code/hsDataDecl.out.9.4
@@ -1,0 +1,182 @@
+[
+  "@generated",
+  {
+    "key": {
+      "constrs": [
+        {
+          "key": {
+            "data_": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "R", "namespace_": 3 } },
+                "sort": { "external": { } }
+              }
+            },
+            "fields": [
+              {
+                "key": {
+                  "con": {
+                    "key": {
+                      "mod": {
+                        "key": {
+                          "name": { "key": "A" },
+                          "unit": { "key": "main" }
+                        }
+                      },
+                      "occ": { "key": { "name": "R", "namespace_": 1 } },
+                      "sort": { "external": { } }
+                    }
+                  },
+                  "name": {
+                    "key": {
+                      "mod": {
+                        "key": {
+                          "name": { "key": "A" },
+                          "unit": { "key": "main" }
+                        }
+                      },
+                      "occ": { "key": { "name": "f1", "namespace_": 0 } },
+                      "sort": { "external": { } }
+                    }
+                  }
+                }
+              },
+              {
+                "key": {
+                  "con": {
+                    "key": {
+                      "mod": {
+                        "key": {
+                          "name": { "key": "A" },
+                          "unit": { "key": "main" }
+                        }
+                      },
+                      "occ": { "key": { "name": "R", "namespace_": 1 } },
+                      "sort": { "external": { } }
+                    }
+                  },
+                  "name": {
+                    "key": {
+                      "mod": {
+                        "key": {
+                          "name": { "key": "A" },
+                          "unit": { "key": "main" }
+                        }
+                      },
+                      "occ": { "key": { "name": "f2", "namespace_": 0 } },
+                      "sort": { "external": { } }
+                    }
+                  }
+                }
+              }
+            ],
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "R", "namespace_": 1 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ],
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "R", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "constrs": [
+        {
+          "key": {
+            "data_": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "T", "namespace_": 3 } },
+                "sort": { "external": { } }
+              }
+            },
+            "fields": [ ],
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "C1", "namespace_": 1 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "data_": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "T", "namespace_": 3 } },
+                "sort": { "external": { } }
+              }
+            },
+            "fields": [ ],
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "C2", "namespace_": 1 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "data_": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "T", "namespace_": 3 } },
+                "sort": { "external": { } }
+              }
+            },
+            "fields": [ ],
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "C3", "namespace_": 1 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ],
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "T", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsDataDecl.out.9.6
+++ b/glean/lang/haskell/tests/code/hsDataDecl.out.9.6
@@ -1,0 +1,182 @@
+[
+  "@generated",
+  {
+    "key": {
+      "constrs": [
+        {
+          "key": {
+            "data_": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "R", "namespace_": 3 } },
+                "sort": { "external": { } }
+              }
+            },
+            "fields": [
+              {
+                "key": {
+                  "con": {
+                    "key": {
+                      "mod": {
+                        "key": {
+                          "name": { "key": "A" },
+                          "unit": { "key": "main" }
+                        }
+                      },
+                      "occ": { "key": { "name": "R", "namespace_": 1 } },
+                      "sort": { "external": { } }
+                    }
+                  },
+                  "name": {
+                    "key": {
+                      "mod": {
+                        "key": {
+                          "name": { "key": "A" },
+                          "unit": { "key": "main" }
+                        }
+                      },
+                      "occ": { "key": { "name": "f1", "namespace_": 0 } },
+                      "sort": { "external": { } }
+                    }
+                  }
+                }
+              },
+              {
+                "key": {
+                  "con": {
+                    "key": {
+                      "mod": {
+                        "key": {
+                          "name": { "key": "A" },
+                          "unit": { "key": "main" }
+                        }
+                      },
+                      "occ": { "key": { "name": "R", "namespace_": 1 } },
+                      "sort": { "external": { } }
+                    }
+                  },
+                  "name": {
+                    "key": {
+                      "mod": {
+                        "key": {
+                          "name": { "key": "A" },
+                          "unit": { "key": "main" }
+                        }
+                      },
+                      "occ": { "key": { "name": "f2", "namespace_": 0 } },
+                      "sort": { "external": { } }
+                    }
+                  }
+                }
+              }
+            ],
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "R", "namespace_": 1 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ],
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "R", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "constrs": [
+        {
+          "key": {
+            "data_": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "T", "namespace_": 3 } },
+                "sort": { "external": { } }
+              }
+            },
+            "fields": [ ],
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "C1", "namespace_": 1 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "data_": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "T", "namespace_": 3 } },
+                "sort": { "external": { } }
+              }
+            },
+            "fields": [ ],
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "C2", "namespace_": 1 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "data_": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "T", "namespace_": 3 } },
+                "sort": { "external": { } }
+              }
+            },
+            "fields": [ ],
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "C3", "namespace_": 1 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ],
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "T", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsDeclarationLocation.out.9.4
+++ b/glean/lang/haskell/tests/code/hsDeclarationLocation.out.9.4
@@ -1,0 +1,378 @@
+[
+  "@generated",
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "A", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 12, "start": 403 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "C", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 53, "start": 492 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "C1", "namespace_": 1 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 8, "start": 428 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "C2", "namespace_": 1 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 4, "start": 439 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "C3", "namespace_": 1 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 4, "start": 446 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "R", "namespace_": 1 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 27, "start": 463 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "R", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 38, "start": 452 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "T", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 33, "start": 417 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 19, "start": 382 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 2 } },
+          "sort": { "internal": { "length": 1, "start": 424 } }
+        }
+      },
+      "span": { "length": 1, "start": 424 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 2 } },
+          "sort": { "internal": { "length": 1, "start": 459 } }
+        }
+      },
+      "span": { "length": 1, "start": 459 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 2 } },
+          "sort": { "internal": { "length": 1, "start": 508 } }
+        }
+      },
+      "span": { "length": 1, "start": 508 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 2 } },
+          "sort": { "internal": { "length": 15, "start": 604 } }
+        }
+      },
+      "span": { "length": 15, "start": 604 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "f", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 68, "start": 620 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "f1", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 2, "start": 467 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "f2", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 2, "start": 479 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "m", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 14, "start": 518 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "m", "namespace_": 0 } },
+          "sort": { "internal": { "length": 10, "start": 535 } }
+        }
+      },
+      "span": { "length": 10, "start": 535 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "m", "namespace_": 0 } },
+          "sort": { "internal": { "length": 12, "start": 570 } }
+        }
+      },
+      "span": { "length": 12, "start": 570 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "r", "namespace_": 0 } },
+          "sort": { "internal": { "length": 1, "start": 643 } }
+        }
+      },
+      "span": { "length": 1, "start": 643 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "x", "namespace_": 0 } },
+          "sort": { "internal": { "length": 1, "start": 572 } }
+        }
+      },
+      "span": { "length": 1, "start": 572 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "x", "namespace_": 0 } },
+          "sort": { "internal": { "length": 1, "start": 630 } }
+        }
+      },
+      "span": { "length": 1, "start": 630 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "zero", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 8, "start": 594 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "b", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 23, "start": 290 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "r", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 32, "start": 327 }
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsDeclarationLocation.out.9.6
+++ b/glean/lang/haskell/tests/code/hsDeclarationLocation.out.9.6
@@ -1,0 +1,378 @@
+[
+  "@generated",
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "A", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 12, "start": 403 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "C", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 53, "start": 492 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "C1", "namespace_": 1 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 8, "start": 428 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "C2", "namespace_": 1 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 4, "start": 439 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "C3", "namespace_": 1 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 4, "start": 446 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "R", "namespace_": 1 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 27, "start": 463 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "R", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 38, "start": 452 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "T", "namespace_": 3 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 33, "start": 417 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 19, "start": 382 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 2 } },
+          "sort": { "internal": { "length": 1, "start": 424 } }
+        }
+      },
+      "span": { "length": 1, "start": 424 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 2 } },
+          "sort": { "internal": { "length": 1, "start": 459 } }
+        }
+      },
+      "span": { "length": 1, "start": 459 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 2 } },
+          "sort": { "internal": { "length": 1, "start": 508 } }
+        }
+      },
+      "span": { "length": 1, "start": 508 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 2 } },
+          "sort": { "internal": { "length": 15, "start": 604 } }
+        }
+      },
+      "span": { "length": 15, "start": 604 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "f", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 68, "start": 620 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "f1", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 2, "start": 467 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "f2", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 2, "start": 479 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "m", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 14, "start": 518 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "m", "namespace_": 0 } },
+          "sort": { "internal": { "length": 10, "start": 535 } }
+        }
+      },
+      "span": { "length": 10, "start": 535 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "m", "namespace_": 0 } },
+          "sort": { "internal": { "length": 12, "start": 570 } }
+        }
+      },
+      "span": { "length": 12, "start": 570 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "r", "namespace_": 0 } },
+          "sort": { "internal": { "length": 1, "start": 643 } }
+        }
+      },
+      "span": { "length": 1, "start": 643 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "x", "namespace_": 0 } },
+          "sort": { "internal": { "length": 1, "start": 572 } }
+        }
+      },
+      "span": { "length": 1, "start": 572 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "x", "namespace_": 0 } },
+          "sort": { "internal": { "length": 1, "start": 630 } }
+        }
+      },
+      "span": { "length": 1, "start": 630 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "zero", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 8, "start": 594 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "b", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 23, "start": 290 }
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "r", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      },
+      "span": { "length": 32, "start": 327 }
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsFileXRefs.out.9.4
+++ b/glean/lang/haskell/tests/code/hsFileXRefs.out.9.4
@@ -1,0 +1,902 @@
+[
+  "@generated",
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "xrefs": [
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 0, "span": { "length": 3, "start": 364 } },
+              { "kind": 2, "span": { "length": 3, "start": 664 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "ord", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 0, "span": { "length": 7, "start": 355 } },
+              { "kind": 2, "span": { "length": 7, "start": 390 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Unicode" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "toLower", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 0, "span": { "length": 9, "start": 344 } } ],
+            "target": { "modName": { "key": "Data.Char" } }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 273 } },
+              { "kind": 3, "span": { "length": 1, "start": 370 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 279 } },
+              { "kind": 2, "span": { "length": 1, "start": 442 } },
+              { "kind": 2, "span": { "length": 1, "start": 592 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "A", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 285 } },
+              { "kind": 2, "span": { "length": 1, "start": 616 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "T", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 295 } },
+              { "kind": 2, "span": { "length": 1, "start": 609 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "R", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 305 } },
+              { "kind": 2, "span": { "length": 1, "start": 556 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "C", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 324 } },
+              { "kind": 3, "span": { "length": 1, "start": 604 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "f", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 4, "start": 315 } },
+              { "kind": 3, "span": { "length": 4, "start": 584 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "zero", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 449 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 2 } },
+                  "sort": { "internal": { "length": 1, "start": 424 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 486 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 2 } },
+                  "sort": { "internal": { "length": 1, "start": 459 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 1, "start": 501 } },
+              { "kind": 2, "span": { "length": 1, "start": 523 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 2 } },
+                  "sort": { "internal": { "length": 1, "start": 508 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 1, "start": 535 } },
+              { "kind": 2, "span": { "length": 1, "start": 570 } },
+              { "kind": 2, "span": { "length": 1, "start": 647 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "m", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 1, "start": 576 } },
+              { "kind": 2, "span": { "length": 1, "start": 581 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "x", "namespace_": 0 } },
+                  "sort": { "internal": { "length": 1, "start": 572 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 1, "start": 611 } },
+              { "kind": 2, "span": { "length": 1, "start": 618 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 2 } },
+                  "sort": { "internal": { "length": 15, "start": 604 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 1, "start": 622 } },
+              { "kind": 2, "span": { "length": 2, "start": 467 } },
+              { "kind": 2, "span": { "length": 2, "start": 479 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "R", "namespace_": 1 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 639 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "x", "namespace_": 0 } },
+                  "sort": { "internal": { "length": 1, "start": 630 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 672 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "r", "namespace_": 0 } },
+                  "sort": { "internal": { "length": 1, "start": 643 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 2, "start": 467 } },
+              { "kind": 2, "span": { "length": 2, "start": 669 } },
+              { "kind": 2, "span": { "length": 2, "start": 676 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "f1", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 2, "start": 479 } },
+              { "kind": 2, "span": { "length": 2, "start": 624 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "f2", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 498 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Classes" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Eq", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 578 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Classes" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "==", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 636 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "C3", "namespace_": 1 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 660 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "C2", "namespace_": 1 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 3, "start": 386 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "map", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 3, "start": 412 } },
+              { "kind": 2, "span": { "length": 3, "start": 558 } },
+              { "kind": 2, "span": { "length": 3, "start": 653 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Int", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 4, "start": 473 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Char", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 4, "start": 528 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Bool", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 4, "start": 541 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "True", "namespace_": 1 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 5, "start": 431 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Float", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 6, "start": 375 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "String", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+      "xrefs": [
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 0, "span": { "length": 1, "start": 254 } } ],
+            "target": { "modName": { "key": "A" } }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [
+              { "kind": 0, "span": { "length": 3, "start": 273 } },
+              { "kind": 2, "span": { "length": 3, "start": 308 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "ord", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 0, "span": { "length": 9, "start": 263 } } ],
+            "target": { "modName": { "key": "Data.Char" } }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 228 } },
+              { "kind": 3, "span": { "length": 1, "start": 279 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "b", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 234 } },
+              { "kind": 3, "span": { "length": 1, "start": 315 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "r", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 302 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "$", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 312 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 320 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "R", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 337 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "f1", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 347 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "f2", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 3, "start": 285 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Int", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 3, "start": 304 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "map", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 3, "start": 331 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "R", "namespace_": 1 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 4, "start": 322 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Char", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 7, "start": 294 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.List" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "reverse", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsFileXRefs.out.9.6
+++ b/glean/lang/haskell/tests/code/hsFileXRefs.out.9.6
@@ -1,0 +1,902 @@
+[
+  "@generated",
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+      "xrefs": [
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 0, "span": { "length": 3, "start": 364 } },
+              { "kind": 2, "span": { "length": 3, "start": 664 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "ord", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 0, "span": { "length": 7, "start": 355 } },
+              { "kind": 2, "span": { "length": 7, "start": 390 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Unicode" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "toLower", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 0, "span": { "length": 9, "start": 344 } } ],
+            "target": { "modName": { "key": "Data.Char" } }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 273 } },
+              { "kind": 3, "span": { "length": 1, "start": 370 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 279 } },
+              { "kind": 2, "span": { "length": 1, "start": 442 } },
+              { "kind": 2, "span": { "length": 1, "start": 592 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "A", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 285 } },
+              { "kind": 2, "span": { "length": 1, "start": 616 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "T", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 295 } },
+              { "kind": 2, "span": { "length": 1, "start": 609 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "R", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 305 } },
+              { "kind": 2, "span": { "length": 1, "start": 556 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "C", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 324 } },
+              { "kind": 3, "span": { "length": 1, "start": 604 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "f", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 4, "start": 315 } },
+              { "kind": 3, "span": { "length": 4, "start": 584 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "zero", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 449 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 2 } },
+                  "sort": { "internal": { "length": 1, "start": 424 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 486 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 2 } },
+                  "sort": { "internal": { "length": 1, "start": 459 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 1, "start": 501 } },
+              { "kind": 2, "span": { "length": 1, "start": 523 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 2 } },
+                  "sort": { "internal": { "length": 1, "start": 508 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 1, "start": 535 } },
+              { "kind": 2, "span": { "length": 1, "start": 570 } },
+              { "kind": 2, "span": { "length": 1, "start": 647 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "m", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 1, "start": 576 } },
+              { "kind": 2, "span": { "length": 1, "start": 581 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "x", "namespace_": 0 } },
+                  "sort": { "internal": { "length": 1, "start": 572 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 1, "start": 611 } },
+              { "kind": 2, "span": { "length": 1, "start": 618 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 2 } },
+                  "sort": { "internal": { "length": 15, "start": 604 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 1, "start": 622 } },
+              { "kind": 2, "span": { "length": 2, "start": 467 } },
+              { "kind": 2, "span": { "length": 2, "start": 479 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "R", "namespace_": 1 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 639 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "x", "namespace_": 0 } },
+                  "sort": { "internal": { "length": 1, "start": 630 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 672 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "r", "namespace_": 0 } },
+                  "sort": { "internal": { "length": 1, "start": 643 } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 2, "start": 467 } },
+              { "kind": 2, "span": { "length": 2, "start": 669 } },
+              { "kind": 2, "span": { "length": 2, "start": 676 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "f1", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 2, "start": 479 } },
+              { "kind": 2, "span": { "length": 2, "start": 624 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "f2", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 498 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Classes" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Eq", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 578 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Classes" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "==", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 636 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "C3", "namespace_": 1 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 660 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "C2", "namespace_": 1 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 3, "start": 386 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "map", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [
+              { "kind": 2, "span": { "length": 3, "start": 412 } },
+              { "kind": 2, "span": { "length": 3, "start": 558 } },
+              { "kind": 2, "span": { "length": 3, "start": 653 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Int", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 4, "start": 473 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Char", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 4, "start": 528 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Bool", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 4, "start": 541 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "True", "namespace_": 1 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 5, "start": 431 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Float", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 6, "start": 375 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "String", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "key": {
+      "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+      "xrefs": [
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 0, "span": { "length": 1, "start": 254 } } ],
+            "target": { "modName": { "key": "A" } }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [
+              { "kind": 0, "span": { "length": 3, "start": 273 } },
+              { "kind": 2, "span": { "length": 3, "start": 308 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "ord", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 0, "span": { "length": 9, "start": 263 } } ],
+            "target": { "modName": { "key": "Data.Char" } }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 228 } },
+              { "kind": 3, "span": { "length": 1, "start": 279 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "b", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [
+              { "kind": 1, "span": { "length": 1, "start": 234 } },
+              { "kind": 3, "span": { "length": 1, "start": 315 } }
+            ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "r", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 302 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "$", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 312 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "a", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 1, "start": 320 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "R", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 337 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "f1", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 2, "start": 347 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "f2", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 3, "start": 285 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Int", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 3, "start": 304 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Base" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "map", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 3, "start": 331 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                  },
+                  "occ": { "key": { "name": "R", "namespace_": 1 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 4, "start": 322 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.Types" },
+                      "unit": { "key": "ghc-prim" }
+                    }
+                  },
+                  "occ": { "key": { "name": "Char", "namespace_": 3 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "key": {
+            "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+            "refs": [ { "kind": 2, "span": { "length": 7, "start": 294 } } ],
+            "target": {
+              "name": {
+                "key": {
+                  "mod": {
+                    "key": {
+                      "name": { "key": "GHC.List" },
+                      "unit": { "key": "base" }
+                    }
+                  },
+                  "occ": { "key": { "name": "reverse", "namespace_": 0 } },
+                  "sort": { "external": { } }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsInstanceDecl.out.9.4
+++ b/glean/lang/haskell/tests/code/hsInstanceDecl.out.9.4
@@ -1,0 +1,30 @@
+[
+  "@generated",
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 35, "start": 547 }
+      },
+      "methods": [
+        {
+          "key": {
+            "loc": {
+              "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+              "span": { "length": 12, "start": 570 }
+            },
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "m", "namespace_": 0 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsInstanceDecl.out.9.6
+++ b/glean/lang/haskell/tests/code/hsInstanceDecl.out.9.6
@@ -1,0 +1,30 @@
+[
+  "@generated",
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 35, "start": 547 }
+      },
+      "methods": [
+        {
+          "key": {
+            "loc": {
+              "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+              "span": { "length": 12, "start": 570 }
+            },
+            "name": {
+              "key": {
+                "mod": {
+                  "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+                },
+                "occ": { "key": { "name": "m", "namespace_": 0 } },
+                "sort": { "external": { } }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsModuleDeclarations.out.9.4
+++ b/glean/lang/haskell/tests/code/hsModuleDeclarations.out.9.4
@@ -1,0 +1,394 @@
+[
+  "@generated",
+  {
+    "key": {
+      "exports": [
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "A", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C1", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C2", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C3", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "R", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "R", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "T", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f1", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f2", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "m", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "zero", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        }
+      ],
+      "module": {
+        "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+      },
+      "names": [
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "A", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C1", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C2", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C3", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "R", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "R", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "T", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 2 } },
+            "sort": { "internal": { "length": 1, "start": 424 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 2 } },
+            "sort": { "internal": { "length": 1, "start": 459 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 2 } },
+            "sort": { "internal": { "length": 1, "start": 508 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 2 } },
+            "sort": { "internal": { "length": 15, "start": 604 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f1", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f2", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "m", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "m", "namespace_": 0 } },
+            "sort": { "internal": { "length": 10, "start": 535 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "m", "namespace_": 0 } },
+            "sort": { "internal": { "length": 12, "start": 570 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "r", "namespace_": 0 } },
+            "sort": { "internal": { "length": 1, "start": 643 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "x", "namespace_": 0 } },
+            "sort": { "internal": { "length": 1, "start": 572 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "x", "namespace_": 0 } },
+            "sort": { "internal": { "length": 1, "start": 630 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "zero", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "key": {
+      "exports": [
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "b", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "r", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        }
+      ],
+      "module": {
+        "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+      },
+      "names": [
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "b", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "r", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsModuleDeclarations.out.9.6
+++ b/glean/lang/haskell/tests/code/hsModuleDeclarations.out.9.6
@@ -1,0 +1,394 @@
+[
+  "@generated",
+  {
+    "key": {
+      "exports": [
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "A", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C1", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C2", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C3", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "R", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "R", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "T", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f1", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f2", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "m", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "zero", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        }
+      ],
+      "module": {
+        "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+      },
+      "names": [
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "A", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C1", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C2", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "C3", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "R", "namespace_": 1 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "R", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "T", "namespace_": 3 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 2 } },
+            "sort": { "internal": { "length": 1, "start": 424 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 2 } },
+            "sort": { "internal": { "length": 1, "start": 459 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 2 } },
+            "sort": { "internal": { "length": 1, "start": 508 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "a", "namespace_": 2 } },
+            "sort": { "internal": { "length": 15, "start": 604 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f1", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "f2", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "m", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "m", "namespace_": 0 } },
+            "sort": { "internal": { "length": 10, "start": 535 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "m", "namespace_": 0 } },
+            "sort": { "internal": { "length": 12, "start": 570 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "r", "namespace_": 0 } },
+            "sort": { "internal": { "length": 1, "start": 643 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "x", "namespace_": 0 } },
+            "sort": { "internal": { "length": 1, "start": 572 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "x", "namespace_": 0 } },
+            "sort": { "internal": { "length": 1, "start": 630 } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "zero", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "key": {
+      "exports": [
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "b", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "r", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        }
+      ],
+      "module": {
+        "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+      },
+      "names": [
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "b", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        },
+        {
+          "key": {
+            "mod": {
+              "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+            },
+            "occ": { "key": { "name": "r", "namespace_": 0 } },
+            "sort": { "external": { } }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsSigDecl.out.9.4
+++ b/glean/lang/haskell/tests/code/hsSigDecl.out.9.4
@@ -1,0 +1,88 @@
+[
+  "@generated",
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 9, "start": 584 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "zero", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 11, "start": 370 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 15, "start": 604 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "f", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+        "span": { "length": 10, "start": 279 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "b", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+        "span": { "length": 11, "start": 315 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "r", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsSigDecl.out.9.6
+++ b/glean/lang/haskell/tests/code/hsSigDecl.out.9.6
@@ -1,0 +1,88 @@
+[
+  "@generated",
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 9, "start": 584 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "zero", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 11, "start": 370 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "a", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/A.hs" },
+        "span": { "length": 15, "start": 604 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "A" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "f", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+        "span": { "length": 10, "start": 279 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "b", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  },
+  {
+    "key": {
+      "loc": {
+        "file": { "key": "glean/lang/haskell/tests/code/B.hs" },
+        "span": { "length": 11, "start": 315 }
+      },
+      "name": {
+        "key": {
+          "mod": {
+            "key": { "name": { "key": "B" }, "unit": { "key": "main" } }
+          },
+          "occ": { "key": { "name": "r", "namespace_": 0 } },
+          "sort": { "external": { } }
+        }
+      }
+    }
+  }
+]

--- a/glean/lang/haskell/tests/code/hsType.out.9.4
+++ b/glean/lang/haskell/tests/code/hsType.out.9.4
@@ -156,53 +156,19 @@
               "kind": {
                 "key": {
                   "tyconapp": {
-                    "args_": [
-                      {
-                        "ty": {
-                          "key": {
-                            "tyconapp": {
-                              "args_": [ ],
-                              "tycon": {
-                                "key": {
-                                  "name": {
-                                    "key": {
-                                      "mod": {
-                                        "key": {
-                                          "name": { "key": "GHC.Types" },
-                                          "unit": { "key": "ghc-prim" }
-                                        }
-                                      },
-                                      "occ": {
-                                        "key": {
-                                          "name": "LiftedRep",
-                                          "namespace_": 3
-                                        }
-                                      },
-                                      "sort": { "external": { } }
-                                    }
-                                  },
-                                  "promoted": false,
-                                  "sort": { "normal": { } }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "visible": true
-                      }
-                    ],
+                    "args_": [ ],
                     "tycon": {
                       "key": {
                         "name": {
                           "key": {
                             "mod": {
                               "key": {
-                                "name": { "key": "GHC.Prim" },
+                                "name": { "key": "GHC.Types" },
                                 "unit": { "key": "ghc-prim" }
                               }
                             },
                             "occ": {
-                              "key": { "name": "TYPE", "namespace_": 3 }
+                              "key": { "name": "Type", "namespace_": 3 }
                             },
                             "sort": { "external": { } }
                           }
@@ -332,53 +298,19 @@
               "kind": {
                 "key": {
                   "tyconapp": {
-                    "args_": [
-                      {
-                        "ty": {
-                          "key": {
-                            "tyconapp": {
-                              "args_": [ ],
-                              "tycon": {
-                                "key": {
-                                  "name": {
-                                    "key": {
-                                      "mod": {
-                                        "key": {
-                                          "name": { "key": "GHC.Types" },
-                                          "unit": { "key": "ghc-prim" }
-                                        }
-                                      },
-                                      "occ": {
-                                        "key": {
-                                          "name": "LiftedRep",
-                                          "namespace_": 3
-                                        }
-                                      },
-                                      "sort": { "external": { } }
-                                    }
-                                  },
-                                  "promoted": false,
-                                  "sort": { "normal": { } }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "visible": true
-                      }
-                    ],
+                    "args_": [ ],
                     "tycon": {
                       "key": {
                         "name": {
                           "key": {
                             "mod": {
                               "key": {
-                                "name": { "key": "GHC.Prim" },
+                                "name": { "key": "GHC.Types" },
                                 "unit": { "key": "ghc-prim" }
                               }
                             },
                             "occ": {
-                              "key": { "name": "TYPE", "namespace_": 3 }
+                              "key": { "name": "Type", "namespace_": 3 }
                             },
                             "sort": { "external": { } }
                           }
@@ -513,53 +445,19 @@
               "kind": {
                 "key": {
                   "tyconapp": {
-                    "args_": [
-                      {
-                        "ty": {
-                          "key": {
-                            "tyconapp": {
-                              "args_": [ ],
-                              "tycon": {
-                                "key": {
-                                  "name": {
-                                    "key": {
-                                      "mod": {
-                                        "key": {
-                                          "name": { "key": "GHC.Types" },
-                                          "unit": { "key": "ghc-prim" }
-                                        }
-                                      },
-                                      "occ": {
-                                        "key": {
-                                          "name": "LiftedRep",
-                                          "namespace_": 3
-                                        }
-                                      },
-                                      "sort": { "external": { } }
-                                    }
-                                  },
-                                  "promoted": false,
-                                  "sort": { "normal": { } }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "visible": true
-                      }
-                    ],
+                    "args_": [ ],
                     "tycon": {
                       "key": {
                         "name": {
                           "key": {
                             "mod": {
                               "key": {
-                                "name": { "key": "GHC.Prim" },
+                                "name": { "key": "GHC.Types" },
                                 "unit": { "key": "ghc-prim" }
                               }
                             },
                             "occ": {
-                              "key": { "name": "TYPE", "namespace_": 3 }
+                              "key": { "name": "Type", "namespace_": 3 }
                             },
                             "sort": { "external": { } }
                           }

--- a/glean/lang/haskell/tests/code/hsType.out.9.6
+++ b/glean/lang/haskell/tests/code/hsType.out.9.6
@@ -156,53 +156,19 @@
               "kind": {
                 "key": {
                   "tyconapp": {
-                    "args_": [
-                      {
-                        "ty": {
-                          "key": {
-                            "tyconapp": {
-                              "args_": [ ],
-                              "tycon": {
-                                "key": {
-                                  "name": {
-                                    "key": {
-                                      "mod": {
-                                        "key": {
-                                          "name": { "key": "GHC.Types" },
-                                          "unit": { "key": "ghc-prim" }
-                                        }
-                                      },
-                                      "occ": {
-                                        "key": {
-                                          "name": "LiftedRep",
-                                          "namespace_": 3
-                                        }
-                                      },
-                                      "sort": { "external": { } }
-                                    }
-                                  },
-                                  "promoted": false,
-                                  "sort": { "normal": { } }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "visible": true
-                      }
-                    ],
+                    "args_": [ ],
                     "tycon": {
                       "key": {
                         "name": {
                           "key": {
                             "mod": {
                               "key": {
-                                "name": { "key": "GHC.Prim" },
+                                "name": { "key": "GHC.Types" },
                                 "unit": { "key": "ghc-prim" }
                               }
                             },
                             "occ": {
-                              "key": { "name": "TYPE", "namespace_": 3 }
+                              "key": { "name": "Type", "namespace_": 3 }
                             },
                             "sort": { "external": { } }
                           }
@@ -332,53 +298,19 @@
               "kind": {
                 "key": {
                   "tyconapp": {
-                    "args_": [
-                      {
-                        "ty": {
-                          "key": {
-                            "tyconapp": {
-                              "args_": [ ],
-                              "tycon": {
-                                "key": {
-                                  "name": {
-                                    "key": {
-                                      "mod": {
-                                        "key": {
-                                          "name": { "key": "GHC.Types" },
-                                          "unit": { "key": "ghc-prim" }
-                                        }
-                                      },
-                                      "occ": {
-                                        "key": {
-                                          "name": "LiftedRep",
-                                          "namespace_": 3
-                                        }
-                                      },
-                                      "sort": { "external": { } }
-                                    }
-                                  },
-                                  "promoted": false,
-                                  "sort": { "normal": { } }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "visible": true
-                      }
-                    ],
+                    "args_": [ ],
                     "tycon": {
                       "key": {
                         "name": {
                           "key": {
                             "mod": {
                               "key": {
-                                "name": { "key": "GHC.Prim" },
+                                "name": { "key": "GHC.Types" },
                                 "unit": { "key": "ghc-prim" }
                               }
                             },
                             "occ": {
-                              "key": { "name": "TYPE", "namespace_": 3 }
+                              "key": { "name": "Type", "namespace_": 3 }
                             },
                             "sort": { "external": { } }
                           }
@@ -495,7 +427,7 @@
                                     }
                                   },
                                   "occ": {
-                                    "key": { "name": "[]", "namespace_": 3 }
+                                    "key": { "name": "List", "namespace_": 3 }
                                   },
                                   "sort": { "external": { } }
                                 }
@@ -513,53 +445,19 @@
               "kind": {
                 "key": {
                   "tyconapp": {
-                    "args_": [
-                      {
-                        "ty": {
-                          "key": {
-                            "tyconapp": {
-                              "args_": [ ],
-                              "tycon": {
-                                "key": {
-                                  "name": {
-                                    "key": {
-                                      "mod": {
-                                        "key": {
-                                          "name": { "key": "GHC.Types" },
-                                          "unit": { "key": "ghc-prim" }
-                                        }
-                                      },
-                                      "occ": {
-                                        "key": {
-                                          "name": "LiftedRep",
-                                          "namespace_": 3
-                                        }
-                                      },
-                                      "sort": { "external": { } }
-                                    }
-                                  },
-                                  "promoted": false,
-                                  "sort": { "normal": { } }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "visible": true
-                      }
-                    ],
+                    "args_": [ ],
                     "tycon": {
                       "key": {
                         "name": {
                           "key": {
                             "mod": {
                               "key": {
-                                "name": { "key": "GHC.Prim" },
+                                "name": { "key": "GHC.Types" },
                                 "unit": { "key": "ghc-prim" }
                               }
                             },
                             "occ": {
-                              "key": { "name": "TYPE", "namespace_": 3 }
+                              "key": { "name": "Type", "namespace_": 3 }
                             },
                             "sort": { "external": { } }
                           }
@@ -949,7 +847,7 @@
                           "unit": { "key": "ghc-prim" }
                         }
                       },
-                      "occ": { "key": { "name": "[]", "namespace_": 3 } },
+                      "occ": { "key": { "name": "List", "namespace_": 3 } },
                       "sort": { "external": { } }
                     }
                   },

--- a/glean/lang/haskell/tests/code/hsType.query
+++ b/glean/lang/haskell/tests/code/hsType.query
@@ -1,7 +1,7 @@
 # Make sure all bindings have types. We can't compare the actual types
 # because some details differ between GHC versions.
-query:
-        N where
-          hs.ValBind { name = N, ty = nothing } |
-          hs.PatBind { name = N, ty = nothing }
+query: |
+        { N, T } where
+          hs.ValBind { name = N, ty = T } |
+          hs.PatBind { name = N, ty = T }
 transform: [normord, []]

--- a/glean/test/regression/Glean/Regression/Snapshot/Driver.hs
+++ b/glean/test/regression/Glean/Regression/Snapshot/Driver.hs
@@ -30,9 +30,24 @@ data Driver opts = Driver
   { driverIndexer :: Indexer opts
       -- ^ test data generator, for a given test group
   , driverGroups :: opts -> [Group]
-      -- ^ groups - Test will be executed once for each group, with
+      -- ^ groups - the Test will be executed once for each group, with
       -- 'testGroup' set appropriately. If empty, test will be
-      -- executed once with 'testGroup' set to "".
+      -- executed once with 'testGroup' set to "". The golden output
+      -- can be different for each group: the first group in the list
+      -- uses @.out@, the second and subsequent groups use @.out.group@
+      -- if the output differs from the contents of @.out@.
+  , driverOutSuffix :: Maybe String
+      -- ^ If set, the extension for golden outputs is
+      -- @.out.suffix[.group]@ instead of @.out[.group]@. This can be
+      -- used if the test needs different outputs depending on some
+      -- aspect of the environment such as the compiler/indexer
+      -- version.
+      --
+      -- NOTE: when a test uses `driverOutSuffix` and has multiple
+      -- output files, when regenerating the outputs with `--replace`
+      -- it will be necessary to run the test in all its different
+      -- ways to regenerate all the outputs.
+      --
   , driverTransforms :: Transforms
       -- ^ Additional query result transformers.
   , driverCreateDatabase :: CreateDatabase opts
@@ -58,6 +73,7 @@ driverFromIndexer :: Indexer opts -> Driver opts
 driverFromIndexer indexer = Driver
   { driverIndexer = indexer
   , driverGroups = const []
+  , driverOutSuffix = Nothing
   , driverTransforms = mempty
   , driverCreateDatabase = defaultCreateDatabase
   }


### PR DESCRIPTION
We had "groups" as a way to run a test multiple ways where the output files might differ, but that only works if you can run the test multiple ways without recompiling. For tests where the output depends on something in the environment, we need a way to manage multiple output files, so that's what this does.

Additionally I've used it in the Haskell indexer tests, where the GHC version affects the output.