### PR TITLE
Bump to 0.2.0.0 for a Hackage release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for glean
 
+## 0.2.0.0
+
+* Added `glean-lsp`, a multi-language LSP server based on Glean
+* Added a new Haskell indexer which consumes `.hie` files directly and
+  collects much richer data than the old indexer.
+
 ## 0.1.0.0 -- YYYY-mm-dd
 
 * First version. Released on an unsuspecting world.

--- a/glean.cabal.in
+++ b/glean.cabal.in
@@ -3,7 +3,7 @@ cabal-version:       3.6
 -- Copyright (c) Facebook, Inc. and its affiliates.
 
 name:                glean
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis: A system for collecting, deriving and working with facts
           about source code.
 homepage:            https://github.com/facebookincubator/Glean
@@ -1068,6 +1068,7 @@ executable disassemble
         glean:if-glean-hs,
         glean:lib,
         glean:util,
+        glean:angle,
 
 library test-unit
     import: fb-haskell, fb-cpp, deps

--- a/glean/lsp/glean-lsp.cabal
+++ b/glean/lsp/glean-lsp.cabal
@@ -86,7 +86,7 @@ executable glean-lsp
         unliftio-core ^>=0.2,
         unordered-containers >= 0.2.9.0 && < 0.3,
         optparse-applicative >= 0.17 && < 0.19,
-        glean:glass-lib,
+        glean:glass-lib >= 0.2 && < 0.3,
         glean:if-glass-hs,
         glean:util,
         fb-util,


### PR DESCRIPTION
includes #618, which was needed to fix the build from Hackage.