### PR TITLE
Fix Github CI path for scip-go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           cache: false
 
       - name: Install indexer (go)
-        run: go install github.com/sourcegraph/scip-go/cmd/scip-go@latest
+        run: go install github.com/scip-code/scip-go/cmd/scip-go@latest
 
       - name: Install indexer (java)
         run: |

--- a/glean/website/docs/indexer/lsif-go.md
+++ b/glean/website/docs/indexer/lsif-go.md
@@ -7,13 +7,13 @@ sidebar_label: Go
 import {OssOnly, FbInternalOnly} from 'internaldocs-fb-helpers';
 import {SrcFile,SrcFileLink} from '@site/utils';
 
-To index [Go](https://go.dev/) we use SourceGraph's [SCIP indexer for Go](https://github.com/sourcegraph/scip-go). [SCIP](https://about.sourcegraph.com/blog/announcing-scip) is a format for tools to share information about code.
+To index [Go](https://go.dev/) we use the [SCIP indexer for Go](https://github.com/scip-code/scip-go). [SCIP](https://about.sourcegraph.com/blog/announcing-scip) is a format for tools to share information about code.
 
 ## Prerequisites
 
 You will need:
 
-* [scip-go](https://github.com/sourcegraph/scip-go), with binary releases available for x86 Linux
+* [scip-go](https://github.com/scip-code/scip-go), with binary releases available for x86 Linux
 * [scip-to-glean](python-scip.md#installing-scip-to-glean), the SCIP-to-Glean converter
 * A recent (>1.15) [version of Go](https://go.dev/dl/)
 


### PR DESCRIPTION
Summary:
Seen CI errors on Glean OSS Github that refer to old scip-go paths. This blocks CI on other PRs.

https://github.com/facebookincubator/Glean/actions/runs/24781487892/job/72513559179

Differential Revision: D102131970


