### PR TITLE
[flow] Default --write-root to "", not "test"

### DIFF
--- a/glean/lang/flow/Glean/Indexer/Flow.hs
+++ b/glean/lang/flow/Glean/Indexer/Flow.hs
@@ -27,7 +27,7 @@ options = do
     long "flow" <>
     value "flow" <>
     help "path to the flow binary"
-  flowWriteRoot <- strOption $ long "write-root" <> value "test"
+  flowWriteRoot <- strOption $ long "write-root" <> value ""
   flowIncludeDirectDeps <- switch (long "include-direct-deps")
   flowIncludeTransitiveDeps <- switch (long "include-transitive-deps")
   return Flow{..}

--- a/glean/website/docs/indexer/flow.md
+++ b/glean/website/docs/indexer/flow.md
@@ -30,15 +30,15 @@ where
 ## Run the indexer (manually)
 
 ```
-flow glean DIR --output-dir JSON --write-root PREFIX
+flow glean DIR --output-dir JSON [--write-root PREFIX]
 ```
 
 where
 
 * `DIR` is the root directory containing the JavaScript/Flow files
 * `JSON` is the directory in which to write the output `.json` files
-* `PREFIX` is a prefix to add to the files in the Glean index (this
-  can be empty if you don't need a prefix)
+* `PREFIX` is a prefix to add to the file paths in the Glean index (this
+  can be omitted if you don't need a prefix)
 
 The generated files can be ingested into a Glean database using [`glean create`](../cli.md#glean-create).
 


### PR DESCRIPTION
The default setting for `--write-root` isn't useful, and is likely to trip up everyone who tries to use this indexer.