### PR TITLE
Fix OSS build after Docusaurus 3 upgrade

### DIFF
--- a/glean/website/docusaurus.config.js
+++ b/glean/website/docusaurus.config.js
@@ -9,6 +9,8 @@
  */
 
 const {fbContent} = require('internaldocs-fb-helpers');
+const {isInternal} = require('docusaurus-plugin-internaldocs-fb/internal');
+const stripFbImports = require('./src/remark/stripFbImports');
 
 module.exports = {
   title: 'Glean',
@@ -109,6 +111,9 @@ module.exports = {
         docs: {
           path: './docs',
           sidebarPath: require.resolve('./sidebars.js'),
+          beforeDefaultRemarkPlugins: [
+            ...(!isInternal() ? [stripFbImports] : []),
+          ],
           editUrl: fbContent({
             internal:
               'https://www.internalfb.com/intern/diffusion/FBS/browse/master/fbcode/glean/website/',

--- a/glean/website/src/remark/stripFbImports.js
+++ b/glean/website/src/remark/stripFbImports.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const fbPath = /\/(.*\/)?fb\//;
+
+function stripFbImports() {
+  return (tree) => {
+    const stripped = new Set();
+    const newChildren = [];
+
+    for (const node of tree.children) {
+      if (node.type !== 'mdxjsEsm' || !node.data?.estree?.body) {
+        newChildren.push(node);
+        continue;
+      }
+
+      const keptStatements = [];
+      const removedSpecifiers = [];
+
+      for (const stmt of node.data.estree.body) {
+        if (
+          stmt.type === 'ImportDeclaration' &&
+          fbPath.test(stmt.source.value)
+        ) {
+          for (const sp of stmt.specifiers ?? [])
+            removedSpecifiers.push(sp.local.name);
+        } else {
+          keptStatements.push(stmt);
+        }
+      }
+
+      for (const name of removedSpecifiers) stripped.add(name);
+
+      if (keptStatements.length === 0) continue;
+
+      if (keptStatements.length === node.data.estree.body.length) {
+        newChildren.push(node);
+      } else {
+        const keptLines = node.value
+          .split('\n')
+          .filter((line) => !fbPath.test(line));
+        newChildren.push({
+          ...node,
+          value: keptLines.join('\n'),
+          data: {
+            ...node.data,
+            estree: { ...node.data.estree, body: keptStatements },
+          },
+        });
+      }
+    }
+
+    tree.children = newChildren;
+    if (stripped.size > 0) stripJsx(tree, stripped);
+  };
+}
+
+function stripJsx(node, names) {
+  if (!node.children) return;
+  node.children = node.children.filter((c) => {
+    if (c.type.startsWith('mdxJsx') && names.has(c.name)) return false;
+    stripJsx(c, names);
+    return true;
+  });
+}
+
+module.exports = stripFbImports;


### PR DESCRIPTION
Summary:
The Docusaurus 2→3 upgrade (D98898843) broke the GitHub CI website build. The bundled remark-mdx-filter-imports plugin visits import AST nodes (MDX v1/v2), but Docusaurus 3 uses MDX v3 where imports are mdxjsEsm nodes instead — so the filter never ran, and webpack failed trying to resolve internal fb/*.md files.

Added a custom remark plugin (stripFbImports) that handles mdxjsEsm nodes correctly. It parses individual import statements within each node and only removes the ones matching 
fb
 paths, preserving other imports (like SrcFileLink, OssOnly) that MDX v3 may bundle into the same node. JSX elements referencing the removed imports are also stripped. Only active in OSS builds.

Differential Revision: D101358870


