### PR TITLE
bug fix, convert KB to Bytes

### DIFF
--- a/glean/db/Glean/Database/Storage/RocksDB.hs
+++ b/glean/db/Glean/Database/Storage/RocksDB.hs
@@ -70,7 +70,7 @@ data RocksDB = RocksDB
   , rocksCache :: Maybe Cache
   , rocksCacheIndexAndFilterBlocks :: Bool
   , rocksMaxDiskSize :: Maybe Int
-    -- ^ virtual limit to report capped disk capacities. The limit is
+    -- ^ virtual limit (bytes) to report capped disk capacities. The limit is
     -- not enforced. It's up to each io usage to check diskspace before writing.
     -- We're using this to avoid serving too many dbs on query servers,
     -- and smarter sharding.
@@ -82,14 +82,14 @@ newStorage root ServerConfig.Config{..} = do
     then
       Just <$> newCache (fromIntegral config_db_rocksdb_cache_mb * 1024 * 1024)
     else return Nothing
-  mem_capacity <- totalMemCapacity
+  mem_capacity <- totalMemCapacityKB
   return RocksDB
     { rocksRoot = root
     , rocksCache = cache
     , rocksCacheIndexAndFilterBlocks =
         config_db_rocksdb_cache_index_and_filter_blocks
     , rocksMaxDiskSize = case mem_capacity of
-        Just mem -> (* mem) . fromIntegral <$>
+        Just mem -> (* (mem * 1024)) . fromIntegral <$>
           config_db_rocksdb_disk_mem_capacity_ratio_limit
         Nothing -> Nothing
     }

--- a/glean/util/Glean/Impl/MemoryReader.hs
+++ b/glean/util/Glean/Impl/MemoryReader.hs
@@ -7,10 +7,10 @@
 -}
 
 module Glean.Impl.MemoryReader
-  (totalMemCapacity
+  (totalMemCapacityKB
   ) where
 
 -- template for open source build
 -- not implemented yet
-totalMemCapacity :: IO (Maybe Int)
-totalMemCapacity = return Nothing
+totalMemCapacityKB :: IO (Maybe Int)
+totalMemCapacityKB = return Nothing


### PR DESCRIPTION
Summary:
Forgot to do a KB -> Bytes conversion, so disk limit was 1000x less than expected :)  This is not in prod yet, the bug didn't affect prod and this fix won't either until we set this variable for glean.query.prod 

https://www.internalfb.com/code/configerator/[dc5e4b26185b5c8a2b17cb4f898e0872f7085882]/source/glean/server/glean.query.shadow.t3.cconf?lines=43-45
*note that the comment about 3.5TB is a bit leading, it's actually 4.2 TiB but our Shardmanager config is set to not use more than 85%*

Reviewed By: malanka

Differential Revision: D89123879


