### PR TITLE
Add ACL ownership augmentation and AND-slice semantics to C++ runtime; export setu32.h header (#704)

### DIFF
--- a/glean/rts/ownership/acl.cpp
+++ b/glean/rts/ownership/acl.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "glean/rts/ownership/acl.h"
+#include "glean/rts/timer.h"
+
+#include <folly/CppAttributes.h>
+#include <folly/container/F14Map.h>
+#include <set>
+
+namespace facebook {
+namespace glean {
+namespace rts {
+
+namespace {
+
+// Create an OR-set from a list of UsetIds and add it to the Usets container.
+Uset* FOLLY_NULLABLE makeOrSet(Usets& usets, const std::vector<UsetId>& ids) {
+  CHECK(!ids.empty());
+  if (ids.size() == 1) {
+    return usets.add(std::make_unique<Uset>(SetU32::from({ids[0]}), Or, 1));
+  }
+  std::set<UsetId> idSet(ids.begin(), ids.end());
+  auto entry = std::make_unique<Uset>(SetU32::from(idSet), Or, 1);
+  return usets.add(std::move(entry));
+}
+
+// Create an AND-set from a list of UsetIds and add it to the Usets container.
+Uset* FOLLY_NULLABLE makeAndSet(Usets& usets, const std::vector<UsetId>& ids) {
+  CHECK(!ids.empty());
+  if (ids.size() == 1) {
+    return usets.lookupById(ids[0]);
+  }
+  std::set<UsetId> idSet(ids.begin(), ids.end());
+  auto entry = std::make_unique<Uset>(SetU32::from(idSet), And, 1);
+  return usets.add(std::move(entry));
+}
+
+// Build UnitId → ACL CNF Uset mapping from assignments.
+// Each assignment's levels are converted to OR-sets and combined into a
+// CNF AND-set. All resulting Usets are promoted so they have IDs.
+folly::F14FastMap<UnitId, Uset*> buildUnitACLMap(
+    Usets& usets,
+    const std::vector<UnitACLAssignment>& assignments) {
+  folly::F14FastMap<UnitId, Uset*> unitACLMap;
+  unitACLMap.reserve(assignments.size());
+
+  for (const auto& assignment : assignments) {
+    if (assignment.levels.empty()) {
+      continue;
+    }
+
+    std::vector<UsetId> orSetIds;
+    orSetIds.reserve(assignment.levels.size());
+    for (const auto& levelGroups : assignment.levels) {
+      if (levelGroups.empty()) {
+        continue;
+      }
+      auto* orSet = CHECK_NOTNULL(makeOrSet(usets, levelGroups));
+      usets.promote(orSet);
+      orSetIds.push_back(orSet->id);
+    }
+
+    if (orSetIds.empty()) {
+      continue;
+    }
+
+    Uset* cnf = makeAndSet(usets, orSetIds);
+    unitACLMap[assignment.unitId] = cnf;
+  }
+
+  for (auto& [unitId, cnf] : unitACLMap) {
+    usets.promote(cnf);
+  }
+
+  return unitACLMap;
+}
+
+} // namespace
+
+void augmentOwnershipWithACL(
+    ComputedOwnership& ownership,
+    const std::vector<UnitACLAssignment>& assignments) {
+  if (assignments.empty()) {
+    return;
+  }
+
+  auto t = makeAutoTimer("augmentOwnershipWithACL");
+  auto& usets = ownership.sets_;
+  auto& facts = ownership.facts_;
+  const auto firstSetId = usets.getFirstId();
+
+  auto unitACLMap = buildUnitACLMap(usets, assignments);
+
+  if (unitACLMap.empty()) {
+    VLOG(1) << "augmentOwnershipWithACL: no unit ACL assignments, skipping";
+    return;
+  }
+
+  VLOG(1) << "augmentOwnershipWithACL: " << unitACLMap.size()
+          << " units with ACL assignments";
+
+  // facts_ is a vector of (Id, UsetId) interval boundaries.
+  size_t augmented = 0;
+
+  // Cache: memoize owner UsetId → augmented UsetId to avoid duplicate work.
+  folly::F14FastMap<UsetId, UsetId> augmentCache;
+
+  for (auto& [factId, ownerUsetId] : facts) {
+    if (ownerUsetId == INVALID_USET) {
+      continue;
+    }
+
+    auto cacheIt = augmentCache.find(ownerUsetId);
+    if (cacheIt != augmentCache.end()) {
+      if (cacheIt->second != ownerUsetId) {
+        ownerUsetId = cacheIt->second;
+        ++augmented;
+      }
+      continue;
+    }
+
+    UsetId originalOwner = ownerUsetId;
+
+    // Collect unique ACL CNF IDs for leaf UnitIds in this owner's set.
+    std::set<UsetId> aclCnfIds;
+
+    if (ownerUsetId < firstSetId) {
+      // ownerUsetId < firstSetId means one of two things:
+      //
+      // 1. A raw leaf UnitId — rare for a non-stacked DB since
+      //    computeOwnership promotes all owners to OR-sets (even
+      //    single-unit owners become length-1 OR-sets), but handled
+      //    defensively.
+      //
+      // 2. A promoted set from a base DB (stacked DB case) — the base
+      //    DB's UsetIds are below this ComputedOwnership's firstSetId.
+      //    This is safe to treat as a UnitId lookup because unitACLMap
+      //    only contains real leaf UnitIds, so a base-DB set ID will
+      //    simply not match, and the base DB already applied its own
+      //    ACL augmentation.
+      auto it = unitACLMap.find(ownerUsetId);
+      if (it != unitACLMap.end()) {
+        aclCnfIds.insert(it->second->id);
+      } else {
+        VLOG(1) << "augmentOwnershipWithACL: ownerUsetId " << ownerUsetId
+                << " < firstSetId " << firstSetId
+                << " has no ACL assignment — this fact will not have"
+                   " ACL constraints applied and will remain accessible"
+                   " based on original ownership alone (expected for"
+                   " units without ACL config or base-DB sets in a"
+                   " stacked DB where ACLs were already applied)";
+      }
+    } else {
+      // Promoted set — resolve and examine leaf members.
+      // After computeOwnership, sets are flat OR-sets of UnitIds
+      // (no nested set references), so checking immediate members
+      // is sufficient.
+      auto* ownerUset = usets.lookupById(ownerUsetId);
+      if (!ownerUset) {
+        // ownerUsetId >= firstSetId means it should be a promoted set in
+        // this ComputedOwnership's Usets container. Base-DB set IDs are
+        // < firstSetId (stacked IDs are always > base IDs) and would
+        // enter the if-branch above. A missing set here means we cannot
+        // determine which UnitIds this fact belongs to, so we cannot
+        // apply the correct ACL constraints — the fact would silently
+        // bypass ACL enforcement. Throw rather than continue with
+        // incorrect access control.
+        throw std::runtime_error(
+            "augmentOwnershipWithACL: UsetId " + std::to_string(ownerUsetId) +
+            " >= firstSetId " + std::to_string(firstSetId) +
+            " but not found in this ComputedOwnership's Usets."
+            " Cannot determine ACL constraints for this fact;"
+            " continuing would risk incorrect access control.");
+      }
+      ownerUset->exp.set.foreach([&](UsetId member) {
+        if (member < firstSetId) {
+          auto it = unitACLMap.find(member);
+          if (it != unitACLMap.end()) {
+            aclCnfIds.insert(it->second->id);
+          }
+        }
+      });
+    }
+
+    if (aclCnfIds.empty()) {
+      augmentCache[originalOwner] = originalOwner;
+      continue;
+    }
+
+    // Create AND(existingOwner, aclCnf1, aclCnf2, ...)
+    std::vector<UsetId> andMembers = {ownerUsetId};
+    andMembers.insert(andMembers.end(), aclCnfIds.begin(), aclCnfIds.end());
+    auto* andSet = CHECK_NOTNULL(makeAndSet(usets, andMembers));
+    usets.promote(andSet);
+
+    augmentCache[originalOwner] = andSet->id;
+    ownerUsetId = andSet->id;
+    ++augmented;
+  }
+
+  VLOG(1) << "augmentOwnershipWithACL: augmented " << augmented
+          << " fact intervals out of " << facts.size();
+  t.log("augmentOwnershipWithACL");
+}
+
+} // namespace rts
+} // namespace glean
+} // namespace facebook

--- a/glean/rts/ownership/acl.h
+++ b/glean/rts/ownership/acl.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "glean/rts/ownership.h"
+#include "glean/rts/ownership/uset.h"
+
+#include <string>
+#include <vector>
+
+namespace facebook {
+namespace glean {
+namespace rts {
+
+/// Entry mapping a directory to a list of ACL group UsetIds.
+/// All groups at the same directory level are ORed together.
+struct ACLConfigEntry {
+  std::string directory;
+  std::vector<UsetId> groupUsetIds;
+};
+
+/// Per-file ACL assignment: a UnitId (representing a single file path)
+//  and its matching ACL levels.
+/// Each inner vector represents groups at one directory level (ORed).
+/// The outer vector represents levels that are ANDed together.
+struct UnitACLAssignment {
+  UnitId unitId;
+  std::vector<std::vector<UsetId>> levels; // outer=AND, inner=OR
+};
+
+/// Augment computed ownership with ACL constraints.
+///
+/// For each UnitACLAssignment `a`:
+/// 1. Transform a.levels vec of vec into a proper boolean expression Uset using
+/// Set32 (outer vec -> AND, inner vec -> OR)
+/// 2. for each (fact, uset) in `ownership`, for each unit in uset, get the CNF
+/// for that unit from output of 1.,
+//  and AND those and the uset
+///
+/// @param ownership  The computed ownership (modified in-place)
+/// @param assignments  Per-unit ACL assignments (UnitId → levels of group IDs)
+void augmentOwnershipWithACL(
+    ComputedOwnership& ownership,
+    const std::vector<UnitACLAssignment>& assignments);
+
+} // namespace rts
+} // namespace glean
+} // namespace facebook

--- a/glean/rts/ownership/setu32.h
+++ b/glean/rts/ownership/setu32.h
@@ -470,6 +470,9 @@ class SetU32 {
   /// Append a new value which must be >= the largest value in the set
   void append(uint32_t value);
 
+  /// Append all blocks from [start, finish)
+  void append(const_iterator start, const_iterator finish);
+
   static SetU32 from(const std::set<uint32_t>& set) {
     SetU32 setu32;
     for (auto elt : set) {
@@ -477,18 +480,9 @@ class SetU32 {
     }
     return setu32;
   }
-
-  /**
-   * Merge two sets. If `right` is a subset of `left` or vice versa, returns a
-   * pointer to the superset. Otherwise, stores the result in `result` and
-   * returns a pointer to it.
-   */
-  static const SetU32*
-  merge(SetU32& result, const SetU32& left, const SetU32& right);
-
   template <typename F>
   void foreach(F&& f) const {
-    for (auto& block : *this) {
+    for (const auto& block : *this) {
       auto id = block.hdr.id() << 8;
       switch (block.hdr.type()) {
         case SetU32::Hdr::Sparse: {
@@ -527,14 +521,16 @@ class SetU32 {
   MutableEliasFanoList toEliasFano(uint32_t upper) const;
   static SetU32 fromEliasFano(const EliasFanoList& list);
 
+  /**
+   * Merge two sets. If `right` is a subset of `left` or vice versa, returns a
+   * pointer to the superset. Otherwise, stores the result in `result` and
+   * returns a pointer to it.
+   */
+  static const SetU32*
+  merge(SetU32& result, const SetU32& left, const SetU32& right);
+
   static void dump(SetU32&);
 
- private:
-  static bool fitsSparse(uint8_t m, uint8_t n) {
-    return int(m) + n < 32;
-  }
-
-  void append(const_iterator start, const_iterator finish);
   void append(uint32_t id, Bits256 w);
 
   void appendMerge(
@@ -543,6 +539,11 @@ class SetU32 {
       const_iterator right,
       const_iterator right_end);
   void appendMerge(Block left, Block right);
+
+ private:
+  static bool fitsSparse(uint8_t m, uint8_t n) {
+    return int(m) + n < 32;
+  }
 
   std::vector<Hdr> hdrs;
   std::vector<Bits256> dense;

--- a/glean/rts/ownership/slice.h
+++ b/glean/rts/ownership/slice.h
@@ -80,13 +80,19 @@ struct Slices {
     if (usetid == INVALID_USET) {
       return false;
     }
+    // AND semantics: when multiple slices cover the same UsetId (e.g.,
+    // an ownership slice and an ACL slice for the same layer), ALL
+    // covering slices must agree the UsetId is visible.
+    bool found = false;
     for (auto slice : slices_) {
       if (slice->inRange(usetid)) {
-        auto visible = slice->visible(usetid);
-        return visible;
+        found = true;
+        if (!slice->visible(usetid)) {
+          return false;
+        }
       }
     }
-    return false;
+    return found;
   }
 
   UsetId first() const {

--- a/glean/rts/ownership/tests/AclTest.cpp
+++ b/glean/rts/ownership/tests/AclTest.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <set>
+
+#include "glean/rts/ownership/acl.h"
+
+namespace facebook::glean::rts {
+
+namespace {
+
+// Helper: create a promoted OR-set of UnitIds in the given Usets container.
+Uset* makePromotedOrSet(Usets& usets, const std::set<UsetId>& members) {
+  auto* uset = new Uset(SetU32::from(members), Or, 1);
+  auto* added = usets.add(uset);
+  usets.promote(added);
+  return added;
+}
+
+// Helper: create a UnitACLAssignment concisely.
+// levels is outer=AND, inner=OR of group UsetIds.
+UnitACLAssignment makeAssignment(
+    UnitId unitId,
+    std::vector<std::vector<UsetId>> levels) {
+  return UnitACLAssignment{unitId, std::move(levels)};
+}
+
+// Helper: recursively render a Uset expression tree as a human-readable string.
+// Leaf IDs (below firstSetId) are printed as plain numbers.
+// Promoted sets expand as "AND(...)" or "OR(...)".
+std::string usetToString(const Usets& usets, UsetId id, UsetId firstSetId) {
+  if (id < firstSetId) {
+    return std::to_string(id);
+  }
+  auto* uset = usets.lookupById(id);
+  if (!uset) {
+    // Opaque reference (e.g., group UsetId not in this Usets container).
+    return std::to_string(id);
+  }
+  std::string result = (uset->exp.op == And) ? "AND(" : "OR(";
+  bool first = true;
+  uset->exp.set.foreach([&](uint32_t member) {
+    if (!first) {
+      result += ", ";
+    }
+    first = false;
+    result += usetToString(usets, member, firstSetId);
+  });
+  result += ")";
+  return result;
+}
+
+} // namespace
+
+// Verify that facts owned by a promoted set with matching UnitIds are
+// augmented with the expected AND(owner, aclCnf) structure.
+TEST(AclTest, BasicAugmentation) {
+  constexpr UsetId kFirstSetId = 10;
+  Usets usets(kFirstSetId);
+
+  // UnitIds 1 and 2 are leaf units.
+  auto* ownerSet = makePromotedOrSet(usets, {1, 2});
+
+  // facts_: one interval owned by ownerSet.
+  std::vector<std::pair<Id, UsetId>> facts = {
+      {Id::fromWord(100), ownerSet->id}};
+
+  ComputedOwnership ownership(std::move(usets), std::move(facts));
+
+  augmentOwnershipWithACL(ownership, {makeAssignment(1, {{50}})});
+
+  EXPECT_EQ(
+      usetToString(ownership.sets_, ownership.facts_[0].second, kFirstSetId),
+      "AND(OR(1, 2), OR(50))");
+}
+
+// Verify that facts whose owner has no matching ACL units are left unchanged.
+TEST(AclTest, NoMatchingACLLeavesOwnerUnchanged) {
+  constexpr UsetId kFirstSetId = 10;
+  Usets usets(kFirstSetId);
+
+  auto* ownerSet = makePromotedOrSet(usets, {1, 2});
+
+  std::vector<std::pair<Id, UsetId>> facts = {
+      {Id::fromWord(100), ownerSet->id}};
+
+  ComputedOwnership ownership(std::move(usets), std::move(facts));
+
+  // ACL assignment is for unit 99, which is NOT in the owner set.
+  augmentOwnershipWithACL(ownership, {makeAssignment(99, {{50}})});
+
+  EXPECT_EQ(ownership.facts_[0].second, ownerSet->id);
+  EXPECT_EQ(
+      usetToString(ownership.sets_, ownership.facts_[0].second, kFirstSetId),
+      "OR(1, 2)");
+}
+
+// Verify that empty assignments produce no changes.
+TEST(AclTest, EmptyAssignmentsNoOp) {
+  constexpr UsetId kFirstSetId = 10;
+  Usets usets(kFirstSetId);
+
+  auto* ownerSet = makePromotedOrSet(usets, {1});
+
+  std::vector<std::pair<Id, UsetId>> facts = {
+      {Id::fromWord(100), ownerSet->id}};
+
+  ComputedOwnership ownership(std::move(usets), std::move(facts));
+
+  augmentOwnershipWithACL(ownership, {});
+
+  EXPECT_EQ(ownership.facts_[0].second, ownerSet->id);
+  EXPECT_EQ(
+      usetToString(ownership.sets_, ownership.facts_[0].second, kFirstSetId),
+      "OR(1)");
+}
+
+// Stacked DB scenario: a fact's ownerUsetId is below the stacked DB's
+// firstSetId because it refers to a promoted set from the base DB.
+//
+// In the stacked DB, firstSetId is higher than any base-DB set ID. So
+// base-DB set IDs fall into the (ownerUsetId < firstSetId) branch,
+// which treats them as leaf UnitId lookups in unitACLMap. Since
+// unitACLMap only contains real leaf UnitIds (not base-DB set IDs),
+// the lookup correctly misses and no ACL is applied — the base DB
+// already handled ACL augmentation for those sets.
+TEST(AclTest, StackedDB_BaseSetIdBelowFirstSetId) {
+  // Simulate a stacked DB whose Usets start at ID 1000.
+  // The base DB used set IDs in the range [10, 999].
+  constexpr UsetId kStackedFirstSetId = 1000;
+  Usets stackedUsets(kStackedFirstSetId);
+
+  // Create a promoted set in the stacked layer (ID >= 1000).
+  auto* stackedOwner = makePromotedOrSet(stackedUsets, {1, 2});
+  ASSERT_GE(stackedOwner->id, kStackedFirstSetId);
+
+  // A base-DB set ID that falls below the stacked firstSetId.
+  // This is NOT a real leaf UnitId — it's a promoted set from the base.
+  constexpr UsetId kBaseDbSetId = 500;
+  ASSERT_LT(kBaseDbSetId, kStackedFirstSetId);
+
+  // facts_: two intervals — one owned by a base-DB set (should be skipped
+  // because unitACLMap won't match a set ID), one owned by a stacked set
+  // (should be augmented).
+  std::vector<std::pair<Id, UsetId>> facts = {
+      {Id::fromWord(50), kBaseDbSetId},
+      {Id::fromWord(200), stackedOwner->id},
+  };
+
+  ComputedOwnership ownership(std::move(stackedUsets), std::move(facts));
+
+  augmentOwnershipWithACL(ownership, {makeAssignment(1, {{50}})});
+
+  // Fact 0 (base-DB set owner): unchanged. The code enters the
+  // (ownerUsetId < firstSetId) branch and does unitACLMap.find(500),
+  // which correctly misses — the base DB already applied ACLs.
+  EXPECT_EQ(ownership.facts_[0].second, kBaseDbSetId);
+
+  // Fact 1 (stacked owner containing unit 1): should be augmented.
+  EXPECT_EQ(
+      usetToString(
+          ownership.sets_, ownership.facts_[1].second, kStackedFirstSetId),
+      "AND(OR(1, 2), OR(50))");
+}
+
+// Verify that INVALID_USET owners are skipped entirely.
+TEST(AclTest, InvalidUsetSkipped) {
+  constexpr UsetId kFirstSetId = 10;
+  Usets usets(kFirstSetId);
+
+  std::vector<std::pair<Id, UsetId>> facts = {
+      {Id::fromWord(100), INVALID_USET}};
+
+  ComputedOwnership ownership(std::move(usets), std::move(facts));
+
+  augmentOwnershipWithACL(ownership, {makeAssignment(1, {{50}})});
+
+  EXPECT_EQ(ownership.facts_[0].second, INVALID_USET);
+}
+
+} // namespace facebook::glean::rts

--- a/glean/rts/ownership/uset.h
+++ b/glean/rts/ownership/uset.h
@@ -137,6 +137,7 @@ struct Usets {
 
   Usets(Usets&& other) noexcept : firstId(other.firstId), nextId(other.nextId) {
     std::swap(usets, other.usets);
+    std::swap(idIndex_, other.idIndex_);
     stats = other.stats;
   }
   Usets(const Usets&) = delete;
@@ -273,7 +274,15 @@ struct Usets {
       // Bump the ref count so it outlives any transient users
       ++uset->refs;
       ++stats.promoted;
+      idIndex_.push_back(uset);
     }
+  }
+
+  Uset* FOLLY_NULLABLE lookupById(UsetId id) const {
+    if (id < firstId || id >= firstId + idIndex_.size()) {
+      return nullptr;
+    }
+    return idIndex_[id - firstId];
   }
 
   size_t size() const {
@@ -316,6 +325,9 @@ struct Usets {
     });
     other.usets
         .clear(); // ownership of the underlying sets has been transferred
+    idIndex_.insert(
+        idIndex_.end(), other.idIndex_.begin(), other.idIndex_.end());
+    other.idIndex_.clear();
     nextId = other.nextId;
   }
 
@@ -328,6 +340,7 @@ struct Usets {
 
  private:
   folly::F14FastSet<Uset*, Uset::Hash, Uset::Eq> usets;
+  std::vector<Uset*> idIndex_;
   Stats stats;
   const UsetId firstId;
   UsetId nextId;

--- a/glean/rts/serialize.h
+++ b/glean/rts/serialize.h
@@ -210,9 +210,11 @@ using Nat = int64_t;
 using Binary = folly::ByteRange;
 using String = std::string;
 using List = std::vector<Nat>; // TODO: generalise
+using StringList = std::vector<String>;
 using Map = std::map<String, List>; // TODO: generalise
+using StringMap = std::map<String, StringList>;
 
-using Field = std::variant<Nat, Binary, Map, String>;
+using Field = std::variant<Nat, Binary, Map, String, StringMap>;
 using Object = std::vector<std::pair<uint32_t, Field>>;
 
 enum Type : uint32_t {
@@ -235,6 +237,10 @@ Type typeOf<String>() {
 }
 template <>
 Type typeOf<std::vector<Nat>>() {
+  return ListTy;
+}
+template <>
+Type typeOf<std::vector<String>>() {
   return ListTy;
 }
 
@@ -298,9 +304,15 @@ inline void put(binary::Output& out, const Object& obj) {
     } else if (std::holds_alternative<Binary>(val)) {
       field(BinaryTy, num);
       put(out, std::get<Binary>(val));
+    } else if (std::holds_alternative<String>(val)) {
+      field(StringTy, num);
+      put(out, std::get<String>(val));
     } else if (std::holds_alternative<Map>(val)) {
       field(MapTy, num);
       put(out, std::get<Map>(val));
+    } else if (std::holds_alternative<StringMap>(val)) {
+      field(MapTy, num);
+      put(out, std::get<StringMap>(val));
     }
   }
   out.fixed(uint8_t(0)); // object terminator


### PR DESCRIPTION
Summary:

# What has changed
Core C++ runtime changes to support ACL enforcement via the ownership infrastructure:
1. New `acl.h/acl.cpp` with `augmentOwnershipWithACL()` — walks computed ownership
   facts and ANDs each fact's existing owner Uset with a CNF Uset built from the
   unit's ACL group assignments (OR within levels, AND across levels).
2. `slice.h` visibility semantics changed from first-match-returns to AND-all:
   when multiple slices cover the same UsetId, ALL must agree the fact is visible.
3. `setu32.h` moves `append(const_iterator, const_iterator)` from private to public,
   adds `from(std::set<uint32_t>)` factory, and changes `foreach` iterator to const.
4. `serialize.h` adds StringList, StringMap variant types to support the new thrift
   acl_config map<string, list<string>> serialization.

# Why the change?
The ownership system already tracks which units own which facts via Usets. ACL
enforcement piggybacks on this: each unit gets an ACL CNF constraint (AND of OR-groups),
which is ANDed with the unit's existing ownership. At query time, the user's groups
form a slice, and the AND-slice semantics ensure a fact is only visible if BOTH
the ownership slice AND the ACL slice agree. This avoids a separate ACL-filtering
pass and reuses the existing ownership visibility infrastructure.

# Most important changes
- `acl.cpp:56-187` - `augmentOwnershipWithACL()` implementation: builds UnitId→CNF map,
  resolves promoted Usets to leaf UnitIds, walks facts with memoization cache
- `acl.cpp:24-47` - `makeOrSet`/`makeAndSet` helpers for CNF construction
- `acl.h:23-51` - New ACLConfigEntry, UnitACLAssignment structs
- `slice.h:83-97` - **CRITICAL**: Changed from first-match return to AND-all semantics.
  Old code returned immediately on first slice match; new code requires ALL covering
  slices to return visible=true. Non-overlapping slices behave identically to before.
- `setu32.h:474` - `append(const_iterator, const_iterator)` moved to public interface
- `serialize.h:213-214` - New StringList/StringMap types added to Field variant
- `serialize.h:307-315` - String and StringMap serialization branches added

Reviewed By: CatherineGasnier

Differential Revision: D97111684


