### PR TITLE
Health check endpoint at /health

### DIFF
--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -230,6 +230,10 @@ library stubs
         tasty,
         tasty-hunit
 
+    if !flag(fbthrift)
+        other-modules: Facebook.Service.HttpFb303
+        build-depends: wai, http-types
+
 library logger
     import: fb-haskell, fb-cpp, deps
     visibility: private

--- a/glean/github/Facebook/Service.hs
+++ b/glean/github/Facebook/Service.hs
@@ -32,6 +32,7 @@ import Thrift.Processor
 import Thrift.Server.CppServer
 #else
 import Thrift.Server.HTTP
+import Facebook.Service.HttpFb303
 #endif
 
 -- | Runs a facebook service on a CPPServer
@@ -166,7 +167,12 @@ withBackgroundFacebookService_
   -> IO a
 withBackgroundFacebookService_ fb303 handler postProcess opts waitAction = do
   bracketFb303 fb303 Fb303_status_STARTING Fb303_status_STOPPED $ do
-    withBackgroundServer' handler postProcess opts waitAction
+#if FBTHRIFT
+    let opts' = opts
+#else
+    let opts' = opts { middleware = middleware opts . fb303Middleware fb303 }
+#endif
+    withBackgroundServer' handler postProcess opts' waitAction
 
 nilPostProcess :: a -> b -> [c]
 nilPostProcess _ _ = []

--- a/glean/github/Facebook/Service/HttpFb303.hs
+++ b/glean/github/Facebook/Service/HttpFb303.hs
@@ -1,0 +1,34 @@
+{-
+  Copyright (c) Meta Platforms, Inc. and affiliates.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+-}
+
+module Facebook.Service.HttpFb303 where
+
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (readIORef)
+import Network.HTTP.Types
+import Network.Wai
+
+import Facebook.Fb303
+import Fb303Core.Types
+
+-- | Middleware exposing Fb303 as a more standard health check endpoint at @/health@.
+fb303Middleware :: Fb303State -> Middleware
+fb303Middleware fb303 app req respond = do
+  case pathInfo req of
+    ["health"] -> do
+      status <- readIORef (fb303_status fb303)
+      let replyStatus = case status of
+            Fb303_status_ALIVE -> ok200
+            Fb303_status_WARNING -> mkStatus 290 "warning"
+            Fb303_status_STARTING -> mkStatus 291 "starting"
+            Fb303_status_STOPPING -> mkStatus 292 "stopping"
+            Fb303_status_STOPPED -> mkStatus 293 "stopped"
+            Fb303_status_DEAD -> mkStatus 294 "dead"
+            Fb303_status__UNKNOWN _ -> mkStatus 299 "unknown status"
+      respond $ responseLBS replyStatus [(hContentType, "text/plain")] (LBS.fromStrict $ statusMessage replyStatus)
+    _ -> app req respond


### PR DESCRIPTION
Problem: AWS ALB doesn't support health checking things except by status code (and nor does basically any other standard load balancer), and Glean only exports health checks as a Thrift service.

Solution: turn health checks into HTTP status with a middleware.

Requires: https://github.com/facebookincubator/hsthrift/pull/167