### PR TITLE
Fix glass-regression-flow test

### DIFF
--- a/glean/glass/test/regression/Glean/Glass/Regression/Flow/Main.hs
+++ b/glean/glass/test/regression/Glean/Glass/Regression/Flow/Main.hs
@@ -12,6 +12,6 @@ import System.Environment
 import qualified Glean.Glass.Regression.Flow as Glass
 
 main :: IO ()
-main = getArgs >>= \args -> withArgs (["--root", path] ++ args) Glass.main
+main = getArgs >>= \args -> withArgs (args ++["--root", path, "--write-root", "test"]) $ Glass.main
   where
     path = "glean/lang/codemarkup/tests/flow/cases/xrefs"


### PR DESCRIPTION
Removing the default `--write-root=test` in #623 broke this test, I tried to update the test to use an empty prefix but couldn't get it to work so I'm just adding `--write-root=test` to fix it for now.