### PR TITLE
Add ACL config support to C++ client library (#724)

### DIFF
--- a/glean/cpp/filewriter.cpp
+++ b/glean/cpp/filewriter.cpp
@@ -35,15 +35,25 @@ class FileWriter : public Sender {
     binary::Output out;
     // Serialize as facebook::glean::thrift::Batch without using fbthrift. These
     // field numbers and types must match those in glean.thrift.
-    serialize::thriftcompact::put(
-        out,
-        {
-            {1, r.first.toThrift()},
-            {2, static_cast<int64_t>(r.count)},
-            {3, folly::ByteRange(r.facts.data(), r.facts.size())},
-            {5, batch.serializeOwnership()},
-            {7, batch.getSchemaId()},
-        });
+    serialize::thriftcompact::Object fields = {
+        {1, r.first.toThrift()},
+        {2, static_cast<int64_t>(r.count)},
+        {3, folly::ByteRange(r.facts.data(), r.facts.size())},
+        {5, batch.serializeOwnership()},
+        {7, batch.getSchemaId()},
+    };
+
+    // Add ACL config fields if present
+    const auto& aclConfig = batch.getACLConfig();
+    if (!aclConfig.empty()) {
+      // Field 9: acl_config - map<string, list<string>>
+      fields.emplace_back(
+          9,
+          serialize::thriftcompact::StringMap(
+              aclConfig.begin(), aclConfig.end()));
+    }
+
+    serialize::thriftcompact::put(out, fields);
     folly::writeFile(folly::ByteRange(out.data(), out.size()), path.c_str());
   }
 

--- a/glean/cpp/glean.cpp
+++ b/glean/cpp/glean.cpp
@@ -224,6 +224,7 @@ std::pair<rts::closed_interval_set<Id>, rts::FactSet> minimalOwnership(
 void BatchBase::endUnit() {
   if (current) {
     current->finish = buffer.firstFreeId();
+
     if (current->finish > current->start) {
       auto p = minimalOwnership(
           inventory->inventory,
@@ -251,6 +252,16 @@ Id BatchBase::define(Pid ty, rts::Fact::Clause clause) {
 void BatchBase::logEnd() const {
   LOG(INFO) << "saw " << seen_units << " units, serialized "
             << total_serialized_units;
+}
+
+void BatchBase::setACLConfig(
+    std::unordered_map<std::string, std::vector<std::string>> config) {
+  aclConfig_ = std::move(config);
+}
+
+const std::unordered_map<std::string, std::vector<std::string>>&
+BatchBase::getACLConfig() const {
+  return aclConfig_;
 }
 
 } // namespace cpp

--- a/glean/cpp/glean.h
+++ b/glean/cpp/glean.h
@@ -482,6 +482,12 @@ class BatchBase {
   std::map<std::string, std::vector<int64_t>> serializeOwnership() const;
   void clearOwnership();
 
+  // ACL config support (path -> list of ACL group ID strings)
+  void setACLConfig(
+      std::unordered_map<std::string, std::vector<std::string>> config);
+  const std::unordered_map<std::string, std::vector<std::string>>&
+  getACLConfig() const;
+
   FactStats bufferStats() const {
     return FactStats{buffer.factMemory(), buffer.size()};
   }
@@ -531,6 +537,9 @@ class BatchBase {
   mutable size_t last_serialized_units = 0;
   mutable size_t total_serialized_units = 0;
   std::set<std::string> unique_units;
+
+  // ACL config support (path -> list of ACL group ID strings)
+  std::unordered_map<std::string, std::vector<std::string>> aclConfig_;
 };
 
 /// A typed instantiation of an Inventory for a particular Schema.
@@ -654,8 +663,10 @@ class Batch : private BatchBase {
   using BatchBase::CacheStats;
   using BatchBase::cacheStats;
   using BatchBase::endUnit;
+  using BatchBase::getACLConfig;
   using BatchBase::logEnd;
   using BatchBase::rebase;
+  using BatchBase::setACLConfig;
 };
 
 } // namespace cpp

--- a/glean/hs/Glean/RTS/Foreign/Ownership.hsc
+++ b/glean/hs/Glean/RTS/Foreign/Ownership.hsc
@@ -14,6 +14,8 @@ module Glean.RTS.Foreign.Ownership
   , firstUsetId
   , Ownership
   , ComputedOwnership
+  , computedOwnershipUnitCount
+  , augmentWithACL
   , Slice
   , slice
   , slicedStack
@@ -88,7 +90,7 @@ newtype UnitId = UnitId Word32
 
 -- | Id of an ownership set
 newtype UsetId = UsetId Word32
-  deriving (Storable)
+  deriving (Storable, Show)
 
 firstUsetId :: UsetId
 firstUsetId = UsetId 0
@@ -367,6 +369,52 @@ unionOwnership =
       HashMap.empty
 
 -- -----------------------------------------------------------------------------
+-- ACL ownership augmentation
+
+computedOwnershipUnitCount :: ComputedOwnership -> IO Word32
+--- get the first UsetID of an AND-OR expr.
+--- All Usets with IDs lower than that are leaf units
+--- (concrete, single file paths)
+--- UnitIds below count represent
+--- e.g. UnitId 0  →  "fbcode/glean/rts/query.cpp"
+--- assume count is 5 then UsetId 5  →  OR(0, 2)
+--- which is a derived fact owned by both query.cpp and another file
+computedOwnershipUnitCount own =
+  with own $ \own_ptr ->
+    invoke $ glean_computed_ownership_unit_count own_ptr
+
+-- | Augment computed ownership with ACL constraints.
+-- Each unit in the assignments list has a list of ACL levels.
+-- Each level has a list of ACL group UsetIds (ORed together).
+-- Levels are ANDed together to form CNF.
+-- The resulting CNF is ANDed with each fact's existing owner.
+augmentWithACL
+  :: ComputedOwnership
+  -> [(Word32, [[Word32]])]  -- ^ (UnitId, [[group_UsetIds_per_level]])
+  -> IO ()
+augmentWithACL _ [] = return ()
+augmentWithACL own assignments =
+  with own $ \own_ptr -> do
+    let numUnits = length assignments
+        unitIds = map fst assignments
+        levelLists = map snd assignments
+        levelCounts = map (fromIntegral . length) levelLists :: [CSize]
+        allLevels = concatMap id levelLists
+        groupCounts = map (fromIntegral . length) allLevels :: [CSize]
+        allGroups = concatMap (map fromIntegral) allLevels :: [Word32]
+    withArray (map fromIntegral unitIds :: [Word32]) $ \p_unitIds ->
+      withArray levelCounts $ \p_levelCounts ->
+      withArray groupCounts $ \p_groupCounts ->
+      withArray allGroups $ \p_groupIds ->
+        invoke $ glean_augment_ownership_with_acl
+          own_ptr
+          p_unitIds
+          p_levelCounts
+          (fromIntegral numUnits)
+          p_groupCounts
+          p_groupIds
+
+-- -----------------------------------------------------------------------------
 -- FFI
 
 foreign import ccall safe glean_get_ownership_stats
@@ -479,8 +527,8 @@ foreign import ccall unsafe glean_make_sliced_stack
   -> Ptr (Ptr Lookup)
   -> IO CString
 
-foreign import ccall unsafe
-   glean_sliced_stack_free :: Ptr Lookup -> IO ()
+foreign import ccall unsafe glean_sliced_stack_free
+  :: Ptr Lookup -> IO ()
 
 foreign import ccall unsafe
    glean_ownership_next_set_id :: Ptr Ownership -> Ptr UsetId -> IO CString
@@ -508,3 +556,15 @@ setOwnershipMergeCacheSize = glean_set_ownership_merge_cache_size
 
 getOwnershipMergeCacheSize :: IO Word64
 getOwnershipMergeCacheSize = glean_get_ownership_merge_cache_size
+
+foreign import ccall unsafe glean_computed_ownership_unit_count
+  :: Ptr ComputedOwnership -> Ptr Word32 -> IO CString
+
+foreign import ccall safe glean_augment_ownership_with_acl
+  :: Ptr ComputedOwnership
+  -> Ptr Word32   -- unit_ids
+  -> Ptr CSize    -- level_counts
+  -> CSize        -- num_units
+  -> Ptr CSize    -- group_counts
+  -> Ptr Word32   -- group_ids
+  -> IO CString

--- a/glean/rocksdb/container-impl.cpp
+++ b/glean/rocksdb/container-impl.cpp
@@ -101,6 +101,8 @@ const Family Family::batchDescriptors(
     [](auto& opts) { opts.OptimizeForPointLookup(10); },
     false);
 
+// Stores locations of fact batches
+
 #ifndef GLEAN_FACEBOOK
 namespace {
 rocksdb::Status openRocksDB(

--- a/glean/rts/acl/acl_provider.cpp
+++ b/glean/rts/acl/acl_provider.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "glean/rts/acl/acl_provider.h"
+
+#include <glog/logging.h>
+
+#include "glean/rts/acl/json_acl_provider.h"
+
+namespace facebook {
+namespace glean {
+namespace rts {
+namespace acl {
+
+std::unique_ptr<ACLProvider> createJsonACLProvider(
+    const std::string& jsonPath,
+    bool permissive) {
+  VLOG(1) << "Creating JsonACLProvider from " << jsonPath
+          << (permissive ? " (permissive mode)" : " (inherited mode)");
+  return std::make_unique<JsonACLProvider>(jsonPath, permissive);
+}
+
+} // namespace acl
+} // namespace rts
+} // namespace glean
+} // namespace facebook

--- a/glean/rts/acl/acl_provider.h
+++ b/glean/rts/acl/acl_provider.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace facebook {
+namespace glean {
+namespace rts {
+namespace acl {
+
+/**
+ * ACLProvider is the interface for looking up ACL groups for a file path.
+ */
+class ACLProvider {
+ public:
+  virtual ~ACLProvider() = default;
+
+  /**
+   * Get the list of ACL group IDs for a given directory path.
+   *
+   * @param dirPath The directory path (relative to repo root, without leading
+   * /)
+   * @return Vector of group IDs that have access to files in this directory.
+   * This has OR semantic, i.e. either ACL is needed to access.
+   * Returns empty vector if no specific ACL is defined (treated as public)
+   */
+  virtual std::vector<int> getACLs(const std::string& dirPath) const = 0;
+};
+
+/**
+ * Factory function to create an ACLProvider from a JSON file.
+ *
+ * @param jsonPath Path to the JSON file containing ACL mappings
+ * @param permissive If true, only exact directory matches apply;
+ *                   if false (default), sub-directories inherit parent ACLs
+ * @return A unique_ptr to the created JsonACLProvider
+ * @throws std::runtime_error if the file cannot be read or parsed
+ */
+std::unique_ptr<ACLProvider> createJsonACLProvider(
+    const std::string& jsonPath,
+    bool permissive = false);
+
+} // namespace acl
+} // namespace rts
+} // namespace glean
+} // namespace facebook

--- a/glean/rts/acl/json_acl_provider.cpp
+++ b/glean/rts/acl/json_acl_provider.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "glean/rts/acl/json_acl_provider.h"
+
+#include <folly/FileUtil.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <glog/logging.h>
+
+namespace facebook {
+namespace glean {
+namespace rts {
+namespace acl {
+
+JsonACLProvider::JsonACLProvider(const std::string& jsonPath, bool permissive)
+    : permissive_(permissive) {
+  loadFromFile(jsonPath);
+  LOG(INFO) << "JsonACLProvider: loaded " << aclMap_.size() << " entries from "
+            << jsonPath
+            << (permissive_ ? " (permissive mode)" : " (inherited mode)");
+}
+
+void JsonACLProvider::loadFromFile(const std::string& jsonPath) {
+  std::string contents;
+  if (!folly::readFile(jsonPath.c_str(), contents)) {
+    throw std::runtime_error(
+        "JsonACLProvider: failed to read file: " + jsonPath);
+  }
+
+  folly::dynamic json;
+  try {
+    json = folly::parseJson(contents);
+  } catch (const std::exception& e) {
+    throw std::runtime_error(
+        "JsonACLProvider: failed to parse JSON from " + jsonPath + ": " +
+        e.what());
+  }
+
+  if (!json.isObject()) {
+    throw std::runtime_error(
+        "JsonACLProvider: expected JSON object at top level in " + jsonPath);
+  }
+
+  loadNewFormat(json);
+}
+
+void JsonACLProvider::loadNewFormat(const folly::dynamic& json) {
+  // Parse "acls" section: {dir_path: int}
+  auto* aclsPtr = json.get_ptr("acls");
+  if (!aclsPtr || !aclsPtr->isObject()) {
+    throw std::runtime_error(
+        "JsonACLProvider: new format missing 'acls' object");
+  }
+
+  for (const auto& kv : aclsPtr->items()) {
+    const auto& dirPath = kv.first.asString();
+    const auto& value = kv.second;
+
+    if (!value.isInt()) {
+      LOG(WARNING) << "JsonACLProvider: expected integer value for path: "
+                   << dirPath;
+      continue;
+    }
+
+    auto rawId = value.asInt();
+    if (rawId < 0 || rawId > 253) {
+      LOG(WARNING) << "JsonACLProvider: group ID " << rawId
+                   << " out of range [0, 253] for path: " << dirPath;
+      continue;
+    }
+
+    int groupId = static_cast<int>(rawId);
+    std::string normalizedPath = normalizeDirPath(dirPath);
+    aclMap_[normalizedPath] = {groupId};
+
+    VLOG(2) << "JsonACLProvider: loaded ACL for " << normalizedPath
+            << ": group " << groupId;
+  }
+}
+
+std::vector<int> JsonACLProvider::getACLs(const std::string& dirPath) const {
+  std::string normalizedPath = normalizeDirPath(dirPath);
+
+  // First, check for an exact match
+  auto it = aclMap_.find(normalizedPath);
+  if (it != aclMap_.end()) {
+    VLOG(2) << "JsonACLProvider: exact match for " << normalizedPath;
+    return it->second;
+  }
+
+  // In permissive mode, only exact matches apply
+  if (permissive_) {
+    VLOG(2) << "JsonACLProvider: no exact match for " << normalizedPath
+            << " (permissive mode, returning ALL_GROUPS)";
+    return {};
+  }
+
+  // In default mode, walk from leaf to root looking for nearest parent with
+  // an ACL entry. This is O(depth) hash lookups, which is efficient given the
+  // sparse ACL map and typical directory depths of 3-6 levels.
+  return findWithInheritance(normalizedPath);
+}
+
+std::vector<int> JsonACLProvider::findWithInheritance(
+    const std::string& dirPath) const {
+  std::string current = dirPath;
+
+  while (!current.empty()) {
+    current = getParentDir(current);
+    if (current.empty()) {
+      break;
+    }
+
+    auto it = aclMap_.find(current);
+    if (it != aclMap_.end()) {
+      VLOG(2) << "JsonACLProvider: inherited ACLs from " << current << " for "
+              << dirPath;
+      return it->second;
+    }
+  }
+
+  VLOG(2) << "JsonACLProvider: no ACLs found for " << dirPath
+          << " (returning ALL_GROUPS)";
+  return {};
+}
+
+std::string JsonACLProvider::normalizeDirPath(const std::string& path) {
+  if (path.empty()) {
+    return "";
+  }
+
+  std::string result = path;
+
+  // Remove trailing slashes
+  while (!result.empty() && result.back() == '/') {
+    result.pop_back();
+  }
+
+  // Remove leading slashes
+  while (!result.empty() && result.front() == '/') {
+    result.erase(0, 1);
+  }
+
+  return result;
+}
+
+std::string JsonACLProvider::getParentDir(const std::string& path) {
+  if (path.empty()) {
+    return "";
+  }
+
+  auto pos = path.rfind('/');
+  if (pos == std::string::npos) {
+    return "";
+  }
+
+  return path.substr(0, pos);
+}
+
+} // namespace acl
+} // namespace rts
+} // namespace glean
+} // namespace facebook

--- a/glean/rts/acl/json_acl_provider.h
+++ b/glean/rts/acl/json_acl_provider.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "glean/rts/acl/acl_provider.h"
+
+namespace folly {
+struct dynamic;
+} // namespace folly
+
+namespace facebook {
+namespace glean {
+namespace rts {
+namespace acl {
+
+/**
+ * JsonACLProvider reads ACL group mappings from a JSON file.
+ *
+ * Expected JSON format:
+ * {
+ *   "acls": {
+ *     "dirpath": 1,
+ *     "another/path": 2
+ *   }
+ * }
+ *
+ * The "acls" section maps directory paths to integer group IDs.
+ *
+ * By default, sub-directories inherit ACL groups from their parent directories.
+ * For example, if "foo" has group 1, then "foo/bar" and "foo/bar/baz"
+ * will also return [1] unless they have their own explicit entry.
+ *
+ * If permissive mode is enabled, only exactly specified directories get their
+ * groups applied; sub-directories without explicit entries return empty
+ * (ALL_GROUPS - accessible to everyone).
+ */
+class JsonACLProvider : public ACLProvider {
+ public:
+  /**
+   * Construct a JsonACLProvider from a JSON file.
+   *
+   * @param jsonPath Path to the JSON file containing ACL mappings
+   * @param permissive If true, only exact directory matches apply;
+   *                   if false (default), sub-directories inherit parent ACLs
+   * @throws std::runtime_error if the file cannot be read or parsed
+   */
+  explicit JsonACLProvider(
+      const std::string& jsonPath,
+      bool permissive = false);
+
+  ~JsonACLProvider() override = default;
+
+  /**
+   * Get ACL groups for a directory path.
+   *
+   * In default mode: looks up the path, then parent directories recursively
+   * until a match is found.
+   *
+   * In permissive mode: only returns groups if the exact path is found.
+   *
+   * @param dirPath The directory path to look up
+   * @return Vector of group IDs, or empty if no ACL is defined (ALL_GROUPS)
+   */
+  std::vector<int> getACLs(const std::string& dirPath) const override;
+
+  /**
+   * Check if the provider is in permissive mode.
+   */
+  bool isPermissive() const {
+    return permissive_;
+  }
+
+  /**
+   * Get the number of entries loaded from the JSON file.
+   */
+  size_t entryCount() const {
+    return aclMap_.size();
+  }
+
+ private:
+  // Load and parse the JSON file
+  void loadFromFile(const std::string& jsonPath);
+
+  // Find ACL groups with parent directory inheritance
+  std::vector<int> findWithInheritance(const std::string& dirPath) const;
+
+  // Normalize a directory path (remove trailing slashes, etc.)
+  static std::string normalizeDirPath(const std::string& path);
+
+  // Get the parent directory of a path
+  static std::string getParentDir(const std::string& path);
+
+  // Parse JSON: {"acls": {...}}
+  void loadNewFormat(const folly::dynamic& json);
+
+  // Map from directory path to ACL groups
+  std::unordered_map<std::string, std::vector<int>> aclMap_;
+
+  // If true, only exact matches apply; if false, sub-directories inherit
+  bool permissive_;
+};
+
+} // namespace acl
+} // namespace rts
+} // namespace glean
+} // namespace facebook

--- a/glean/rts/acl/tests/JsonAclProviderTest.cpp
+++ b/glean/rts/acl/tests/JsonAclProviderTest.cpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/FileUtil.h>
+#include <folly/testing/TestUtil.h>
+#include <gtest/gtest.h>
+
+#include "glean/rts/acl/json_acl_provider.h"
+
+namespace facebook::glean::rts::acl {
+
+class JsonACLProviderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Create a temporary directory for test files
+    tempDir_ = std::make_unique<folly::test::TemporaryDirectory>();
+  }
+
+  std::string writeJsonFile(const std::string& content) {
+    auto path = tempDir_->path().string() + "/acls.json";
+    folly::writeFile(content, path.c_str());
+    return path;
+  }
+
+  std::unique_ptr<folly::test::TemporaryDirectory> tempDir_;
+};
+
+TEST_F(JsonACLProviderTest, LoadValidJsonFile) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src/foo": 1,
+      "src/bar": 2
+    }
+  })");
+
+  JsonACLProvider provider(jsonPath);
+  EXPECT_EQ(provider.entryCount(), 2);
+}
+
+TEST_F(JsonACLProviderTest, ExactMatchLookup) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src/foo": 5
+    }
+  })");
+
+  JsonACLProvider provider(jsonPath);
+
+  const std::vector<int> expected{5};
+  EXPECT_EQ(provider.getACLs("src/foo"), expected);
+}
+
+TEST_F(JsonACLProviderTest, SubdirectoryInheritance) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src/foo": 1
+    }
+  })");
+
+  // Default mode: sub-directories inherit parent's ACLs
+  JsonACLProvider provider(jsonPath, false);
+
+  const std::vector<int> expected{1};
+
+  // Exact match
+  EXPECT_EQ(provider.getACLs("src/foo"), expected);
+
+  // Sub-directory inherits from src/foo
+  EXPECT_EQ(provider.getACLs("src/foo/bar"), expected);
+
+  // Deeply nested sub-directory also inherits
+  EXPECT_EQ(provider.getACLs("src/foo/bar/baz/qux"), expected);
+}
+
+TEST_F(JsonACLProviderTest, PermissiveModeNoInheritance) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src/foo": 1
+    }
+  })");
+
+  // Permissive mode: only exact matches apply
+  JsonACLProvider provider(jsonPath, true);
+  EXPECT_TRUE(provider.isPermissive());
+
+  // Exact match works
+  const std::vector<int> expected{1};
+  EXPECT_EQ(provider.getACLs("src/foo"), expected);
+
+  // Sub-directory does NOT inherit - returns empty (ALL_GROUPS)
+  EXPECT_TRUE(provider.getACLs("src/foo/bar").empty());
+
+  // Unrelated path also returns empty
+  EXPECT_TRUE(provider.getACLs("other/path").empty());
+}
+
+TEST_F(JsonACLProviderTest, NestedDirectoryOverrides) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src": 0,
+      "src/foo": 1,
+      "src/foo/bar": 3
+    }
+  })");
+
+  JsonACLProvider provider(jsonPath, false);
+
+  // Each level gets its own explicit ACLs
+  const std::vector<int> expectedSrc{0};
+  const std::vector<int> expectedFoo{1};
+  const std::vector<int> expectedBar{3};
+
+  EXPECT_EQ(provider.getACLs("src"), expectedSrc);
+  EXPECT_EQ(provider.getACLs("src/foo"), expectedFoo);
+  EXPECT_EQ(provider.getACLs("src/foo/bar"), expectedBar);
+
+  // Deeper path inherits from nearest parent
+  EXPECT_EQ(provider.getACLs("src/foo/bar/baz"), expectedBar);
+
+  // Path without explicit entry inherits from parent
+  EXPECT_EQ(provider.getACLs("src/other"), expectedSrc);
+}
+
+TEST_F(JsonACLProviderTest, PathNormalization) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src/foo": 1
+    }
+  })");
+
+  JsonACLProvider provider(jsonPath, false);
+
+  const std::vector<int> expected{1};
+
+  // With leading slash
+  EXPECT_EQ(provider.getACLs("/src/foo"), expected);
+
+  // With trailing slash
+  EXPECT_EQ(provider.getACLs("src/foo/"), expected);
+
+  // With both
+  EXPECT_EQ(provider.getACLs("/src/foo/"), expected);
+}
+
+TEST_F(JsonACLProviderTest, EmptyPath) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src/foo": 1
+    }
+  })");
+
+  JsonACLProvider provider(jsonPath, false);
+
+  EXPECT_TRUE(provider.getACLs("").empty()); // ALL_GROUPS
+}
+
+TEST_F(JsonACLProviderTest, NoMatchReturnsEmpty) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src/foo": 1
+    }
+  })");
+
+  JsonACLProvider provider(jsonPath, false);
+
+  // Path that doesn't match any entry or parent
+  EXPECT_TRUE(provider.getACLs("other/path").empty()); // ALL_GROUPS
+}
+
+TEST_F(JsonACLProviderTest, InvalidJsonThrows) {
+  auto jsonPath = writeJsonFile("not valid json {{{");
+
+  EXPECT_THROW(JsonACLProvider(jsonPath, false), std::runtime_error);
+}
+
+TEST_F(JsonACLProviderTest, NonExistentFileThrows) {
+  EXPECT_THROW(
+      JsonACLProvider("/nonexistent/path/acls.json", false),
+      std::runtime_error);
+}
+
+TEST_F(JsonACLProviderTest, NonObjectTopLevelThrows) {
+  auto jsonPath = writeJsonFile("[1, 2, 3]");
+
+  EXPECT_THROW(JsonACLProvider(jsonPath, false), std::runtime_error);
+}
+
+TEST_F(JsonACLProviderTest, MissingAclsKeyThrows) {
+  auto jsonPath = writeJsonFile(R"({
+    "other": {"alpha": 1}
+  })");
+
+  EXPECT_THROW(JsonACLProvider(jsonPath, false), std::runtime_error);
+}
+
+TEST_F(JsonACLProviderTest, NewFormatInheritance) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src/foo": 5
+    }
+  })");
+
+  // Default mode: sub-directories inherit
+  JsonACLProvider provider(jsonPath, false);
+
+  const std::vector<int> expected{5};
+
+  EXPECT_EQ(provider.getACLs("src/foo"), expected);
+
+  // Sub-directory inherits
+  EXPECT_EQ(provider.getACLs("src/foo/bar/baz"), expected);
+
+  // Unrelated path returns empty
+  EXPECT_TRUE(provider.getACLs("other/path").empty());
+}
+
+TEST_F(JsonACLProviderTest, NewFormatPermissive) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src/foo": 3
+    }
+  })");
+
+  // Permissive mode
+  JsonACLProvider provider(jsonPath, true);
+
+  const std::vector<int> expected{3};
+  EXPECT_EQ(provider.getACLs("src/foo"), expected);
+
+  // Sub-directory does NOT inherit in permissive mode
+  EXPECT_TRUE(provider.getACLs("src/foo/bar").empty());
+}
+
+TEST_F(JsonACLProviderTest, NewFormatInvalidIdFiltered) {
+  auto jsonPath = writeJsonFile(R"({
+    "acls": {
+      "src/valid": 100,
+      "src/negative": -1,
+      "src/too_high": 254
+    }
+  })");
+
+  JsonACLProvider provider(jsonPath);
+  // Only the valid entry should be loaded
+  EXPECT_EQ(provider.entryCount(), 1);
+
+  const std::vector<int> expected{100};
+  EXPECT_EQ(provider.getACLs("src/valid"), expected);
+
+  // Invalid entries should not be present
+  EXPECT_TRUE(provider.getACLs("src/negative").empty());
+  EXPECT_TRUE(provider.getACLs("src/too_high").empty());
+}
+
+} // namespace facebook::glean::rts::acl

--- a/glean/rts/ffi.cpp
+++ b/glean/rts/ffi.cpp
@@ -19,6 +19,7 @@
 #include "glean/rts/id.h"
 #include "glean/rts/lookup.h"
 #include "glean/rts/ownership.h"
+#include "glean/rts/ownership/acl.h"
 #include "glean/rts/ownership/slice.h"
 #include "glean/rts/query.h"
 #include "glean/rts/sanity.h"
@@ -955,6 +956,47 @@ void glean_ownership_free(Ownership* own) {
 
 void glean_computed_ownership_free(ComputedOwnership* own) {
   ffi::free_(own);
+}
+
+const char* glean_computed_ownership_unit_count(
+    ComputedOwnership* own,
+    uint32_t* result) {
+  return ffi::wrap([=] { *result = own->sets_.getFirstId(); });
+}
+
+const char* glean_augment_ownership_with_acl(
+    ComputedOwnership* ownership,
+    const uint32_t* unit_ids,
+    const size_t* level_counts,
+    size_t num_units,
+    const size_t* group_counts,
+    const uint32_t* group_ids) {
+  return ffi::wrap([=] {
+    std::vector<UnitACLAssignment> assignments;
+    assignments.reserve(num_units);
+
+    size_t level_offset = 0;
+    size_t group_offset = 0;
+
+    for (size_t i = 0; i < num_units; ++i) {
+      UnitACLAssignment assignment;
+      assignment.unitId = unit_ids[i];
+      assignment.levels.reserve(level_counts[i]);
+
+      for (size_t l = 0; l < level_counts[i]; ++l) {
+        size_t nGroups = group_counts[level_offset + l];
+        std::vector<UsetId> groups(
+            group_ids + group_offset, group_ids + group_offset + nGroups);
+        assignment.levels.push_back(std::move(groups));
+        group_offset += nGroups;
+      }
+      level_offset += level_counts[i];
+
+      assignments.push_back(std::move(assignment));
+    }
+
+    augmentOwnershipWithACL(*ownership, assignments);
+  });
 }
 
 const char* glean_ownership_next_set_id(

--- a/glean/rts/ffi.h
+++ b/glean/rts/ffi.h
@@ -518,6 +518,29 @@ uint64_t glean_get_ownership_compact_threshold(void);
 void glean_set_ownership_merge_cache_size(uint64_t size);
 uint64_t glean_get_ownership_merge_cache_size(void);
 
+// Get the first UsetId that is a composite (AND/OR) set, i.e. the boundary
+// between leaf UnitIds and compound ownership expressions.
+// All UsetIds below *result are leaf units (concrete, single file paths).
+// UsetIds at or above *result are composite sets built from AND/OR of leaves.
+// Returns NULL on success, or an error string on failure.
+const char* glean_computed_ownership_unit_count(
+    ComputedOwnership* own,
+    uint32_t* result);
+
+// Augment computed ownership with ACL constraints.
+// Each unit in the assignments list has a list of ACL levels.
+// Each level has a list of ACL group UsetIds (ORed together).
+// Levels are ANDed together to form CNF.
+// The resulting CNF is ANDed with each fact's existing owner.
+// Returns NULL on success, or an error string on failure.
+const char* glean_augment_ownership_with_acl(
+    ComputedOwnership* ownership,
+    const uint32_t* unit_ids,
+    const size_t* level_counts,
+    size_t num_units,
+    const size_t* group_counts,
+    const uint32_t* group_ids);
+
 #ifdef __cplusplus
 }
 }

--- a/glean/rts/ownership/acl.cpp
+++ b/glean/rts/ownership/acl.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "glean/rts/ownership/acl.h"
+#include "glean/rts/timer.h"
+
+#include <folly/CppAttributes.h>
+#include <folly/container/F14Map.h>
+#include <set>
+
+namespace facebook {
+namespace glean {
+namespace rts {
+
+namespace {
+
+// Create an OR-set from a list of UsetIds and add it to the Usets container.
+Uset* FOLLY_NULLABLE makeOrSet(Usets& usets, const std::vector<UsetId>& ids) {
+  CHECK(!ids.empty());
+  if (ids.size() == 1) {
+    return usets.add(std::make_unique<Uset>(SetU32::from({ids[0]}), Or, 1));
+  }
+  std::set<UsetId> idSet(ids.begin(), ids.end());
+  auto entry = std::make_unique<Uset>(SetU32::from(idSet), Or, 1);
+  return usets.add(std::move(entry));
+}
+
+// Create an AND-set from a list of UsetIds and add it to the Usets container.
+Uset* FOLLY_NULLABLE makeAndSet(Usets& usets, const std::vector<UsetId>& ids) {
+  CHECK(!ids.empty());
+  if (ids.size() == 1) {
+    return usets.lookupById(ids[0]);
+  }
+  std::set<UsetId> idSet(ids.begin(), ids.end());
+  auto entry = std::make_unique<Uset>(SetU32::from(idSet), And, 1);
+  return usets.add(std::move(entry));
+}
+
+// Build UnitId → ACL CNF Uset mapping from assignments.
+// Each assignment's levels are converted to OR-sets and combined into a
+// CNF AND-set. All resulting Usets are promoted so they have IDs.
+folly::F14FastMap<UnitId, Uset*> buildUnitACLMap(
+    Usets& usets,
+    const std::vector<UnitACLAssignment>& assignments) {
+  folly::F14FastMap<UnitId, Uset*> unitACLMap;
+  unitACLMap.reserve(assignments.size());
+
+  for (const auto& assignment : assignments) {
+    if (assignment.levels.empty()) {
+      continue;
+    }
+
+    std::vector<UsetId> orSetIds;
+    orSetIds.reserve(assignment.levels.size());
+    for (const auto& levelGroups : assignment.levels) {
+      if (levelGroups.empty()) {
+        continue;
+      }
+      auto* orSet = CHECK_NOTNULL(makeOrSet(usets, levelGroups));
+      usets.promote(orSet);
+      orSetIds.push_back(orSet->id);
+    }
+
+    if (orSetIds.empty()) {
+      continue;
+    }
+
+    Uset* cnf = makeAndSet(usets, orSetIds);
+    unitACLMap[assignment.unitId] = cnf;
+  }
+
+  for (auto& [unitId, cnf] : unitACLMap) {
+    usets.promote(cnf);
+  }
+
+  return unitACLMap;
+}
+
+} // namespace
+
+void augmentOwnershipWithACL(
+    ComputedOwnership& ownership,
+    const std::vector<UnitACLAssignment>& assignments) {
+  if (assignments.empty()) {
+    return;
+  }
+
+  auto t = makeAutoTimer("augmentOwnershipWithACL");
+  auto& usets = ownership.sets_;
+  auto& facts = ownership.facts_;
+  const auto firstSetId = usets.getFirstId();
+
+  auto unitACLMap = buildUnitACLMap(usets, assignments);
+
+  if (unitACLMap.empty()) {
+    VLOG(1) << "augmentOwnershipWithACL: no unit ACL assignments, skipping";
+    return;
+  }
+
+  VLOG(1) << "augmentOwnershipWithACL: " << unitACLMap.size()
+          << " units with ACL assignments";
+
+  // facts_ is a vector of (Id, UsetId) interval boundaries.
+  size_t augmented = 0;
+
+  // Cache: memoize owner UsetId → augmented UsetId to avoid duplicate work.
+  folly::F14FastMap<UsetId, UsetId> augmentCache;
+
+  for (auto& [factId, ownerUsetId] : facts) {
+    if (ownerUsetId == INVALID_USET) {
+      continue;
+    }
+
+    auto cacheIt = augmentCache.find(ownerUsetId);
+    if (cacheIt != augmentCache.end()) {
+      if (cacheIt->second != ownerUsetId) {
+        ownerUsetId = cacheIt->second;
+        ++augmented;
+      }
+      continue;
+    }
+
+    UsetId originalOwner = ownerUsetId;
+
+    // Collect unique ACL CNF IDs for leaf UnitIds in this owner's set.
+    std::set<UsetId> aclCnfIds;
+
+    if (ownerUsetId < firstSetId) {
+      // ownerUsetId < firstSetId means one of two things:
+      //
+      // 1. A raw leaf UnitId — rare for a non-stacked DB since
+      //    computeOwnership promotes all owners to OR-sets (even
+      //    single-unit owners become length-1 OR-sets), but handled
+      //    defensively.
+      //
+      // 2. A promoted set from a base DB (stacked DB case) — the base
+      //    DB's UsetIds are below this ComputedOwnership's firstSetId.
+      //    This is safe to treat as a UnitId lookup because unitACLMap
+      //    only contains real leaf UnitIds, so a base-DB set ID will
+      //    simply not match, and the base DB already applied its own
+      //    ACL augmentation.
+      auto it = unitACLMap.find(ownerUsetId);
+      if (it != unitACLMap.end()) {
+        aclCnfIds.insert(it->second->id);
+      } else {
+        VLOG(1) << "augmentOwnershipWithACL: ownerUsetId " << ownerUsetId
+                << " < firstSetId " << firstSetId
+                << " has no ACL assignment — this fact will not have"
+                   " ACL constraints applied and will remain accessible"
+                   " based on original ownership alone (expected for"
+                   " units without ACL config or base-DB sets in a"
+                   " stacked DB where ACLs were already applied)";
+      }
+    } else {
+      // Promoted set — resolve and examine leaf members.
+      // After computeOwnership, sets are flat OR-sets of UnitIds
+      // (no nested set references), so checking immediate members
+      // is sufficient.
+      auto* ownerUset = usets.lookupById(ownerUsetId);
+      if (!ownerUset) {
+        // ownerUsetId >= firstSetId means it should be a promoted set in
+        // this ComputedOwnership's Usets container. Base-DB set IDs are
+        // < firstSetId (stacked IDs are always > base IDs) and would
+        // enter the if-branch above. A missing set here means we cannot
+        // determine which UnitIds this fact belongs to, so we cannot
+        // apply the correct ACL constraints — the fact would silently
+        // bypass ACL enforcement. Throw rather than continue with
+        // incorrect access control.
+        throw std::runtime_error(
+            "augmentOwnershipWithACL: UsetId " + std::to_string(ownerUsetId) +
+            " >= firstSetId " + std::to_string(firstSetId) +
+            " but not found in this ComputedOwnership's Usets."
+            " Cannot determine ACL constraints for this fact;"
+            " continuing would risk incorrect access control.");
+      }
+      ownerUset->exp.set.foreach([&](UsetId member) {
+        if (member < firstSetId) {
+          auto it = unitACLMap.find(member);
+          if (it != unitACLMap.end()) {
+            aclCnfIds.insert(it->second->id);
+          }
+        }
+      });
+    }
+
+    if (aclCnfIds.empty()) {
+      augmentCache[originalOwner] = originalOwner;
+      continue;
+    }
+
+    // Create AND(existingOwner, aclCnf1, aclCnf2, ...)
+    std::vector<UsetId> andMembers = {ownerUsetId};
+    andMembers.insert(andMembers.end(), aclCnfIds.begin(), aclCnfIds.end());
+    auto* andSet = CHECK_NOTNULL(makeAndSet(usets, andMembers));
+    usets.promote(andSet);
+
+    augmentCache[originalOwner] = andSet->id;
+    ownerUsetId = andSet->id;
+    ++augmented;
+  }
+
+  VLOG(1) << "augmentOwnershipWithACL: augmented " << augmented
+          << " fact intervals out of " << facts.size();
+  t.log("augmentOwnershipWithACL");
+}
+
+} // namespace rts
+} // namespace glean
+} // namespace facebook

--- a/glean/rts/ownership/acl.h
+++ b/glean/rts/ownership/acl.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "glean/rts/ownership.h"
+#include "glean/rts/ownership/uset.h"
+
+#include <string>
+#include <vector>
+
+namespace facebook {
+namespace glean {
+namespace rts {
+
+/// Entry mapping a directory to a list of ACL group UsetIds.
+/// All groups at the same directory level are ORed together.
+struct ACLConfigEntry {
+  std::string directory;
+  std::vector<UsetId> groupUsetIds;
+};
+
+/// Per-file ACL assignment: a UnitId (representing a single file path)
+//  and its matching ACL levels.
+/// Each inner vector represents groups at one directory level (ORed).
+/// The outer vector represents levels that are ANDed together.
+struct UnitACLAssignment {
+  UnitId unitId;
+  std::vector<std::vector<UsetId>> levels; // outer=AND, inner=OR
+};
+
+/// Augment computed ownership with ACL constraints.
+///
+/// For each UnitACLAssignment `a`:
+/// 1. Transform a.levels vec of vec into a proper boolean expression Uset using
+/// Set32 (outer vec -> AND, inner vec -> OR)
+/// 2. for each (fact, uset) in `ownership`, for each unit in uset, get the CNF
+/// for that unit from output of 1.,
+//  and AND those and the uset
+///
+/// @param ownership  The computed ownership (modified in-place)
+/// @param assignments  Per-unit ACL assignments (UnitId → levels of group IDs)
+void augmentOwnershipWithACL(
+    ComputedOwnership& ownership,
+    const std::vector<UnitACLAssignment>& assignments);
+
+} // namespace rts
+} // namespace glean
+} // namespace facebook

--- a/glean/rts/ownership/setu32.h
+++ b/glean/rts/ownership/setu32.h
@@ -470,6 +470,9 @@ class SetU32 {
   /// Append a new value which must be >= the largest value in the set
   void append(uint32_t value);
 
+  /// Append all blocks from [start, finish)
+  void append(const_iterator start, const_iterator finish);
+
   static SetU32 from(const std::set<uint32_t>& set) {
     SetU32 setu32;
     for (auto elt : set) {
@@ -477,18 +480,9 @@ class SetU32 {
     }
     return setu32;
   }
-
-  /**
-   * Merge two sets. If `right` is a subset of `left` or vice versa, returns a
-   * pointer to the superset. Otherwise, stores the result in `result` and
-   * returns a pointer to it.
-   */
-  static const SetU32*
-  merge(SetU32& result, const SetU32& left, const SetU32& right);
-
   template <typename F>
   void foreach(F&& f) const {
-    for (auto& block : *this) {
+    for (const auto& block : *this) {
       auto id = block.hdr.id() << 8;
       switch (block.hdr.type()) {
         case SetU32::Hdr::Sparse: {
@@ -527,14 +521,16 @@ class SetU32 {
   MutableEliasFanoList toEliasFano(uint32_t upper) const;
   static SetU32 fromEliasFano(const EliasFanoList& list);
 
+  /**
+   * Merge two sets. If `right` is a subset of `left` or vice versa, returns a
+   * pointer to the superset. Otherwise, stores the result in `result` and
+   * returns a pointer to it.
+   */
+  static const SetU32*
+  merge(SetU32& result, const SetU32& left, const SetU32& right);
+
   static void dump(SetU32&);
 
- private:
-  static bool fitsSparse(uint8_t m, uint8_t n) {
-    return int(m) + n < 32;
-  }
-
-  void append(const_iterator start, const_iterator finish);
   void append(uint32_t id, Bits256 w);
 
   void appendMerge(
@@ -543,6 +539,11 @@ class SetU32 {
       const_iterator right,
       const_iterator right_end);
   void appendMerge(Block left, Block right);
+
+ private:
+  static bool fitsSparse(uint8_t m, uint8_t n) {
+    return int(m) + n < 32;
+  }
 
   std::vector<Hdr> hdrs;
   std::vector<Bits256> dense;

--- a/glean/rts/ownership/slice.h
+++ b/glean/rts/ownership/slice.h
@@ -80,13 +80,19 @@ struct Slices {
     if (usetid == INVALID_USET) {
       return false;
     }
+    // AND semantics: when multiple slices cover the same UsetId (e.g.,
+    // an ownership slice and an ACL slice for the same layer), ALL
+    // covering slices must agree the UsetId is visible.
+    bool found = false;
     for (auto slice : slices_) {
       if (slice->inRange(usetid)) {
-        auto visible = slice->visible(usetid);
-        return visible;
+        found = true;
+        if (!slice->visible(usetid)) {
+          return false;
+        }
       }
     }
-    return false;
+    return found;
   }
 
   UsetId first() const {

--- a/glean/rts/ownership/tests/AclTest.cpp
+++ b/glean/rts/ownership/tests/AclTest.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <set>
+
+#include "glean/rts/ownership/acl.h"
+
+namespace facebook::glean::rts {
+
+namespace {
+
+// Helper: create a promoted OR-set of UnitIds in the given Usets container.
+Uset* makePromotedOrSet(Usets& usets, const std::set<UsetId>& members) {
+  auto* uset = new Uset(SetU32::from(members), Or, 1);
+  auto* added = usets.add(uset);
+  usets.promote(added);
+  return added;
+}
+
+// Helper: create a UnitACLAssignment concisely.
+// levels is outer=AND, inner=OR of group UsetIds.
+UnitACLAssignment makeAssignment(
+    UnitId unitId,
+    std::vector<std::vector<UsetId>> levels) {
+  return UnitACLAssignment{unitId, std::move(levels)};
+}
+
+// Helper: recursively render a Uset expression tree as a human-readable string.
+// Leaf IDs (below firstSetId) are printed as plain numbers.
+// Promoted sets expand as "AND(...)" or "OR(...)".
+std::string usetToString(const Usets& usets, UsetId id, UsetId firstSetId) {
+  if (id < firstSetId) {
+    return std::to_string(id);
+  }
+  auto* uset = usets.lookupById(id);
+  if (!uset) {
+    // Opaque reference (e.g., group UsetId not in this Usets container).
+    return std::to_string(id);
+  }
+  std::string result = (uset->exp.op == And) ? "AND(" : "OR(";
+  bool first = true;
+  uset->exp.set.foreach([&](uint32_t member) {
+    if (!first) {
+      result += ", ";
+    }
+    first = false;
+    result += usetToString(usets, member, firstSetId);
+  });
+  result += ")";
+  return result;
+}
+
+} // namespace
+
+// Verify that facts owned by a promoted set with matching UnitIds are
+// augmented with the expected AND(owner, aclCnf) structure.
+TEST(AclTest, BasicAugmentation) {
+  constexpr UsetId kFirstSetId = 10;
+  Usets usets(kFirstSetId);
+
+  // UnitIds 1 and 2 are leaf units.
+  auto* ownerSet = makePromotedOrSet(usets, {1, 2});
+
+  // facts_: one interval owned by ownerSet.
+  std::vector<std::pair<Id, UsetId>> facts = {
+      {Id::fromWord(100), ownerSet->id}};
+
+  ComputedOwnership ownership(std::move(usets), std::move(facts));
+
+  augmentOwnershipWithACL(ownership, {makeAssignment(1, {{50}})});
+
+  EXPECT_EQ(
+      usetToString(ownership.sets_, ownership.facts_[0].second, kFirstSetId),
+      "AND(OR(1, 2), OR(50))");
+}
+
+// Verify that facts whose owner has no matching ACL units are left unchanged.
+TEST(AclTest, NoMatchingACLLeavesOwnerUnchanged) {
+  constexpr UsetId kFirstSetId = 10;
+  Usets usets(kFirstSetId);
+
+  auto* ownerSet = makePromotedOrSet(usets, {1, 2});
+
+  std::vector<std::pair<Id, UsetId>> facts = {
+      {Id::fromWord(100), ownerSet->id}};
+
+  ComputedOwnership ownership(std::move(usets), std::move(facts));
+
+  // ACL assignment is for unit 99, which is NOT in the owner set.
+  augmentOwnershipWithACL(ownership, {makeAssignment(99, {{50}})});
+
+  EXPECT_EQ(ownership.facts_[0].second, ownerSet->id);
+  EXPECT_EQ(
+      usetToString(ownership.sets_, ownership.facts_[0].second, kFirstSetId),
+      "OR(1, 2)");
+}
+
+// Verify that empty assignments produce no changes.
+TEST(AclTest, EmptyAssignmentsNoOp) {
+  constexpr UsetId kFirstSetId = 10;
+  Usets usets(kFirstSetId);
+
+  auto* ownerSet = makePromotedOrSet(usets, {1});
+
+  std::vector<std::pair<Id, UsetId>> facts = {
+      {Id::fromWord(100), ownerSet->id}};
+
+  ComputedOwnership ownership(std::move(usets), std::move(facts));
+
+  augmentOwnershipWithACL(ownership, {});
+
+  EXPECT_EQ(ownership.facts_[0].second, ownerSet->id);
+  EXPECT_EQ(
+      usetToString(ownership.sets_, ownership.facts_[0].second, kFirstSetId),
+      "OR(1)");
+}
+
+// Stacked DB scenario: a fact's ownerUsetId is below the stacked DB's
+// firstSetId because it refers to a promoted set from the base DB.
+//
+// In the stacked DB, firstSetId is higher than any base-DB set ID. So
+// base-DB set IDs fall into the (ownerUsetId < firstSetId) branch,
+// which treats them as leaf UnitId lookups in unitACLMap. Since
+// unitACLMap only contains real leaf UnitIds (not base-DB set IDs),
+// the lookup correctly misses and no ACL is applied — the base DB
+// already handled ACL augmentation for those sets.
+TEST(AclTest, StackedDB_BaseSetIdBelowFirstSetId) {
+  // Simulate a stacked DB whose Usets start at ID 1000.
+  // The base DB used set IDs in the range [10, 999].
+  constexpr UsetId kStackedFirstSetId = 1000;
+  Usets stackedUsets(kStackedFirstSetId);
+
+  // Create a promoted set in the stacked layer (ID >= 1000).
+  auto* stackedOwner = makePromotedOrSet(stackedUsets, {1, 2});
+  ASSERT_GE(stackedOwner->id, kStackedFirstSetId);
+
+  // A base-DB set ID that falls below the stacked firstSetId.
+  // This is NOT a real leaf UnitId — it's a promoted set from the base.
+  constexpr UsetId kBaseDbSetId = 500;
+  ASSERT_LT(kBaseDbSetId, kStackedFirstSetId);
+
+  // facts_: two intervals — one owned by a base-DB set (should be skipped
+  // because unitACLMap won't match a set ID), one owned by a stacked set
+  // (should be augmented).
+  std::vector<std::pair<Id, UsetId>> facts = {
+      {Id::fromWord(50), kBaseDbSetId},
+      {Id::fromWord(200), stackedOwner->id},
+  };
+
+  ComputedOwnership ownership(std::move(stackedUsets), std::move(facts));
+
+  augmentOwnershipWithACL(ownership, {makeAssignment(1, {{50}})});
+
+  // Fact 0 (base-DB set owner): unchanged. The code enters the
+  // (ownerUsetId < firstSetId) branch and does unitACLMap.find(500),
+  // which correctly misses — the base DB already applied ACLs.
+  EXPECT_EQ(ownership.facts_[0].second, kBaseDbSetId);
+
+  // Fact 1 (stacked owner containing unit 1): should be augmented.
+  EXPECT_EQ(
+      usetToString(
+          ownership.sets_, ownership.facts_[1].second, kStackedFirstSetId),
+      "AND(OR(1, 2), OR(50))");
+}
+
+// Verify that INVALID_USET owners are skipped entirely.
+TEST(AclTest, InvalidUsetSkipped) {
+  constexpr UsetId kFirstSetId = 10;
+  Usets usets(kFirstSetId);
+
+  std::vector<std::pair<Id, UsetId>> facts = {
+      {Id::fromWord(100), INVALID_USET}};
+
+  ComputedOwnership ownership(std::move(usets), std::move(facts));
+
+  augmentOwnershipWithACL(ownership, {makeAssignment(1, {{50}})});
+
+  EXPECT_EQ(ownership.facts_[0].second, INVALID_USET);
+}
+
+} // namespace facebook::glean::rts

--- a/glean/rts/ownership/uset.h
+++ b/glean/rts/ownership/uset.h
@@ -137,6 +137,7 @@ struct Usets {
 
   Usets(Usets&& other) noexcept : firstId(other.firstId), nextId(other.nextId) {
     std::swap(usets, other.usets);
+    std::swap(idIndex_, other.idIndex_);
     stats = other.stats;
   }
   Usets(const Usets&) = delete;
@@ -273,7 +274,15 @@ struct Usets {
       // Bump the ref count so it outlives any transient users
       ++uset->refs;
       ++stats.promoted;
+      idIndex_.push_back(uset);
     }
+  }
+
+  Uset* FOLLY_NULLABLE lookupById(UsetId id) const {
+    if (id < firstId || id >= firstId + idIndex_.size()) {
+      return nullptr;
+    }
+    return idIndex_[id - firstId];
   }
 
   size_t size() const {
@@ -316,6 +325,9 @@ struct Usets {
     });
     other.usets
         .clear(); // ownership of the underlying sets has been transferred
+    idIndex_.insert(
+        idIndex_.end(), other.idIndex_.begin(), other.idIndex_.end());
+    other.idIndex_.clear();
     nextId = other.nextId;
   }
 
@@ -328,6 +340,7 @@ struct Usets {
 
  private:
   folly::F14FastSet<Uset*, Uset::Hash, Uset::Eq> usets;
+  std::vector<Uset*> idIndex_;
   Stats stats;
   const UsetId firstId;
   UsetId nextId;

--- a/glean/rts/query.cpp
+++ b/glean/rts/query.cpp
@@ -529,6 +529,27 @@ std::unique_ptr<QueryResults> QueryExecutor::finish(
   return res;
 }
 
+// Internal entry point that constructs a QueryExecutor, configures timeouts,
+// and runs the query subroutine. Supports both fresh queries and continuations
+// (via `iters` and `restart`).
+//
+// @param inventory      Predicate inventory (schema).
+// @param facts          Fact store to query against.
+// @param ownership      Standard derived-fact ownership tracker (may be null).
+// @param sub            Compiled query subroutine.
+// @param pid            Target predicate id.
+// @param traverse       Subroutine for nested-fact expansion (may be null).
+// @param maxResults     Max result count limit, if set.
+// @param maxBytes       Max result byte limit, if set.
+// @param maxTime        Max wall-clock time in nanoseconds, if set.
+// @param maxSetSize     Max intermediate set size, if set.
+// @param depth          Nested-fact expansion mode.
+// @param expandPids     Predicate ids eligible for nested expansion.
+// @param wantStats      Whether to collect per-predicate statistics.
+// @param iters          Pre-existing iterators (non-empty when resuming from a
+//                       continuation).
+// @param restart        Saved activation state to resume (nullopt for fresh
+//                       queries).
 std::unique_ptr<QueryResults> executeQuery(
     Inventory& inventory,
     Define& facts,
@@ -631,6 +652,23 @@ void interruptRunningQueries() {
   last_interrupt = Clock::now();
 }
 
+// Resume a query from a serialized continuation produced by a previous
+// execution. Deserializes the iterator state, subroutine activation, predicate
+// id, and traverse subroutine, then delegates to the internal executeQuery.
+//
+// @param inventory        Predicate inventory (schema).
+// @param facts            Fact store to query against.
+// @param ownership        Standard derived-fact ownership tracker (may be
+// null).
+// @param maxResults       Max result count limit, if set.
+// @param maxBytes         Max result byte limit, if set.
+// @param maxTime          Max wall-clock time in nanoseconds, if set.
+// @param maxSetSize       Max intermediate set size, if set.
+// @param depth            Nested-fact expansion mode.
+// @param expandPids       Predicate ids eligible for nested expansion.
+// @param wantStats        Whether to collect per-predicate statistics.
+// @param serializedCont   Pointer to the serialized continuation blob.
+// @param serializedContLen  Length in bytes of the continuation blob.
 std::unique_ptr<QueryResults> restartQuery(
     Inventory& inventory,
     Define& facts,

--- a/glean/rts/serialize.h
+++ b/glean/rts/serialize.h
@@ -210,9 +210,11 @@ using Nat = int64_t;
 using Binary = folly::ByteRange;
 using String = std::string;
 using List = std::vector<Nat>; // TODO: generalise
+using StringList = std::vector<String>;
 using Map = std::map<String, List>; // TODO: generalise
+using StringMap = std::map<String, StringList>;
 
-using Field = std::variant<Nat, Binary, Map, String>;
+using Field = std::variant<Nat, Binary, Map, String, StringMap>;
 using Object = std::vector<std::pair<uint32_t, Field>>;
 
 enum Type : uint32_t {
@@ -235,6 +237,10 @@ Type typeOf<String>() {
 }
 template <>
 Type typeOf<std::vector<Nat>>() {
+  return ListTy;
+}
+template <>
+Type typeOf<std::vector<String>>() {
   return ListTy;
 }
 
@@ -298,9 +304,15 @@ inline void put(binary::Output& out, const Object& obj) {
     } else if (std::holds_alternative<Binary>(val)) {
       field(BinaryTy, num);
       put(out, std::get<Binary>(val));
+    } else if (std::holds_alternative<String>(val)) {
+      field(StringTy, num);
+      put(out, std::get<String>(val));
     } else if (std::holds_alternative<Map>(val)) {
       field(MapTy, num);
       put(out, std::get<Map>(val));
+    } else if (std::holds_alternative<StringMap>(val)) {
+      field(MapTy, num);
+      put(out, std::get<StringMap>(val));
     }
   }
   out.fixed(uint8_t(0)); // object terminator

--- a/glean/storage/common.h
+++ b/glean/storage/common.h
@@ -1200,6 +1200,7 @@ std::unique_ptr<rts::Ownership> DatabaseCommon<C>::getOwnership() {
   container_.requireOpen();
   return std::make_unique<StoredOwnership<C>>(this);
 }
+
 } // namespace db
 } // namespace glean
 } // namespace facebook


### PR DESCRIPTION
Summary:

# What has changed
Added ACL configuration support to the C++ client library (glean/cpp). The
BatchBase class now carries an optional ACL config mapping (path -> list of
ACL group ID strings). Three new methods (setACLConfig, getACLConfig,
hasACLConfig) allow indexers to attach ACL configuration to a batch. The
file writer serializes this ACL config into thrift Batch field 9 as a
map<string, list<string>> using the thriftcompact StringMap type. The
derived Batch template class exposes the new methods via using-declarations.

# Why the change?
Indexers (Clang, Python, etc.) need a way to attach ACL group mappings to
fact batches so that the server can associate facts with ACL groups during
ingestion. This change provides the C++ API surface for indexers to pass
ACL configuration through the existing batch pipeline, serialized alongside
ownership data in the same thrift Batch structure.

# Most important changes
- `glean.h:485-490` - New method declarations: setACLConfig(), getACLConfig(), hasACLConfig() on BatchBase
- `glean.h:540-541` - New private member aclConfig_ (unordered_map<string, vector<string>>) storing the ACL configuration
- `glean.h:667-669` - using-declarations in Batch<Schema> to expose ACL methods from BatchBase
- `glean.cpp:257-268` - Implementation of setACLConfig (move semantics), getACLConfig (const ref), hasACLConfig (empty check)
- `filewriter.cpp:38-58` - Refactored thrift serialization to build fields incrementally; conditionally appends field 9 (acl_config) as a StringMap when ACL config is present

Reviewed By: CatherineGasnier

Differential Revision: D97111676
