### PR TITLE
Add CodeQL workflow to fix Analyze (java-kotlin) CI failure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+# CodeQL analysis workflow for Glean
+#
+# This replaces the GitHub org-level CodeQL default setup for java-kotlin,
+# which fails because the Java/Kotlin code in this repo uses Buck and cannot
+# be auto-built by CodeQL's autobuild.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: java-kotlin
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Summary:
The "Analyze (java-kotlin)" GitHub Actions check was failing because GitHub's organization-level CodeQL default setup uses autobuild for Java/Kotlin analysis. The Glean repo's Java/Kotlin code (indexer code, test cases) uses Buck as its build system and cannot be compiled by CodeQL's autobuild, causing the analysis to consistently fail.

The thrift/Haskell changes in D94378719 did not cause this failure - it is a pre-existing issue with the CodeQL default setup configuration that was correlated with D94378719 by timing.

This diff adds a custom CodeQL workflow that:
- Explicitly configures java-kotlin analysis with `build-mode: none`, which performs source-only analysis without requiring compilation
- Replaces the failing org-level CodeQL default setup for java-kotlin
- Follows the same pattern used by other Meta open source repos (pytorch/text, ttpforge) to customize CodeQL analysis

The workflow file is placed at `.github/workflows/codeql.yml` in the ShipIt-exported GitHub repo structure (`fbcode/glean/github/tld/`).

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=cbf8a985-5c99-403a-80c3-8f678e2cfa4f)

Differential Revision: D96743566


